### PR TITLE
port 80, 8080 and 443 are HTTP ports

### DIFF
--- a/mesos-marathon-vmss/parts/base-template.json
+++ b/mesos-marathon-vmss/parts/base-template.json
@@ -686,7 +686,7 @@
                 "id": "[concat(variables('agentsLbID'), '/backendAddressPools/', variables('agentsLbBackendPoolName'))]"
               },
               "protocol": "http",
-              "path": '/',
+              "path": "/",
               "frontendPort": 80,
               "backendPort": 80,
               "enableFloatingIP": false,
@@ -707,7 +707,7 @@
                 "id": "[concat(variables('agentsLbID'), '/backendAddressPools/', variables('agentsLbBackendPoolName'))]"
               },
               "protocol": "http",
-              "path": '/',
+              "path": "/",
               "frontendPort": 443,
               "backendPort": 443,
               "enableFloatingIP": false,
@@ -728,7 +728,7 @@
                 "id": "[concat(variables('agentsLbID'), '/backendAddressPools/', variables('agentsLbBackendPoolName'))]"
               },
               "protocol": "http",
-              "path": '/',
+              "path": "/",
               "frontendPort": 8080,
               "backendPort": 8080,
               "enableFloatingIP": false,


### PR DESCRIPTION
Ports 80, 8080 and 443 are open by default in ACS clusters. These ports are traditionally used for HTTP communications, but our template creates probes on TCP. This works, but results in a very long response time (6-12 seconds). switching to the http protocol resolves this.
