### PR TITLE
Fix for creating nested dirs

### DIFF
--- a/acstgen/acstgen.go
+++ b/acstgen/acstgen.go
@@ -153,7 +153,7 @@ func saveFileString(dir string, file string, data string) error {
 
 func saveFile(dir string, file string, data []byte) error {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		if e := os.Mkdir(dir, 0700); e != nil {
+		if e := os.MkdirAll(dir, 0700); e != nil {
 			return fmt.Errorf("error creating directory '%s': %s", dir, e.Error())
 		}
 	}


### PR DESCRIPTION
I'm getting error

```
./acstgen clusterdefinitions/kubernetes.json
cert creation took 9.031332747s
error writing artifacts error creating directory 'output/Kubernetes-65597485': mkdir output/Kubernetes-65597485: no such file or directory
```

This fixes that. You don't have to merge.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com

cc: @anhowe 
