### PR TITLE
Generate parameters.json with 'value' key

### DIFF
--- a/acstgen/tgen/template.go
+++ b/acstgen/tgen/template.go
@@ -212,7 +212,7 @@ func getParameters(acsCluster *vlabs.AcsCluster) (*map[string]interface{}, error
 
 func addValue(m *map[string]interface{}, k string, v interface{}) {
 	(*m)[k] = *(&map[string]interface{}{})
-	(*m)[k].(map[string]interface{})["Value"] = v
+	(*m)[k].(map[string]interface{})["value"] = v
 }
 
 // getTemplateFuncMap returns all functions used in template generation


### PR DESCRIPTION
Currently generated templates are with 'Value' key as opposed to
'value', therefore azure-xplat-cli refuses them and prompts for
parameters in the `azure group deployment create` cmd.

cc: @anhowe You don't have to merge, sending out to report the issue.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
