### PR TITLE
k8s: reconcile volume mounts with kube-anywhere

### DIFF
--- a/parts/kubernetesagentcustomdata.yml
+++ b/parts/kubernetesagentcustomdata.yml
@@ -74,6 +74,7 @@ write_files:
     Description=Kubelet
     Requires=docker.service
     After=docker.service
+
     [Service]
     Restart=always
     ExecStartPre=/bin/mkdir -p /var/lib/kubelet
@@ -83,13 +84,14 @@ write_files:
       --net=host \
       --pid=host \
       --privileged \
-      --volume=/:/rootfs:ro \
+      --volume=/dev:/dev \
       --volume=/sys:/sys:ro \
       --volume=/var/run:/var/run:rw \
       --volume=/var/lib/docker/:/var/lib/docker:rw \
       --volume=/var/lib/kubelet/:/var/lib/kubelet:shared \
-      --volume=/var/log/containers/:/var/log/containers:rw \
-      --volume=/etc/kubernetes/:/etc/kubernetes/:rw \
+      --volume=/var/log:/var/log:rw \
+      --volume=/etc/kubernetes/:/etc/kubernetes/:ro \
+      --volume=/srv/kubernetes/:/srv/kubernetes/:ro \
         {{{kubernetesHyperkubeSpec}}} \
           /hyperkube kubelet \
             --api-servers="https://{{{masterPrivateIp}}}:443" \

--- a/parts/kubernetesmastercustomdata.yml
+++ b/parts/kubernetesmastercustomdata.yml
@@ -286,7 +286,7 @@ write_files:
     Description=Kubelet
     Requires=docker.service
     After=docker.service
-    
+
     [Service]
     Restart=always
     ExecStartPre=/bin/mkdir -p /var/lib/kubelet
@@ -297,13 +297,14 @@ write_files:
       --net=host \
       --pid=host \
       --privileged \
-      --volume=/:/rootfs:ro \
+      --volume=/dev:/dev \
       --volume=/sys:/sys:ro \
       --volume=/var/run:/var/run:rw \
       --volume=/var/lib/docker/:/var/lib/docker:rw \
       --volume=/var/lib/kubelet/:/var/lib/kubelet:shared \
-      --volume=/var/log/containers/:/var/log/containers:rw \
-      --volume=/etc/kubernetes/:/etc/kubernetes:rw \
+      --volume=/var/log:/var/log:rw \
+      --volume=/etc/kubernetes/:/etc/kubernetes:ro \
+      --volume=/srv/kubernetes/:/srv/kubernetes:ro \
         {{{kubernetesHyperkubeSpec}}} \
           /hyperkube kubelet \
             --api-servers="https://{{{masterPrivateIp}}}:443" \


### PR DESCRIPTION
Fixes #30.
Fixes #31.

This brings our volume mounts for `kubelet.service` into alignment with what is used in `kubernetes-anywhere`: https://github.com/kubernetes/kubernetes-anywhere/blob/master/phase2/ignition/vanilla/kubelet.service

This will fix it so that logging addons work (they would've mostly work previously, but fluentd writes it's cursor to /var/logs, so it would've had problems if the fluentd Pod were restarted).

It also fixes the ability to mount AzureDisk volumes.
