### PR TITLE
Update agentparams.t

### DIFF
--- a/parts/agentparams.t
+++ b/parts/agentparams.t
@@ -1,7 +1,7 @@
     "{{.Name}}Count": {
       "allowedValues": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100], 
       "metadata": {
-        "description": "The number of Mesos agents for the cluster.  This value can be from 1 to 100"
+        "description": "The number of agents for the cluster.  This value can be from 1 to 100"
       }, 
       "type": "int"
     },


### PR DESCRIPTION
Removed Mesos from the metadata:description of the count parameter. This would be confusing as these parameters are the same for all orchestrator engine templates.