### PR TITLE
Update clusterdefinition.md for publicKeys

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -114,4 +114,4 @@ For apiVersion "2016-03-30", a cluster may have only 1 agent pool profiles.
 |Name|Required|Description|
 |---|---|---|
 |adminUsername|yes|describes the username to be used on all linux clusters|
-|ssh.publicKeys.keyData|yes|The public SSH key used for authenticating access to all Linux nodes in the cluster.  Here are instructions for [generating a public/private key pair](ssh.md#ssh-key-generation).|
+|ssh.publicKeys[0].keyData|yes|The public SSH key used for authenticating access to all Linux nodes in the cluster.  Here are instructions for [generating a public/private key pair](ssh.md#ssh-key-generation).|


### PR DESCRIPTION
publicKeys is a slice of object. It is misleading to use publicKeys.keyData. 
What is required is, the first element's keyData of publicKeys