### PR TITLE
Updated docs with native installation steps for Linux and OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,25 +44,7 @@ same environment used in our Continuous Integration system).
 
 ## Development (Native)
 
-### Requirements
-- PowerShell (Windows)
-- `bash` + `make` (Linux)
-- `git`
-- `go` (with a properly configured GOPATH)
-
-### Building (Linux)
-
-```shell
-make build
-```
-
-### Building (Windows, PowerShell)
-
-```shell
-cd ${env:GOPATH}/github.com/Azure/acs-engine
-go get .
-go build .
-```
+Follow the steps in the User Guide: [ACS Engine](docs/acsengine.md)
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -26,27 +26,6 @@ The cluster definition file enables the following customizations to your Docker 
 * [Managed Disks](examples/disks-managed) (under private preview) - shows how to use managed disks 
 * [Large Clusters](examples/largeclusters) - shows how to create cluster sizes of up to 1200 nodes
 
-## Development (Docker)
-
-The easiest way to get started developing on `acs-engine` is to use Docker.
-If you already have Docker or "Docker for {Windows,Mac}" then you can get started
-without needing to install anything extra.
-
-* Windows (PowerShell): `.\scripts\devenv.ps1`
-* Linux (bash): `./scripts/devenv.sh`
-
-This setup mounts the `acs-engine` source directory as a volume into the Docker container.
-This means that you can edit your source code normally in your favorite editor on your
-machine, while still being able to compile and test inside of the Docker container (the
-same environment used in our Continuous Integration system).
-
-[Here's a quick demo video showing the dev/build/test cycle with this setup.](https://www.youtube.com/watch?v=lc6UZmqxQMs)
-
-## Development (Native)
-
-Follow the steps in the User Guide: [ACS Engine](docs/acsengine.md)
-
-
 ## Contributing
 
 Please follow these instructions before submitting a PR:

--- a/docs/acsengine.md
+++ b/docs/acsengine.md
@@ -4,16 +4,16 @@ The Azure Container Service Engine (`acs-engine`) generates ARM (Azure Resource 
 
 # Downloading and Building ACS Engine
 
-As mentioned in the README, the simpliest way to run ACS Engine is via a Docker container (insrtuctions in the README). 
+As mentioned in the README, the simpliest way to run ACS Engine is via a Docker container (instructions in the [README](README.md).
 
-That said, ACS Engine can also be built and run natively on Windows OS X, and Linux. Instructions below: 
+That said, ACS Engine can also be built and run natively on Windows, OS X, and Linux. Instructions below: 
 
 ## Windows
 
 Requirements:
-- Powershell 
 - Git for Windows. Download and install [here](https://git-scm.com/download/win)
 - Go for Windows. Download and install [here](https://golang.org/dl/), accept all defaults.
+- Powershell 
 
 Build Steps: 
  
@@ -41,11 +41,11 @@ Requirements:
 Build Steps: 
 
 1. Open a command prompt to setup your gopath:
-  1. `mkdir $HOME/go`
+  1. `mkdir $HOME/gopath`
   2. edit `$HOME/.sh_profile` and add the following line to setup your go path
   ```
   export PATH=$PATH:/usr/local/go/bin
-  export GOPATH=$HOME/go
+  export GOPATH=$HOME/gopath
   ```
   3. `source $HOME/.sh_profile`
 2. Build acs-engine:
@@ -66,11 +66,11 @@ Requirements:
 Build Steps: 
 
 1. Setup Go path:
-  1. `mkdir $HOME/go`
+  1. `mkdir $HOME/gopath`
   2. edit `$HOME/.profile` and add the following line to setup your go path
   ```
   export PATH=$PATH:/usr/local/go/bin
-  export GOPATH=$HOME/go
+  export GOPATH=$HOME/gopath
   ```
   3. `source $HOME/.profile`
 2. Build acs-engine:

--- a/docs/acsengine.md
+++ b/docs/acsengine.md
@@ -2,11 +2,23 @@
 
 The Azure Container Service Engine (`acs-engine`) generates ARM (Azure Resource Manager) templates for Docker enabled clusters on Microsoft Azure with your choice of DCOS, Kubernetes, or Swarm orchestrators. The input to the tool is a cluster definition. The cluster definition is very similar to (in many cases the same as) the ARM template syntax used to deploy a Microsoft Azure Container Service cluster.
 
-# Downloading and Building ACS Engine
+## Development in Docker
 
-As mentioned in the README, the simpliest way to run ACS Engine is via a Docker container (instructions in the README).
+The easiest way to get started developing on `acs-engine` is to use Docker. If you already have Docker or "Docker for {Windows,Mac}" then you can get started without needing to install anything extra.
 
-That said, ACS Engine can also be built and run natively on Windows, OS X, and Linux. Instructions below: 
+* Windows (PowerShell): `.\scripts\devenv.ps1`
+* Linux (bash): `./scripts/devenv.sh`
+
+This setup mounts the `acs-engine` source directory as a volume into the Docker container.
+This means that you can edit your source code normally in your favorite editor on your
+machine, while still being able to compile and test inside of the Docker container (the
+same environment used in our Continuous Integration system).
+
+[Here's a quick demo video showing the dev/build/test cycle with this setup.](https://www.youtube.com/watch?v=lc6UZmqxQMs)
+
+# Downloading and Building ACS Engine Locally 
+
+ACS Engine can also be built and run natively on Windows, OS X, and Linux. Instructions below: 
 
 ## Windows
 

--- a/docs/acsengine.md
+++ b/docs/acsengine.md
@@ -36,7 +36,7 @@ Build Steps:
 ## OS X
 
 Requirements:
-- Go for OS X. Download and install [Go for OS X](https://golang.org/dl/)
+- Go for OS X. Download and install [here](https://golang.org/dl/)
 
 Build Steps: 
 
@@ -58,9 +58,10 @@ Build Steps:
 ## Linux
 
 Requirements:
-- Go for Linux. Download and install [Go for Linux](https://golang.org/dl/)
+- Go for Linux
+  - Download the appropriate archive for your system [here](https://golang.org/dl/)
+  - sudo tar -C /usr/local -xzf go$VERSION.$OS-$ARCH.tar.gz (replace with your downloaded archive)
 - `git`
-- https://github.com/Azure/acs-engine#development-docker
 
 Build Steps: 
 

--- a/docs/acsengine.md
+++ b/docs/acsengine.md
@@ -4,11 +4,16 @@ The Azure Container Service Engine (`acs-engine`) generates ARM (Azure Resource 
 
 # Downloading and Building ACS Engine
 
-Here are the instructions for downloading and building the ACS Engine for Windows, OS X, and Linux.
+As mentioned in the README, the simpliest way to run ACS Engine is via a Docker container (insrtuctions in the README). 
+
+That said, ACS Engine can also be built and run natively on Windows OS X, and Linux. Instructions below: 
 
 ## Windows
 
-Here is how to download and building ACS Engine:
+Requirements:
+- Powershell 
+
+Build Steps: 
 
 1. Download and install [git for windows](https://git-scm.com/download/win)
 2. Download and install [Go for Windows](https://golang.org/dl/), accept all defaults.
@@ -30,6 +35,11 @@ Here is how to download and building ACS Engine:
 
 ## OS X
 
+Requirements:
+
+
+Build Steps: 
+
 1. Download and install [Go for OS X](https://golang.org/dl/)
 2. Open a command prompt to setup your gopath:
   1. `mkdir $HOME/go`
@@ -48,7 +58,16 @@ Here is how to download and building ACS Engine:
 
 ## Linux
 
-For Linux, ensure Docker is installed, and follow the developer instructions at https://github.com/Azure/acs-engine#development-docker to build and use the ACS Engine.
+Requirements:
+- `bash` + `make` (Linux)
+- `git`
+- `go` (with a properly configured GOPATH)
+- Docker 
+- https://github.com/Azure/acs-engine#development-docker
+
+Build Steps: 
+
+
 
 # Template Generation
 

--- a/docs/acsengine.md
+++ b/docs/acsengine.md
@@ -2,7 +2,7 @@
 
 The Azure Container Service Engine (`acs-engine`) generates ARM (Azure Resource Manager) templates for Docker enabled clusters on Microsoft Azure with your choice of DCOS, Kubernetes, or Swarm orchestrators. The input to the tool is a cluster definition. The cluster definition is very similar to (in many cases the same as) the ARM template syntax used to deploy a Microsoft Azure Container Service cluster.
 
-## Development in Docker
+# Development in Docker
 
 The easiest way to get started developing on `acs-engine` is to use Docker. If you already have Docker or "Docker for {Windows,Mac}" then you can get started without needing to install anything extra.
 

--- a/docs/acsengine.md
+++ b/docs/acsengine.md
@@ -4,7 +4,7 @@ The Azure Container Service Engine (`acs-engine`) generates ARM (Azure Resource 
 
 # Downloading and Building ACS Engine
 
-As mentioned in the README, the simpliest way to run ACS Engine is via a Docker container (instructions in the [README](README.md).
+As mentioned in the README, the simpliest way to run ACS Engine is via a Docker container (instructions in the README).
 
 That said, ACS Engine can also be built and run natively on Windows, OS X, and Linux. Instructions below: 
 

--- a/docs/acsengine.md
+++ b/docs/acsengine.md
@@ -12,17 +12,17 @@ That said, ACS Engine can also be built and run natively on Windows OS X, and Li
 
 Requirements:
 - Powershell 
+- Git for Windows. Download and install [here](https://git-scm.com/download/win)
+- Go for Windows. Download and install [here](https://golang.org/dl/), accept all defaults.
 
 Build Steps: 
-
-1. Download and install [git for windows](https://git-scm.com/download/win)
-2. Download and install [Go for Windows](https://golang.org/dl/), accept all defaults.
-3. Setup your go workspace.  This example assumes you are using `c:\gopath` as your workspace:
+ 
+1. Setup your go workspace.  This example assumes you are using `c:\gopath` as your workspace:
   1. Windows key-R to open the run prompt
   2. `rundll32 sysdm.cpl,EditEnvironmentVariables` to open the system variables
   3. add `c:\go\bin` to your PATH variables
   4. click "new" and add new environment variable GOPATH and set to `c:\gopath`
-4. Build acs-engine:
+2. Build acs-engine:
   1. Windows key-R to open the run prompt
   2. `cmd` to open command prompt
   3. mkdir %GOPATH%
@@ -31,42 +31,53 @@ Build Steps:
   6. type `go get all` to get the supporting components
   7. `cd %GOPATH%\src\github.com\Azure\acs-engine`
   8. `go build` to build the project
-  9. `acs-engine` to see the command line parameters
+3. `acs-engine` to see the command line parameters
 
 ## OS X
 
 Requirements:
-
+- Go for OS X. Download and install [Go for OS X](https://golang.org/dl/)
 
 Build Steps: 
 
-1. Download and install [Go for OS X](https://golang.org/dl/)
-2. Open a command prompt to setup your gopath:
+1. Open a command prompt to setup your gopath:
   1. `mkdir $HOME/go`
-  2. edit `$HOME/.profile` and add the following line to setup your go path
+  2. edit `$HOME/.sh_profile` and add the following line to setup your go path
   ```
   export PATH=$PATH:/usr/local/go/bin
-  export GOPATH=$HOME/gopath
+  export GOPATH=$HOME/go
   ```
-  3. `source $HOME/.profile`
-3. Build acs-engine:
+  3. `source $HOME/.sh_profile`
+2. Build acs-engine:
   1. type `go get github.com/Azure/acs-engine` to get the acs-engine Github project
   2. type `go get all` to get the supporting components
   3. `cd $GOPATH/src/github.com/Azure/acs-engine`
   4. `go build` to build the project
-  5. `acs-engine` to see the command line parameters
+3. `./acs-engine` to see the command line parameters
 
 ## Linux
 
 Requirements:
-- `bash` + `make` (Linux)
+- Go for Linux. Download and install [Go for Linux](https://golang.org/dl/)
 - `git`
-- `go` (with a properly configured GOPATH)
-- Docker 
 - https://github.com/Azure/acs-engine#development-docker
 
 Build Steps: 
 
+1. Setup Go path:
+  1. `mkdir $HOME/go`
+  2. edit `$HOME/.profile` and add the following line to setup your go path
+  ```
+  export PATH=$PATH:/usr/local/go/bin
+  export GOPATH=$HOME/go
+  ```
+  3. `source $HOME/.profile`
+2. Build acs-engine:
+  1. type `go get github.com/Azure/acs-engine` to get the acs-engine Github project
+  2. type `go get all` to get the supporting components
+  3. `cd $GOPATH/src/github.com/Azure/acs-engine`
+  4. `go build` to build the project
+3. `./acs-engine` to see the command line parameters
 
 
 # Template Generation


### PR DESCRIPTION
Updated the base README to offer both Docker and native (but Docker is recommended). Instructions updated with steps for Linux and fixed a couple items in the OS X steps. Tested with Ubuntu Server 16.04.

Did not change or test anything for the Windows portion. 