### PR TITLE
azure account set takes --subscription instead of --name arg

### DIFF
--- a/docs/serviceprincipal.md
+++ b/docs/serviceprincipal.md
@@ -21,7 +21,7 @@ There are several ways to create a Service Principal in Azure Active Directory:
    
    ```shell
    az login
-   az account set --name="${SUBSCRIPTION_ID}"
+   az account set --subscription="${SUBSCRIPTION_ID}"
    az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/${SUBSCRIPTION_ID}"
    ```
    


### PR DESCRIPTION
following the serviceprincipal.md doc I found that the azure account set does not take a --name arg but a --subscription arg (azure-cli version azure-cli (0.1.0b8))