### PR TITLE
set config mode as arm for xplatform cli before deploying acs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ $ azure login
 
 $ azure account set "<SUBSCRIPTION NAME OR ID>"
 
+$ azure config mode arm
+
 $ azure group create \
     --name="<RESOURCE_GROUP_NAME>" \
     --location="<LOCATION>"


### PR DESCRIPTION
default mode is asm after installation of xplatform cli. Need to run command to change mode to arm, or will get error run following command.