### PR TITLE
Fixes #116. Naming container when starting

### DIFF
--- a/parts/kubernetesmastercustomdata.yml
+++ b/parts/kubernetesmastercustomdata.yml
@@ -294,6 +294,7 @@ write_files:
     ExecStartPre=/bin/mount --bind /var/lib/kubelet /var/lib/kubelet
     ExecStartPre=/bin/mount --make-shared /var/lib/kubelet
     ExecStart=/usr/bin/docker run \
+      --name=kubelet
       --net=host \
       --pid=host \
       --privileged \


### PR DESCRIPTION
Fixes https://github.com/Azure/acs-engine/issues/116 by naming container to `kubelet` on start such that it can be stopped through `systemctl`