### PR TITLE
pki: remove wildcard from subject alt names

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -89,7 +89,6 @@ func setDefaultCerts(a *api.Properties) (bool, error) {
 		return false, nil
 	}
 
-	masterWildCardFQDN := FormatAzureProdFQDN(a.MasterProfile.DNSPrefix, "*")
 	masterExtraFQDNs := FormatAzureProdFQDNs(a.MasterProfile.DNSPrefix)
 	firstMasterIP := net.ParseIP(a.MasterProfile.FirstConsecutiveStaticIP)
 
@@ -103,7 +102,7 @@ func setDefaultCerts(a *api.Properties) (bool, error) {
 		ips = append(ips, net.IP{firstMasterIP[12], firstMasterIP[13], firstMasterIP[14], firstMasterIP[15] + byte(i)})
 	}
 
-	caPair, apiServerPair, clientPair, kubeConfigPair, err := CreatePki(masterWildCardFQDN, masterExtraFQDNs, ips, DefaultKubernetesClusterDomain)
+	caPair, apiServerPair, clientPair, kubeConfigPair, err := CreatePki(masterExtraFQDNs, ips, DefaultKubernetesClusterDomain)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This PR is designed to remove the wildcard FQDN from the end of the subjectAltNames in the APIServer certificate.  I was tempted to change some of the calling code to make the intent more clear, but opted for the 1-line change instead.

This PR resolves the following `pyopenssl` error:

```console
WARNING:requests.packages.urllib3.contrib.pyopenssl:A problem was encountered with the certificate that prevented urllib3 from finding the SubjectAlternativeName field. This can affect certificate validation. The error was Codepoint U+002A at position 1 of '*' not allowed
/usr/local/lib/python3.5/dist-packages/requests/packages/urllib3/connection.py:337: SubjectAltNameWarning: Certificate for 10.0.0.1 has no `subjectAltName`, falling back to check for a `commonName` for now. This feature is being removed by major browsers and deprecated by RFC 2818. (See https://github.com/shazow/urllib3/issues/497 for details.)
  SubjectAltNameWarning
ERROR:requests.packages.urllib3.connection:Certificate did not match expected hostname: 10.0.0.1. Certificate: {'subject': ((('commonName', 'apiserver'),),), 'subjectAltName': []}
ERROR There was a problem retrieving data from the Kubernetes API server. URL: https://10.0.0.1:443/api/v1/namespaces/test-288243432, params: {}
ERROR:scheduler:There was a problem retrieving data from the Kubernetes API server. URL: https://10.0.0.1:443/api/v1/namespaces/test-288243432, params: {}
```