### PR TITLE
Update Azure CLI 2.0 commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ $ az login
 
 $ az account set --subscription "<SUBSCRIPTION NAME OR ID>"
 
-$ az group create \
+$ az resource group create \
     --name "<RESOURCE_GROUP_NAME>" \
     --location "<LOCATION>"
 
-$ az group deployment create \
+$ az resource group deployment create \
     --name "<DEPLOYMENT NAME>" \
     --resource-group "<RESOURCE_GROUP_NAME>" \
     --template-file "./_output/<INSTANCE>/azuredeploy.json" \


### PR DESCRIPTION
Looks like az command line changed and requires `resource` to be included in front of `group`, updating where needed.