### PR TITLE
testing: fix DCOS validation script

### DIFF
--- a/test/cluster-tests/dcos/marathon.json
+++ b/test/cluster-tests/dcos/marathon.json
@@ -1,0 +1,31 @@
+{
+  "id": "web",
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "yeasy/simple-web",
+      "network": "BRIDGE",
+      "portMappings": [
+        { "hostPort": 0, "containerPort": 80, "servicePort": 10000 }
+      ],
+      "forcePullImage":true
+    }
+  },
+  "instances": 3,
+  "cpus": 0.1,
+  "mem": 65,
+  "healthChecks": [{
+      "protocol": "HTTP",
+      "path": "/",
+      "portIndex": 0,
+      "timeoutSeconds": 10,
+      "gracePeriodSeconds": 10,
+      "intervalSeconds": 2,
+      "maxConsecutiveFailures": 10
+  }],
+  "labels":{
+    "HAPROXY_GROUP":"external",
+    "HAPROXY_0_VHOST":"weekly-testagents.eastus.cloudapp.azure.com",
+    "HAPROXY_0_MODE":"http"
+  }
+}

--- a/test/cluster-tests/dcos/test.sh
+++ b/test/cluster-tests/dcos/test.sh
@@ -1,55 +1,40 @@
 #!/bin/bash
 
-set -x
-set -e
-
-usage() { echo "Usage: $0 [-h <hostname>] [-u <username>]" 1>&2; exit 1; }
-
-while getopts ":h:u:" o; do
-    case "${o}" in
-        h)
-            host=${OPTARG}
-            ;;
-        u)
-            user=${OPTARG}
-            ;;
-        *)
-            usage
-            ;;
-    esac
+####################################################
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
-shift $((OPTIND-1))
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+####################################################
 
-if [[ ! -z $1 ]]; then
-  usage
-fi
+set -e
+# -o pipefail
+set -x
 
-if [[ -z $host ]]; then
-  host=$(az acs show --resource-group=acs-weekly-dcos --name=weekly-test --query=masterProfile.fqdn | sed -e 's/^"//' -e 's/"$//')
-fi
-
-if [[ -z $user ]]; then
-  user=$(az acs show --resource-group=acs-weekly-dcos --name=weekly-test --query=linuxProfile.adminUsername | sed -e 's/^"//' -e 's/"$//')
-fi
-
-echo $host
-
-remote_exec="ssh -i ~/.ssh/id_rsa ${user}@${host}"
+remote_exec="ssh -i "${SSH_KEY}" -o StrictHostKeyChecking=no azureuser@${INSTANCE_NAME}.${LOCATION}.cloudapp.azure.com -p2200"
+remote_cp="scp -i "${SSH_KEY}" -P 2200 -o StrictHostKeyChecking=no"
 
 function teardown {
-  ${remote_exec} dcos marathon app remove /web
+  ${remote_exec} ./dcos marathon app remove /web
 }
 
-scp -i ~/.ssh/id_rsa ${HOME}/marathon.json ${user}@${host}:marathon.json
+${remote_exec} curl -O https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.8/dcos
+${remote_exec} chmod a+x ./dcos
+${remote_exec} ./dcos config set core.dcos_url http://localhost:80
+
+${remote_cp} "${DIR}/marathon.json" azureuser@${INSTANCE_NAME}.${LOCATION}.cloudapp.azure.com:marathon.json
 
 trap teardown EXIT
 
-${remote_exec} dcos marathon app add marathon.json
+${remote_exec} ./dcos marathon app add marathon.json
 
 count=0
-while [[ ${count} < 10 ]]; do
-  count=(count + 1)
-  running=$(${remote_exec} dcos marathon app show /web | jq .tasksRunning)
+while [[ ${count} -lt 25 ]]; do
+  count=$((count+1))
+  running=$(${remote_exec} ./dcos marathon app show /web | jq .tasksRunning)
   if [[ "${running}" == "3" ]]; then
     echo "Found 3 running tasks"
     break
@@ -61,5 +46,6 @@ if [[ "${running}" == "3" ]]; then
   echo "Deployment succeeded"
 else
   echo "Deployment failed"
+  ${remote_exec} ./dcos marathon app show /web
   exit 1
 fi


### PR DESCRIPTION
Note, this stacks on top of #226. Please only review the latest commit here.

1. Add `marathon.json` file so the test has a hope of passing.

2. Remove positional args, all-in on environment variables

3. Remove `az acs` usage, this is `acs-engine`.

4. Correct usage of `dcos` client, download it ahead of time, etc.