### PR TITLE
Configuring docker live restore mode

### DIFF
--- a/parts/kubernetesagentcustomdata.yml
+++ b/parts/kubernetesagentcustomdata.yml
@@ -31,6 +31,14 @@ write_files:
     ExecStart=
     ExecStart=/usr/bin/docker daemon -H fd:// --storage-driver=overlay
 
+- path: "/etc/docker/daemon.json"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    {
+      "live-restore": true
+    }
+
 - path: "/etc/kubernetes/certs/ca.crt"
   permissions: "0644"
   encoding: "base64"

--- a/parts/kubernetesmastercustomdata.yml
+++ b/parts/kubernetesmastercustomdata.yml
@@ -37,6 +37,14 @@ write_files:
     ExecStart=
     ExecStart=/usr/bin/docker daemon -H fd:// --storage-driver=overlay
 
+- path: "/etc/docker/daemon.json"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    {
+      "live-restore": true
+    }
+
 - path: "/etc/kubernetes/certs/ca.crt"
   permissions: "0644"
   encoding: "base64"


### PR DESCRIPTION
As per https://docs.docker.com/engine/admin/live-restore/ this enables live-restore mode for docker, ensuring pods don't die when a docker upgrade hits the wire
