### PR TITLE
fix: test/deploy.sh is usable standalone

### DIFF
--- a/test/deploy.sh
+++ b/test/deploy.sh
@@ -52,7 +52,7 @@ fi
 
 
 # Ensure Cluster Definition
-if [[ -z "${CLUSTER_DEFINITION}" ]]; then
+if [[ -z "${CLUSTER_DEFINITION:-}" ]]; then
 	if [[ -z "${1:-}" ]]; then echo "You must specify a parameterized apimodel.json clusterdefinition"; exit -1; fi
 	CLUSTER_DEFINITION="${1}"
 fi


### PR DESCRIPTION
Guess I missed this, was mostly testing with `prow`, forgot to try manually. Caught this while trying to test out the LB/Azure-sdk-for-go fix for Kubernetes...