### PR TITLE
Remove the Subscription type from the Public API model

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -20,23 +20,10 @@ const (
 	DockerCE OrchestratorType = "DockerCE"
 )
 
+// the OSTypes supported by vlabs
 const (
 	Windows OSType = "Windows"
 	Linux   OSType = "Linux"
-)
-
-// subscription states
-const (
-	// Registered means the subscription is entitled to use the namespace
-	Registered SubscriptionState = iota
-	// Unregistered means the subscription is not entitled to use the namespace
-	Unregistered
-	// Suspended means the subscription has been suspended from the system
-	Suspended
-	// Deleted means the subscription has been deleted
-	Deleted
-	// Warned means the subscription has been warned
-	Warned
 )
 
 // validation values

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -9,30 +9,12 @@ import (
 )
 
 ///////////////////////////////////////////////////////////
-// The converter exposes functions to convert the 2 top
-// level resources:
-// 1. Subscription
-// 2. ContainerService
+// The converter exposes functions to convert the top level
+// ContainerService resource
 //
 // All other functions are internal helper functions used
 // for converting.
 ///////////////////////////////////////////////////////////
-
-// ConvertSubscriptionToV20160330 converts a v20160330 Subscription to an unversioned Subscription
-func ConvertSubscriptionToV20160330(api *Subscription) *v20160330.Subscription {
-	s := &v20160330.Subscription{}
-	s.ID = api.ID
-	s.State = v20160330.SubscriptionState(api.State)
-	return s
-}
-
-// ConvertSubscriptionToVLabs converts a vlabs Subscription to an unversioned Subscription
-func ConvertSubscriptionToVLabs(api *Subscription) *vlabs.Subscription {
-	s := &vlabs.Subscription{}
-	s.ID = api.ID
-	s.State = vlabs.SubscriptionState(api.State)
-	return s
-}
 
 // ConvertContainerServiceToV20160930 converts an unversioned ContainerService to a v20160930 ContainerService to
 func ConvertContainerServiceToV20160930(api *ContainerService) *v20160930.ContainerService {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -7,30 +7,12 @@ import (
 )
 
 ///////////////////////////////////////////////////////////
-// The converter exposes functions to convert the 2 top
-// level resources:
-// 1. Subscription
-// 2. ContainerService
+// The converter exposes functions to convert the top level
+// ContainerService resource
 //
 // All other functions are internal helper functions used
 // for converting.
 ///////////////////////////////////////////////////////////
-
-// ConvertV20160330Subscription converts a v20160330 Subscription to an unversioned Subscription
-func ConvertV20160330Subscription(v20160330 *v20160330.Subscription) *Subscription {
-	s := &Subscription{}
-	s.ID = v20160330.ID
-	s.State = SubscriptionState(v20160330.State)
-	return s
-}
-
-// ConvertVLabsSubscription converts a vlabs Subscription to an unversioned Subscription
-func ConvertVLabsSubscription(vlabs *vlabs.Subscription) *Subscription {
-	s := &Subscription{}
-	s.ID = vlabs.ID
-	s.State = SubscriptionState(vlabs.State)
-	return s
-}
 
 // ConvertV20160930ContainerService converts a v20160930 ContainerService to an unversioned ContainerService
 func ConvertV20160930ContainerService(v20160930 *v20160930.ContainerService) *ContainerService {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -14,15 +14,6 @@ type TypeMeta struct {
 	APIVersion string `json:"apiVersion"`
 }
 
-// SubscriptionState represents the state of the subscription
-type SubscriptionState int
-
-// Subscription represents the customer subscription
-type Subscription struct {
-	ID    string
-	State SubscriptionState
-}
-
 // ResourcePurchasePlan defines resource plan as required by ARM
 // for billing purposes.
 type ResourcePurchasePlan struct {

--- a/pkg/api/v20160330/const.go
+++ b/pkg/api/v20160330/const.go
@@ -12,23 +12,10 @@ const (
 	DCOS  OrchestratorType = "DCOS"
 )
 
+// v20160330 supports OSTypes Windows and Linux
 const (
 	Windows OSType = "Windows"
 	Linux   OSType = "Linux"
-)
-
-// subscription states
-const (
-	// Registered means the subscription is entitled to use the namespace
-	Registered SubscriptionState = iota
-	// Unregistered means the subscription is not entitled to use the namespace
-	Unregistered
-	// Suspended means the subscription has been suspended from the system
-	Suspended
-	// Deleted means the subscription has been deleted
-	Deleted
-	// Warned means the subscription has been warned
-	Warned
 )
 
 // validation values

--- a/pkg/api/v20160330/types.go
+++ b/pkg/api/v20160330/types.go
@@ -4,15 +4,6 @@ import (
 	neturl "net/url"
 )
 
-// SubscriptionState represents the state of the subscription
-type SubscriptionState int
-
-// Subscription represents the customer subscription
-type Subscription struct {
-	ID    string
-	State SubscriptionState
-}
-
 // ResourcePurchasePlan defines resource plan as required by ARM
 // for billing purposes.
 type ResourcePurchasePlan struct {

--- a/pkg/api/vlabs/const.go
+++ b/pkg/api/vlabs/const.go
@@ -23,23 +23,10 @@ const (
 	DockerCE = "DockerCE"
 )
 
+// the OSTypes supported by vlabs
 const (
 	Windows OSType = "Windows"
 	Linux   OSType = "Linux"
-)
-
-// subscription states
-const (
-	// Registered means the subscription is entitled to use the namespace
-	Registered SubscriptionState = iota
-	// Unregistered means the subscription is not entitled to use the namespace
-	Unregistered
-	// Suspended means the subscription has been suspended from the system
-	Suspended
-	// Deleted means the subscription has been deleted
-	Deleted
-	// Warned means the subscription has been warned
-	Warned
 )
 
 // validation values

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -1,14 +1,5 @@
 package vlabs
 
-// SubscriptionState represents the state of the subscription
-type SubscriptionState int
-
-// Subscription represents the customer subscription
-type Subscription struct {
-	ID    string
-	State SubscriptionState
-}
-
 // ResourcePurchasePlan defines resource plan as required by ARM
 // for billing purposes.
 type ResourcePurchasePlan struct {


### PR DESCRIPTION
It's referenced only in AzureContainerService and not by the acs-engine