### PR TITLE
[k8s] Add experimental-nvidia-gpus flag when VM has GPU

### DIFF
--- a/parts/kubernetesagentcustomdata.yml
+++ b/parts/kubernetesagentcustomdata.yml
@@ -115,7 +115,7 @@ write_files:
             --kubeconfig=/var/lib/kubelet/kubeconfig \
             --address=0.0.0.0 \
             --allow-privileged=true \
-            --experimental-nvidia-gpus {{{experimentalGpuFlag}}} \
+            --experimental-nvidia-gpus {{{[[VMName]]experimentalGpuFlag}}} \
             --enable-server \
             --enable-debugging-handlers \
             --config=/etc/kubernetes/manifests \

--- a/parts/kubernetesagentcustomdata.yml
+++ b/parts/kubernetesagentcustomdata.yml
@@ -115,6 +115,7 @@ write_files:
             --kubeconfig=/var/lib/kubelet/kubeconfig \
             --address=0.0.0.0 \
             --allow-privileged=true \
+            --experimental-nvidia-gpus {{{experimentalGpuFlag}}} \
             --enable-server \
             --enable-debugging-handlers \
             --config=/etc/kubernetes/manifests \

--- a/parts/kubernetesagentresourcesvmas.t
+++ b/parts/kubernetesagentresourcesvmas.t
@@ -112,7 +112,7 @@
         "osProfile": {
           "adminUsername": "[variables('username')]",
           "computername": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex())]",
-          {{GetKubernetesAgentCustomData}}
+          {{GetKubernetesAgentCustomData .}}
           "linuxConfiguration": {
               "disablePasswordAuthentication": "true",
               "ssh": {

--- a/parts/kubernetesagentvars.t
+++ b/parts/kubernetesagentvars.t
@@ -1,3 +1,4 @@
+    "experimentalGpuFlag": {{ExperimentalGpuFlag}},    
     "{{.Name}}StorageAccountOffset": "[mul(variables('maxStorageAccountsPerAgent'),variables('{{.Name}}Index'))]",
     "{{.Name}}Count": "[parameters('{{.Name}}Count')]",
     "{{.Name}}AvailabilitySet": "[concat('{{.Name}}-availabilitySet-', variables('nameSuffix'))]",

--- a/parts/kubernetesagentvars.t
+++ b/parts/kubernetesagentvars.t
@@ -1,4 +1,4 @@
-    "experimentalGpuFlag": {{ExperimentalGpuFlag}},    
+    "{{.Name}}experimentalGpuFlag": {{.HasGPU}},    
     "{{.Name}}StorageAccountOffset": "[mul(variables('maxStorageAccountsPerAgent'),variables('{{.Name}}Index'))]",
     "{{.Name}}Count": "[parameters('{{.Name}}Count')]",
     "{{.Name}}AvailabilitySet": "[concat('{{.Name}}-availabilitySet-', variables('nameSuffix'))]",

--- a/parts/kubernetesagentvars.t
+++ b/parts/kubernetesagentvars.t
@@ -1,4 +1,4 @@
-    "{{.Name}}experimentalGpuFlag": {{.HasGPU}},    
+    "{{.Name}}experimentalGpuFlag": {{.GetGPUCount}},    
     "{{.Name}}StorageAccountOffset": "[mul(variables('maxStorageAccountsPerAgent'),variables('{{.Name}}Index'))]",
     "{{.Name}}Count": "[parameters('{{.Name}}Count')]",
     "{{.Name}}AvailabilitySet": "[concat('{{.Name}}-availabilitySet-', variables('nameSuffix'))]",

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -564,6 +564,14 @@ func (t *TemplateGenerator) getTemplateFuncMap(properties *api.Properties) map[s
 		"HasWindowsSecrets": func() bool {
 			return properties.WindowsProfile.HasSecrets()
 		},
+		"ExperimentalGpuFlag": func() int {
+			//Only test a single profile, since all agents should be the same size
+			isGpuVM := strings.HasPrefix(properties.AgentPoolProfiles[0].VMSize, "Standard_N")
+			if isGpuVM {
+				return 1
+			}
+			return 0
+		},
 		// inspired by http://stackoverflow.com/questions/18276173/calling-a-template-with-several-pipeline-parameters/18276968#18276968
 		"dict": func(values ...interface{}) (map[string]interface{}, error) {
 			if len(values)%2 != 0 {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -338,9 +338,14 @@ func (a *AgentPoolProfile) HasDisks() bool {
 	return len(a.DiskSizesGB) > 0
 }
 
-//HasGPU returns true if the VMSize of the agent profile is one of the GPU capabable Sku (NC* & NV*)
-func (a *AgentPoolProfile) HasGPU() bool {
-	return strings.HasPrefix(a.VMSize, "Standard_N")
+//GetGPUCount returns 1 if the VMSize of the agent profile is one of the GPU capabable Sku (NC* & NV*) otherwise 0
+func (a *AgentPoolProfile) GetGPUCount() int {
+	//only support 0 or 1 for now, multi-GPU will be available in k8s 1.6 but 
+	//the flag will change anyway so no need for a more complex rule so far
+	if strings.HasPrefix(a.VMSize, "Standard_N") == true {
+		return 1
+	}
+	return 0
 }
 
 // HasSecrets returns true if the customer specified secrets to install

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	neturl "net/url"
+	"strings"
 
 	"github.com/Azure/acs-engine/pkg/api/v20160330"
+	"github.com/Azure/acs-engine/pkg/api/v20160930"
 	"github.com/Azure/acs-engine/pkg/api/vlabs"
 )
 
@@ -56,6 +58,7 @@ type Properties struct {
 	JumpboxProfile          JumpboxProfile          `json:"jumpboxProfile"`
 	ServicePrincipalProfile ServicePrincipalProfile `json:"servicePrincipalProfile"`
 	CertificateProfile      CertificateProfile      `json:"certificateProfile"`
+	CustomProfile           CustomProfile           `json:"customProfile"`
 }
 
 // ServicePrincipalProfile contains the client and secret used by the cluster for Azure Resource CRUD
@@ -228,6 +231,12 @@ type KeyVaultCertificate struct {
 // OSType represents OS types of agents
 type OSType string
 
+// CustomProfile specifies custom properties that are used for
+// cluster instantiation.  Should not be used by most users.
+type CustomProfile struct {
+	Orchestrator string `json:"orchestrator,omitempty"`
+}
+
 // VlabsARMContainerService is the type we read and write from file
 // needed because the json that is sent to ARM and acs-engine
 // is different from the json that the ACS RP Api gets from ARM
@@ -242,6 +251,14 @@ type VlabsARMContainerService struct {
 type V20160330ARMContainerService struct {
 	TypeMeta
 	*v20160330.ContainerService
+}
+
+// V20160930ARMContainerService is the type we read and write from file
+// needed because the json that is sent to ARM and acs-engine
+// is different from the json that the ACS RP Api gets from ARM
+type V20160930ARMContainerService struct {
+	TypeMeta
+	*v20160930.ContainerService
 }
 
 // HasWindows returns true if the cluster contains windows
@@ -319,6 +336,11 @@ func (a *AgentPoolProfile) IsStorageAccount() bool {
 // HasDisks returns true if the customer specified disks
 func (a *AgentPoolProfile) HasDisks() bool {
 	return len(a.DiskSizesGB) > 0
+}
+
+//HasGPU returns true if the VMSize of the agent profile is one of the GPU capabable Sku (NC* & NV*)
+func (a *AgentPoolProfile) HasGPU() bool {
+	return strings.HasPrefix(a.VMSize, "Standard_N")
 }
 
 // HasSecrets returns true if the customer specified secrets to install


### PR DESCRIPTION
Mostly for discussion, as I don't think we want custom code like that for every k8s experimental feature.

In order to allow Kubernetes to schedule workloads requiring GPU resource against a node, the 
`--experimental-nvidia-gpus` needs to be set to `1`.
This PR checks the `VMSize` of the agent profile, and set the flag to 1 for any `Standard_N*` size.

Broader related issue: https://github.com/Azure/acs-engine/issues/266

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/267)
<!-- Reviewable:end -->
