### PR TITLE
Fixes the issue I just introduced.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,21 @@
 
 .PHONY: build test validate-generated lint ci devenv
 
-build:
+prereqs:
 	go get github.com/jteeuwen/go-bindata/...
+
+build: prereqs
 	go generate -v ./...
 	go get .
 	go build -v
 
-test:
+test: prereqs
 	go test -v ./...
 
-validate-generated:
+validate-generated: prereqs
 	./scripts/validate-generated.sh
 
-lint:
+lint: prereqs
 	go get -u github.com/golang/lint/golint
 	# TODO: fix lint errors, enable linting
 	# golint -set_exit_status


### PR DESCRIPTION
There's an ordering problem.
`make ci` calls for validation. Validation requires `go-bindata` but `go-bindata` isn't installed until the build command.

This moves the prereqs into an explicit build target and then make sures dependent targets require it.