### PR TITLE
acsengine-features allows setting CUSTOM_HYPERKUBE_SPEC as a build param

### DIFF
--- a/test/acsengine-features.groovy
+++ b/test/acsengine-features.groovy
@@ -40,7 +40,7 @@ node {
 
                 // First check to see if var exists in context, then check for true-ness
                 // In Groovy, null and empty strings are false...
-                if(getBinding().hasVariable("myparameter") && CUSTOM_HYPERKUBE_SPEC) {
+                if(getBinding().hasVariable("CUSTOM_HYPERKUBE_SPEC") && CUSTOM_HYPERKUBE_SPEC) {
                     env.CUSTOM_HYPERKUBE_SPEC="${CUSTOM_HYPERKUBE_SPEC}"
                 }
 

--- a/test/acsengine-features.groovy
+++ b/test/acsengine-features.groovy
@@ -37,7 +37,10 @@ node {
                 env.SUBSCRIPTION_ID="${SUBSCRIPTION_ID}"
                 env.CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID="${CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID}"
                 env.CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET="${CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET}"
-                if(CUSTOM_HYPERKUBE_SPEC) {
+
+                // First check to see if var exists in context, then check for true-ness
+                // In Groovy, null and empty strings are false...
+                if(getBinding().hasVariable("myparameter") && CUSTOM_HYPERKUBE_SPEC) {
                     env.CUSTOM_HYPERKUBE_SPEC="${CUSTOM_HYPERKUBE_SPEC}"
                 }
 

--- a/test/acsengine-features.groovy
+++ b/test/acsengine-features.groovy
@@ -37,6 +37,9 @@ node {
                 env.SUBSCRIPTION_ID="${SUBSCRIPTION_ID}"
                 env.CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID="${CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID}"
                 env.CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET="${CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET}"
+                if(CUSTOM_HYPERKUBE_SPEC) {
+                    env.CUSTOM_HYPERKUBE_SPEC="${CUSTOM_HYPERKUBE_SPEC}"
+                }
 
                 sh("printf 'acs-features-test%x' \$(date '+%s') > INSTANCE_NAME_PREFIX")
                 prefix = readFile('INSTANCE_NAME_PREFIX').trim()


### PR DESCRIPTION
cc: @dmitsh / @weinong 

We need this for investigations and to setup jobs for pre-release builds of Kubernetes.

Please let me know thoughts, I know these are not right:
~~1. convention for naming build parameters?~~
2. does this need to be changed in other groovy scripts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/395)
<!-- Reviewable:end -->
