### PR TITLE
Add instructions for service principal using PowerShell

### DIFF
--- a/docs/serviceprincipal.md
+++ b/docs/serviceprincipal.md
@@ -42,6 +42,25 @@ There are several ways to create a Service Principal in Azure Active Directory:
 
    Instructions: ["Use Azure PowerShell to create a service principal to access resources"](https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenticate-service-principal/)
 
+   To get you started quickly, the following are simplified instructions for creating a single-tenant AD application and a service principal with password authentication. Please read the full instructions above for proper RBAC setup of your application. Display name and URI are a friendly arbitrary name and address for your application.
+
+   ```powershell
+   PS> Login-AzureRmAccount -SubscriptionId $subscriptionId
+   PS> $app = New-AzureRmADApplication -DisplayName $name -IdentifierUris $uri -Password $passwd
+   PS> New-AzureRmADServicePrincipal -ApplicationId $app.ApplicationId
+   PS> New-AzureRmRoleAssignment -RoleDefinitionName Contributor -ServicePrincipalName $app.ApplicationId
+   ```
+
+   The first command outputs your `tenantId`, used below. The `$app.ApplicationId` is used for the `servicePrincipalProfile.servicePrincipalClientId` and the `$passwd` is used for `servicePrincipalProfile.servicePrincipalClientSecret`.
+
+   Confirm your service principal by opening a new PowerShell session and running the following commands. Enter `$app.ApplicationId` for username.
+
+   ```powershell
+   PS> $creds = Get-Credential
+   PS> Login-AzureRmAccount -ServicePrincipal -TenantId $tenantId -Credential $creds
+   PS> Get-AzureRmVMSize -Location westus
+   ```
+
 * **With the [Portal](https://portal.azure.com)**
 
    Instructions: ["Use portal to create Active Directory application and service principal that can access resources"](https://azure.microsoft.com/en-us/documentation/articles/resource-group-create-service-principal-portal/)

--- a/docs/serviceprincipal.md
+++ b/docs/serviceprincipal.md
@@ -25,9 +25,9 @@ There are several ways to create a Service Principal in Azure Active Directory:
    az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/${SUBSCRIPTION_ID}"
    ```
 
-This will output your `appId`, `password`, `name`, and `tenant`.  The `name` or `appId` may be used for the `servicePrincipalProfile.servicePrincipalClientId` and the `password` is used for `servicePrincipalProfile.servicePrincipalClientSecret`.
+   This will output your `appId`, `password`, `name`, and `tenant`.  The `name` or `appId` may be used for the `servicePrincipalProfile.servicePrincipalClientId` and the `password` is used for `servicePrincipalProfile.servicePrincipalClientSecret`.
 
-Confirm your service principal by opening a new shell and run the following commands substituting in `name`, `password`, and `tenant`:
+   Confirm your service principal by opening a new shell and run the following commands substituting in `name`, `password`, and `tenant`:
 
    ```shell
    az login --service-principal -u NAME -p PASSWORD --tenant TENANT
@@ -38,10 +38,10 @@ Confirm your service principal by opening a new shell and run the following comm
 
    Instructions: ["Use Azure CLI to create a service principal to access resources"](https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenticate-service-principal-cli/)
 
-* **With [PowerShell](https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenticate-service-principal/)**
+* **With [PowerShell](https://github.com/Azure/azure-powershell)**
 
    Instructions: ["Use Azure PowerShell to create a service principal to access resources"](https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenticate-service-principal/)
 
-* **With the [Legacy Portal](https://azure.microsoft.com/en-us/documentation/articles/resource-group-create-service-principal-portal/)**
+* **With the [Portal](https://portal.azure.com)**
 
    Instructions: ["Use portal to create Active Directory application and service principal that can access resources"](https://azure.microsoft.com/en-us/documentation/articles/resource-group-create-service-principal-portal/)


### PR DESCRIPTION
Added quick instructions to bring ServicePrincipal PowerShell documentation on par with Azure CLI documentation.

When I first created my service principal, I made a few mistakes which resulted in broken ACS clusters. I thought I'd share the exact steps so that others don't repeat the same mistakes. Confirmed correctness by running the instructions in a clean subscription.

Also replaced some links that were repeated twice with more useful links, and fixed indentation in other places on the same page.

Fixes #402 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/398)
<!-- Reviewable:end -->
