### PR TITLE
Update acsengine.md

### DIFF
--- a/docs/acsengine.md
+++ b/docs/acsengine.md
@@ -84,8 +84,8 @@ Build Steps:
   ```
   export PATH=$PATH:/usr/local/go/bin
   export GOPATH=$HOME/gopath
+  source $HOME/.sh_profile
   ```
-  3. `source $HOME/.sh_profile`
 2. Build acs-engine:
   1. type `go get github.com/Azure/acs-engine` to get the acs-engine Github project
   2. type `go get all` to get the supporting components


### PR DESCRIPTION
Grouped all 'bash_profile' additions for OSX in same format. Some users were missing the last line as not grouped with the others when configuring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/431)
<!-- Reviewable:end -->
