### PR TITLE
Making converting diagnostics profiles not throw nil pointer panics

### DIFF
--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -363,9 +363,10 @@ func convertAgentPoolProfileToVLabs(api *AgentPoolProfile, p *vlabs.AgentPoolPro
 	}
 }
 
-func convertDiagnosticsProfileToV20160930(api *DiagnosticsProfile, v20160930 *v20160930.DiagnosticsProfile) {
+func convertDiagnosticsProfileToV20160930(api *DiagnosticsProfile, dp *v20160930.DiagnosticsProfile) {
 	if api.VMDiagnostics != nil {
-		convertVMDiagnosticsToV20160930(api.VMDiagnostics, v20160930.VMDiagnostics)
+		dp.VMDiagnostics = &v20160930.VMDiagnostics{}
+		convertVMDiagnosticsToV20160930(api.VMDiagnostics, dp.VMDiagnostics)
 	}
 }
 
@@ -374,9 +375,10 @@ func convertVMDiagnosticsToV20160930(api *VMDiagnostics, v20160930 *v20160930.VM
 	v20160930.StorageURL = api.StorageURL
 }
 
-func convertDiagnosticsProfileToV20160330(api *DiagnosticsProfile, v20160330 *v20160330.DiagnosticsProfile) {
+func convertDiagnosticsProfileToV20160330(api *DiagnosticsProfile, dp *v20160330.DiagnosticsProfile) {
 	if api.VMDiagnostics != nil {
-		convertVMDiagnosticsToV20160330(api.VMDiagnostics, v20160330.VMDiagnostics)
+		dp.VMDiagnostics = &v20160330.VMDiagnostics{}
+		convertVMDiagnosticsToV20160330(api.VMDiagnostics, dp.VMDiagnostics)
 	}
 }
 


### PR DESCRIPTION
I made a bad assumption about the state of the target object( thought we had serialized it from json).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/462)
<!-- Reviewable:end -->
