### PR TITLE
fix kubelet.service template

### DIFF
--- a/parts/kuberneteskubelet.service
+++ b/parts/kuberneteskubelet.service
@@ -43,3 +43,8 @@ ExecStart=/usr/bin/docker run \
         --hairpin-mode=promiscuous-bridge \
         --network-plugin=${KUBELET_NETWORK_PLUGIN} \
         --v=2
+ExecStop=/usr/bin/docker stop -t 10 kubelet
+ExecStopPost=/usr/bin/docker rm -f kubelet
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Missing [Install] section prevents creating symlink while `systemctl enable kubelet`. Service does not start after node restart.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/477)
<!-- Reviewable:end -->
