### PR TITLE
Fix k8s custom VNet example so that the pods work

### DIFF
--- a/examples/vnet/kubernetesvnet.json
+++ b/examples/vnet/kubernetesvnet.json
@@ -2,7 +2,8 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
+      "orchestratorType": "Kubernetes",
+      "clusterCidr": "10.239.0.0/16"
     },
     "masterProfile": {
       "count": 1,

--- a/examples/vnet/vnetarmtemplate/azuredeploy.kubernetes.json
+++ b/examples/vnet/vnetarmtemplate/azuredeploy.kubernetes.json
@@ -18,7 +18,7 @@
           {
             "name": "KubernetesSubnet",
             "properties": {
-              "addressPrefix": "10.239.0.0/16"
+              "addressPrefix": "10.239.255.0/24"
             }
           }
         ]


### PR DESCRIPTION
Without this fix the agent nodes will be assigned IPs by DHCP at the start of this range (10.239.0.4, .5, .6 etc is common for three agents) and when the RouteTable is manually associated the kube cloud provider will add routes - including one of 10.239.0.0/24 to one the nodes which will immediately make the other two nodes unreachable. The fix is to make sure the nodes are assigned IP address from the end of the network space (or alternatively from outside the clusterCidr all together but still in the VNet space)

Addresses one of the problems mentioned in #493 (but perhaps not the original reported problem.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/507)
<!-- Reviewable:end -->
