### PR TITLE
temporary allow k8s agentpool dnsprefix, and drop it in validate

### DIFF
--- a/pkg/api/v20160930/validate.go
+++ b/pkg/api/v20160930/validate.go
@@ -50,6 +50,8 @@ func (a *AgentPoolProfile) Validate(orchestratorType OrchestratorType) error {
 	}
 	// Kubernetes don't allow agent DNSPrefix
 	if orchestratorType == Kubernetes {
+		// The line below need to be removed after June 2017
+		a.DNSPrefix = ""
 		if e := validateNameEmpty(a.DNSPrefix, "AgentPoolProfile.DNSPrefix"); e != nil {
 			return e
 		}

--- a/pkg/api/v20170131/validate.go
+++ b/pkg/api/v20170131/validate.go
@@ -50,6 +50,8 @@ func (a *AgentPoolProfile) Validate(orchestratorType OrchestratorType) error {
 	}
 	// Kubernetes don't allow agent DNSPrefix
 	if orchestratorType == Kubernetes {
+		// The line below need to be removed after June 2017
+		a.DNSPrefix = ""
 		if e := validateNameEmpty(a.DNSPrefix, "AgentPoolProfile.DNSPrefix"); e != nil {
 			return e
 		}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/544)
<!-- Reviewable:end -->
