### PR TITLE
Configurable k8s cluster and service subnets

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -33,7 +33,9 @@ Here are the valid values for the orchestrator types:
 |kubernetesImageBase|no|This specifies the image of kubernetes to use for the cluster.|
 |networkPolicy|no|Specifies the network policy tool for the cluster. Valid values are:<br>`none` (default), which won't enforce any network policy,<br>`azure` for applying Azure VNET network policy,<br>`calico` for Calico network policy for clusters with Linux agents only.<br>See [network policy examples](../examples/networkpolicy) for more information.|
 |clusterSubnet|no|The IP subnet used for allocating IP addresses for pod network interfaces. The subnet must be in the VNET address space. Default value is 10.244.0.0/16.|
+|dnsServiceIP|no|IP address for kube-dns to listen on. If specified must be in the range of `serviceCidr`.|
 |dockerBridgeSubnet|no|The specific IP and subnet used for allocating IP addresses for the docker bridge network created on the kubernetes master and agents. Default value is 172.17.0.1/16. This value is used to configure the docker daemon using the [--bip flag](https://docs.docker.com/engine/userguide/networking/default_network/custom-docker0).|
+|serviceCidr|no|IP range for Service IPs, Default is "10.0.0.0/16". This range is never routed outside of a node so does not need to lie within clusterSubnet or the VNet.|
 |enableRbac|no|Enable [Kubernetes RBAC](https://kubernetes.io/docs/admin/authorization/rbac/) (boolean - default == false) |
 |maxPods|no|The maximum number of pods per node. The minimum valid value, necessary for running kube-system pods, is 5. Default value is 30 when networkPolicy equals azure, 110 otherwise.|
 

--- a/parts/kubernetesmastercustomdata.yml
+++ b/parts/kubernetesmastercustomdata.yml
@@ -239,6 +239,7 @@ write_files:
     sed -i "s|<kubernetesHeapsterSpec>|{{WrapAsVariable "kubernetesHeapsterSpec"}}|g; s|<kubernetesAddonResizerSpec>|{{WrapAsVariable "kubernetesAddonResizerSpec"}}|g" "/etc/kubernetes/addons/kube-heapster-deployment.yaml"
     sed -i "s|<kubernetesDashboardSpec>|{{WrapAsVariable "kubernetesDashboardSpec"}}|g" "/etc/kubernetes/addons/kubernetes-dashboard-deployment.yaml"
     sed -i "s|<kubernetesTillerSpec>|{{WrapAsVariable "kubernetesTillerSpec"}}|g" "/etc/kubernetes/addons/kube-tiller-deployment.yaml"
+    sed -i "s|<kubeDnsServiceIP>|{{WrapAsVariable "kubeDnsServiceIP"}}|g" "/etc/kubernetes/addons/kube-dns-deployment.yaml"
 
 {{if .OrchestratorProfile.KubernetesConfig.EnableRbac }}
     # If RBAC enabled then add parameters to API server and Controller manager configuration

--- a/parts/kubernetesmastervars.t
+++ b/parts/kubernetesmastervars.t
@@ -133,8 +133,8 @@
     "virtualNetworkName": "[concat(variables('orchestratorName'), '-vnet-', variables('nameSuffix'))]",
 {{end}}
     "vnetCidr": "[parameters('vnetCidr')]",
-    "kubeDnsServiceIp": "10.0.0.10",
-    "kubeServiceCidr": "10.0.0.0/16",
+    "kubeDnsServiceIP": "[parameters('kubeDnsServiceIP')]",
+    "kubeServiceCidr": "[parameters('kubeServiceCidr')]",
     "kubeClusterCidr": "[parameters('kubeClusterCidr')]",
     "dockerBridgeCidr": "[parameters('dockerBridgeCidr')]",
 {{if IsKubernetesVersionGe "1.6.0"}}

--- a/parts/kubernetesparams.t
+++ b/parts/kubernetesparams.t
@@ -69,6 +69,20 @@
       },
       "type": "string"
     },
+    "kubeDnsServiceIP": {
+      {{PopulateClassicModeDefaultValue "kubeDnsServiceIP"}}
+      "metadata": {
+        "description": "Kubernetes DNS IP"
+      },
+      "type": "string"
+    },
+    "kubeServiceCidr": {
+      {{PopulateClassicModeDefaultValue "kubeServiceCidr"}}
+      "metadata": {
+        "description": "Kubernetes service address space"
+      },
+      "type": "string"
+    },
     "kubernetesHyperkubeSpec": {
       {{PopulateClassicModeDefaultValue "kubernetesHyperkubeSpec"}}
       "metadata": {

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -68,6 +68,12 @@ const (
 	DefaultKubernetesCloudProviderRateLimitBucket = 10
 	// DefaultTillerImage defines the Helm Tiller deployment version on Kubernetes Clusters
 	DefaultTillerImage = "tiller:v2.6.0"
+	// DefaultKubernetesDnsServiceIP specifies the IP address that kube-dns
+	// listens on by default. must by in the default Service CIDR range.
+	DefaultKubernetesDnsServiceIP = "10.0.0.10"
+	// DefaultKubernetesServiceCIDR specifies the IP subnet that kubernetes will
+	// create Service IPs within.
+	DefaultKubernetesServiceCIDR = "10.0.0.0/16"
 )
 
 const (

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/Azure/acs-engine/pkg/api"
+	"github.com/Azure/acs-engine/pkg/api/common"
 	"github.com/Masterminds/semver"
 )
 
@@ -102,8 +103,14 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 				a.OrchestratorProfile.KubernetesConfig.MaxPods = DefaultKubernetesMaxPods
 			}
 		}
+		if a.OrchestratorProfile.KubernetesConfig.DnsServiceIP == "" {
+			a.OrchestratorProfile.KubernetesConfig.DnsServiceIP = DefaultKubernetesDnsServiceIP
+		}
 		if a.OrchestratorProfile.KubernetesConfig.DockerBridgeSubnet == "" {
 			a.OrchestratorProfile.KubernetesConfig.DockerBridgeSubnet = DefaultDockerBridgeSubnet
+		}
+		if a.OrchestratorProfile.KubernetesConfig.ServiceCIDR == "" {
+			a.OrchestratorProfile.KubernetesConfig.ServiceCIDR = DefaultKubernetesServiceCIDR
 		}
 		if a.OrchestratorProfile.KubernetesConfig.NodeStatusUpdateFrequency == "" {
 			a.OrchestratorProfile.KubernetesConfig.NodeStatusUpdateFrequency = KubeConfigs[k8sRelease]["nodestatusfreq"]
@@ -281,6 +288,12 @@ func setDefaultCerts(a *api.Properties) (bool, error) {
 		a.CertificateProfile.CaCertificate = caPair.CertificatePem
 		a.CertificateProfile.CaPrivateKey = caPair.PrivateKeyPem
 	}
+
+	cidrFirstIp, err := common.CidrStringFirstIp(a.OrchestratorProfile.KubernetesConfig.ServiceCIDR)
+	if err != nil {
+		return false, err
+	}
+	ips = append(ips, cidrFirstIp)
 
 	apiServerPair, clientPair, kubeConfigPair, err := CreatePki(masterExtraFQDNs, ips, DefaultKubernetesClusterDomain, caPair)
 	if err != nil {

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -438,6 +438,8 @@ func getParameters(cs *api.ContainerService, isClassicMode bool) (paramsMap, err
 			addValue(parametersMap, "kubernetesEndpoint", properties.HostedMasterProfile.FQDN)
 		}
 		addValue(parametersMap, "dockerEngineDownloadRepo", cloudSpecConfig.DockerSpecConfig.DockerEngineRepo)
+		addValue(parametersMap, "kubeDnsServiceIP", properties.OrchestratorProfile.KubernetesConfig.DnsServiceIP)
+		addValue(parametersMap, "kubeServiceCidr", properties.OrchestratorProfile.KubernetesConfig.ServiceCIDR)
 		addValue(parametersMap, "kubernetesHyperkubeSpec", kubernetesHyperkubeSpec)
 		addValue(parametersMap, "kubernetesAddonManagerSpec", cloudSpecConfig.KubernetesSpecConfig.KubernetesImageBase+KubeConfigs[KubernetesRelease]["addonmanager"])
 		addValue(parametersMap, "kubernetesAddonResizerSpec", cloudSpecConfig.KubernetesSpecConfig.KubernetesImageBase+KubeConfigs[KubernetesRelease]["addonresizer"])
@@ -924,7 +926,11 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 				case "kubeBinariesSASURL":
 					val = cloudSpecConfig.KubernetesSpecConfig.KubeBinariesSASURLBase + KubeConfigs[kubernetesRelease]["windowszip"]
 				case "kubeClusterCidr":
-					val = "10.244.0.0/16"
+					val = DefaultKubernetesClusterSubnet
+				case "kubeDnsServiceIP":
+					val = DefaultKubernetesDnsServiceIP
+				case "kubeServiceCidr":
+					val = DefaultKubernetesServiceCIDR
 				case "kubeBinariesVersion":
 					val = api.KubernetesReleaseToVersion[cs.Properties.OrchestratorProfile.OrchestratorRelease]
 				case "caPrivateKey":

--- a/pkg/acsengine/pki.go
+++ b/pkg/acsengine/pki.go
@@ -130,8 +130,6 @@ func createCertificate(commonName string, caCertificate *x509.Certificate, caPri
 		template.KeyUsage |= x509.KeyUsageCertSign
 		template.IsCA = isCA
 	} else if isServer {
-		extraIPs = append(extraIPs, net.ParseIP("10.0.0.1"))
-
 		template.DNSNames = extraFQDNs
 		template.IPAddresses = extraIPs
 		template.ExtKeyUsage = append(template.ExtKeyUsage, x509.ExtKeyUsageServerAuth)

--- a/pkg/acsengine/testdata/vnet/kubernetesvnet.json
+++ b/pkg/acsengine/testdata/vnet/kubernetesvnet.json
@@ -2,7 +2,12 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
+      "orchestratorType": "Kubernetes",
+      "kubernetesConfig": {
+        "dnsServiceIP": "172.17.1.10",
+        "serviceCidr": "172.16.0.0/14",
+        "clusterSubnet": "172.40.0.0/16"
+      }
     },
     "masterProfile": {
       "count": 1,

--- a/pkg/api/common/net.go
+++ b/pkg/api/common/net.go
@@ -1,0 +1,39 @@
+package common
+
+import "net"
+
+// CidrStringFirstIp returns the first IP of the provided subnet.
+func CidrFirstIp(cidr net.IP) net.IP {
+	for j := len(cidr) - 1; j >= 0; j-- {
+		cidr[j]++
+		if cidr[j] > 0 {
+			break
+		}
+	}
+	return cidr
+}
+
+// CidrStringFirstIp returns the first IP of the provided subnet string. Returns an error
+// if the string cannot be parsed.
+func CidrStringFirstIp(ip string) (net.IP, error) {
+	cidr, _, err := net.ParseCIDR(ip)
+	if err != nil {
+		return nil, err
+	}
+	return CidrFirstIp(cidr), nil
+}
+
+// Ip4BroadcastAddress returns the broadcast address for the given IP subnet.
+func Ip4BroadcastAddress(n *net.IPNet) net.IP {
+	// see https://groups.google.com/d/msg/golang-nuts/IrfXFTUavXE/8YwzIOBwJf0J
+	ip4 := n.IP.To4()
+	if ip4 == nil {
+		return nil
+	}
+	last := make(net.IP, len(ip4))
+	copy(last, ip4)
+	for i := range ip4 {
+		last[i] |= ^n.Mask[i]
+	}
+	return last
+}

--- a/pkg/api/common/net_test.go
+++ b/pkg/api/common/net_test.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"net"
+	"testing"
+)
+
+type test struct {
+	cidr     string
+	expected string
+}
+
+func Test_CidrFirstIp(t *testing.T) {
+	scenarios := []test{
+		{
+			cidr:     "10.0.0.0/16",
+			expected: "10.0.0.1",
+		},
+		{
+			cidr:     "10.16.32.32/27",
+			expected: "10.16.32.33",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		if first, _ := CidrStringFirstIp(scenario.cidr); first.String() != scenario.expected {
+			t.Errorf("expected first ip of subnet %v to be %v but was %v", scenario.cidr, scenario.expected, first)
+		}
+	}
+}
+
+func Test_Ip4BroadcastAddress(t *testing.T) {
+	scenarios := []test{
+		{
+			cidr:     "10.0.0.0/16",
+			expected: "10.0.255.255",
+		},
+		{
+			cidr:     "10.16.32.32/27",
+			expected: "10.16.32.63",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		_, cidr, _ := net.ParseCIDR(scenario.cidr)
+		if broadcast := Ip4BroadcastAddress(cidr); broadcast.String() != scenario.expected {
+			t.Errorf("expected broadcast ip of subnet %v to be %v but was %v", scenario.cidr, scenario.expected, broadcast)
+		}
+	}
+}

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -554,6 +554,8 @@ func convertOrchestratorProfileToVLabs(api *OrchestratorProfile, o *vlabs.Orches
 func convertKubernetesConfigToVLabs(api *KubernetesConfig, vlabs *vlabs.KubernetesConfig) {
 	vlabs.KubernetesImageBase = api.KubernetesImageBase
 	vlabs.ClusterSubnet = api.ClusterSubnet
+	vlabs.DnsServiceIP = api.DnsServiceIP
+	vlabs.ServiceCidr = api.ServiceCIDR
 	vlabs.NetworkPolicy = api.NetworkPolicy
 	vlabs.MaxPods = api.MaxPods
 	vlabs.DockerBridgeSubnet = api.DockerBridgeSubnet

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -555,6 +555,8 @@ func convertVLabsOrchestratorProfile(vlabscs *vlabs.OrchestratorProfile, api *Or
 func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *KubernetesConfig) {
 	api.KubernetesImageBase = vlabs.KubernetesImageBase
 	api.ClusterSubnet = vlabs.ClusterSubnet
+	api.DnsServiceIP = vlabs.DnsServiceIP
+	api.ServiceCIDR = vlabs.ServiceCidr
 	api.NetworkPolicy = vlabs.NetworkPolicy
 	api.MaxPods = vlabs.MaxPods
 	api.DockerBridgeSubnet = vlabs.DockerBridgeSubnet

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -146,6 +146,8 @@ type KubernetesConfig struct {
 	NetworkPolicy                    string  `json:"networkPolicy,omitempty"`
 	MaxPods                          int     `json:"maxPods,omitempty"`
 	DockerBridgeSubnet               string  `json:"dockerBridgeSubnet,omitempty"`
+	DnsServiceIP                     string  `json:"dnsServiceIP,omitempty"`
+	ServiceCIDR                      string  `json:"serviceCidr,omitempty"`
 	NodeStatusUpdateFrequency        string  `json:"nodeStatusUpdateFrequency,omitempty"`
 	CtrlMgrNodeMonitorGracePeriod    string  `json:"ctrlMgrNodeMonitorGracePeriod,omitempty"`
 	CtrlMgrPodEvictionTimeout        string  `json:"ctrlMgrPodEvictionTimeout,omitempty"`

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -174,6 +174,8 @@ func (o *OrchestratorProfile) UnmarshalJSON(b []byte) error {
 type KubernetesConfig struct {
 	KubernetesImageBase              string  `json:"kubernetesImageBase,omitempty"`
 	ClusterSubnet                    string  `json:"clusterSubnet,omitempty"`
+	DnsServiceIP                     string  `json:"dnsServiceIP,omitempty"`
+	ServiceCidr                      string  `json:"serviceCidr,omitempty"`
 	NetworkPolicy                    string  `json:"networkPolicy,omitempty"`
 	MaxPods                          int     `json:"maxPods,omitempty"`
 	DockerBridgeSubnet               string  `json:"DockerBridgeSubnet,omitempty"`


### PR DESCRIPTION
This pull request re-implements the changes originally discussed in https://github.com/Azure/acs-engine/pull/191.

It makes the kubernetes cluster and subnets configurable rather than using the default 10.0.0.0/8. This is useful, for example, to allow the kubernetes cluster to communicate with other services within Azure that may also be within the 10.0.0.0/8 subnet.

Fixes #1161 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/546)
<!-- Reviewable:end -->
