### PR TITLE
use pointer for []*AgentPoolProfile

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -124,9 +124,7 @@ func setAgentNetworkDefaults(a *api.Properties) {
 	// configure the subnets if not in custom VNET
 	if !a.MasterProfile.IsCustomVNET() {
 		subnetCounter := 0
-		for i := range a.AgentPoolProfiles {
-			profile := &a.AgentPoolProfiles[i]
-
+		for _, profile := range a.AgentPoolProfiles {
 			if a.OrchestratorProfile.OrchestratorType == api.Kubernetes {
 				profile.Subnet = a.MasterProfile.Subnet
 			} else {
@@ -137,9 +135,7 @@ func setAgentNetworkDefaults(a *api.Properties) {
 		}
 	}
 
-	for i := range a.AgentPoolProfiles {
-		profile := &a.AgentPoolProfiles[i]
-
+	for _, profile := range a.AgentPoolProfiles {
 		// set default OSType to Linux
 		if profile.OSType == "" {
 			profile.OSType = api.Linux
@@ -159,8 +155,7 @@ func setAgentNetworkDefaults(a *api.Properties) {
 
 // setStorageDefaults for agents
 func setStorageDefaults(a *api.Properties) {
-	for i := range a.AgentPoolProfiles {
-		profile := &a.AgentPoolProfiles[i]
+	for _, profile := range a.AgentPoolProfiles {
 		if len(profile.StorageProfile) == 0 {
 			profile.StorageProfile = api.StorageAccount
 		}

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -823,8 +823,7 @@ func getVNETAddressPrefixes(properties *api.Properties) string {
 	var buf bytes.Buffer
 	buf.WriteString(`"[variables('masterSubnet')]"`)
 	visitedSubnets[properties.MasterProfile.Subnet] = true
-	for i := range properties.AgentPoolProfiles {
-		profile := &properties.AgentPoolProfiles[i]
+	for _, profile := range properties.AgentPoolProfiles {
 		if _, ok := visitedSubnets[profile.Subnet]; !ok {
 			buf.WriteString(fmt.Sprintf(",\n            \"[variables('%sSubnet')]\"", profile.Name))
 		}

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -139,11 +139,11 @@ func convertPropertiesToV20160930(api *Properties, p *v20160930.Properties) {
 		p.MasterProfile = &v20160930.MasterProfile{}
 		convertMasterProfileToV20160930(api.MasterProfile, p.MasterProfile)
 	}
-	p.AgentPoolProfiles = []v20160930.AgentPoolProfile{}
+	p.AgentPoolProfiles = []*v20160930.AgentPoolProfile{}
 	for _, apiProfile := range api.AgentPoolProfiles {
 		v20160930Profile := &v20160930.AgentPoolProfile{}
-		convertAgentPoolProfileToV20160930(&apiProfile, v20160930Profile)
-		p.AgentPoolProfiles = append(p.AgentPoolProfiles, *v20160930Profile)
+		convertAgentPoolProfileToV20160930(apiProfile, v20160930Profile)
+		p.AgentPoolProfiles = append(p.AgentPoolProfiles, v20160930Profile)
 	}
 	if api.LinuxProfile != nil {
 		p.LinuxProfile = &v20160930.LinuxProfile{}
@@ -181,11 +181,11 @@ func convertPropertiesToV20160330(api *Properties, p *v20160330.Properties) {
 		p.MasterProfile = &v20160330.MasterProfile{}
 		convertMasterProfileToV20160330(api.MasterProfile, p.MasterProfile)
 	}
-	p.AgentPoolProfiles = []v20160330.AgentPoolProfile{}
+	p.AgentPoolProfiles = []*v20160330.AgentPoolProfile{}
 	for _, apiProfile := range api.AgentPoolProfiles {
 		v20160330Profile := &v20160330.AgentPoolProfile{}
-		convertAgentPoolProfileToV20160330(&apiProfile, v20160330Profile)
-		p.AgentPoolProfiles = append(p.AgentPoolProfiles, *v20160330Profile)
+		convertAgentPoolProfileToV20160330(apiProfile, v20160330Profile)
+		p.AgentPoolProfiles = append(p.AgentPoolProfiles, v20160330Profile)
 	}
 	if api.LinuxProfile != nil {
 		p.LinuxProfile = &v20160330.LinuxProfile{}
@@ -215,11 +215,11 @@ func convertPropertiesToV20170131(api *Properties, p *v20170131.Properties) {
 		p.MasterProfile = &v20170131.MasterProfile{}
 		convertMasterProfileToV20170131(api.MasterProfile, p.MasterProfile)
 	}
-	p.AgentPoolProfiles = []v20170131.AgentPoolProfile{}
+	p.AgentPoolProfiles = []*v20170131.AgentPoolProfile{}
 	for _, apiProfile := range api.AgentPoolProfiles {
 		v20170131Profile := &v20170131.AgentPoolProfile{}
-		convertAgentPoolProfileToV20170131(&apiProfile, v20170131Profile)
-		p.AgentPoolProfiles = append(p.AgentPoolProfiles, *v20170131Profile)
+		convertAgentPoolProfileToV20170131(apiProfile, v20170131Profile)
+		p.AgentPoolProfiles = append(p.AgentPoolProfiles, v20170131Profile)
 	}
 	if api.LinuxProfile != nil {
 		p.LinuxProfile = &v20170131.LinuxProfile{}
@@ -257,11 +257,11 @@ func convertPropertiesToVLabs(api *Properties, vlabsProps *vlabs.Properties) {
 		vlabsProps.MasterProfile = &vlabs.MasterProfile{}
 		convertMasterProfileToVLabs(api.MasterProfile, vlabsProps.MasterProfile)
 	}
-	vlabsProps.AgentPoolProfiles = []vlabs.AgentPoolProfile{}
+	vlabsProps.AgentPoolProfiles = []*vlabs.AgentPoolProfile{}
 	for _, apiProfile := range api.AgentPoolProfiles {
 		vlabsProfile := &vlabs.AgentPoolProfile{}
-		convertAgentPoolProfileToVLabs(&apiProfile, vlabsProfile)
-		vlabsProps.AgentPoolProfiles = append(vlabsProps.AgentPoolProfiles, *vlabsProfile)
+		convertAgentPoolProfileToVLabs(apiProfile, vlabsProfile)
+		vlabsProps.AgentPoolProfiles = append(vlabsProps.AgentPoolProfiles, vlabsProfile)
 	}
 	if api.LinuxProfile != nil {
 		vlabsProps.LinuxProfile = &vlabs.LinuxProfile{}

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -137,18 +137,18 @@ func convertV20160930Properties(v20160930 *v20160930.Properties, api *Properties
 		api.MasterProfile = &MasterProfile{}
 		convertV20160930MasterProfile(v20160930.MasterProfile, api.MasterProfile)
 	}
-	api.AgentPoolProfiles = []AgentPoolProfile{}
+	api.AgentPoolProfiles = []*AgentPoolProfile{}
 	for _, p := range v20160930.AgentPoolProfiles {
 		apiProfile := &AgentPoolProfile{}
 		// api.OrchestratorProfile already be filled in correctly
 		if api.OrchestratorProfile.IsKubernetes() {
 			// we only allow AvailabilitySet for kubernetes's agentpool
-			convertV20160930AgentPoolProfile(&p, AvailabilitySet, apiProfile)
+			convertV20160930AgentPoolProfile(p, AvailabilitySet, apiProfile)
 		} else {
 			// other orchestrators all use VMSS
-			convertV20160930AgentPoolProfile(&p, VirtualMachineScaleSets, apiProfile)
+			convertV20160930AgentPoolProfile(p, VirtualMachineScaleSets, apiProfile)
 		}
-		api.AgentPoolProfiles = append(api.AgentPoolProfiles, *apiProfile)
+		api.AgentPoolProfiles = append(api.AgentPoolProfiles, apiProfile)
 	}
 	if v20160930.LinuxProfile != nil {
 		api.LinuxProfile = &LinuxProfile{}
@@ -186,11 +186,11 @@ func convertV20160330Properties(v20160330 *v20160330.Properties, api *Properties
 		api.MasterProfile = &MasterProfile{}
 		convertV20160330MasterProfile(v20160330.MasterProfile, api.MasterProfile)
 	}
-	api.AgentPoolProfiles = []AgentPoolProfile{}
+	api.AgentPoolProfiles = []*AgentPoolProfile{}
 	for _, p := range v20160330.AgentPoolProfiles {
 		apiProfile := &AgentPoolProfile{}
-		convertV20160330AgentPoolProfile(&p, apiProfile)
-		api.AgentPoolProfiles = append(api.AgentPoolProfiles, *apiProfile)
+		convertV20160330AgentPoolProfile(p, apiProfile)
+		api.AgentPoolProfiles = append(api.AgentPoolProfiles, apiProfile)
 
 	}
 	if v20160330.LinuxProfile != nil {
@@ -221,18 +221,18 @@ func convertV20170131Properties(v20170131 *v20170131.Properties, api *Properties
 		api.MasterProfile = &MasterProfile{}
 		convertV20170131MasterProfile(v20170131.MasterProfile, api.MasterProfile)
 	}
-	api.AgentPoolProfiles = []AgentPoolProfile{}
+	api.AgentPoolProfiles = []*AgentPoolProfile{}
 	for _, p := range v20170131.AgentPoolProfiles {
 		apiProfile := &AgentPoolProfile{}
 		// api.OrchestratorProfile already be filled in correctly
 		if api.OrchestratorProfile.IsKubernetes() {
 			// we only allow AvailabilitySet for kubernetes's agentpool
-			convertV20170131AgentPoolProfile(&p, AvailabilitySet, apiProfile)
+			convertV20170131AgentPoolProfile(p, AvailabilitySet, apiProfile)
 		} else {
 			// other orchestrators all use VMSS
-			convertV20170131AgentPoolProfile(&p, VirtualMachineScaleSets, apiProfile)
+			convertV20170131AgentPoolProfile(p, VirtualMachineScaleSets, apiProfile)
 		}
-		api.AgentPoolProfiles = append(api.AgentPoolProfiles, *apiProfile)
+		api.AgentPoolProfiles = append(api.AgentPoolProfiles, apiProfile)
 	}
 	if v20170131.LinuxProfile != nil {
 		api.LinuxProfile = &LinuxProfile{}
@@ -270,11 +270,11 @@ func convertVLabsProperties(vlabs *vlabs.Properties, api *Properties) {
 		api.MasterProfile = &MasterProfile{}
 		convertVLabsMasterProfile(vlabs.MasterProfile, api.MasterProfile)
 	}
-	api.AgentPoolProfiles = []AgentPoolProfile{}
+	api.AgentPoolProfiles = []*AgentPoolProfile{}
 	for _, p := range vlabs.AgentPoolProfiles {
 		apiProfile := &AgentPoolProfile{}
-		convertVLabsAgentPoolProfile(&p, apiProfile)
-		api.AgentPoolProfiles = append(api.AgentPoolProfiles, *apiProfile)
+		convertVLabsAgentPoolProfile(p, apiProfile)
+		api.AgentPoolProfiles = append(api.AgentPoolProfiles, apiProfile)
 	}
 	if vlabs.LinuxProfile != nil {
 		api.LinuxProfile = &LinuxProfile{}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -42,7 +42,7 @@ type Properties struct {
 	ProvisioningState       ProvisioningState        `json:"provisioningState,omitempty"`
 	OrchestratorProfile     *OrchestratorProfile     `json:"orchestratorProfile,omitempty"`
 	MasterProfile           *MasterProfile           `json:"masterProfile,omitempty"`
-	AgentPoolProfiles       []AgentPoolProfile       `json:"agentPoolProfiles,omitempty"`
+	AgentPoolProfiles       []*AgentPoolProfile      `json:"agentPoolProfiles,omitempty"`
 	LinuxProfile            *LinuxProfile            `json:"linuxProfile,omitempty"`
 	WindowsProfile          *WindowsProfile          `json:"windowsProfile,omitempty"`
 	DiagnosticsProfile      *DiagnosticsProfile      `json:"diagnosticsProfile,omitempty"`

--- a/pkg/api/v20160330/types.go
+++ b/pkg/api/v20160330/types.go
@@ -33,7 +33,7 @@ type Properties struct {
 	ProvisioningState   ProvisioningState    `json:"provisioningState,omitempty"`
 	OrchestratorProfile *OrchestratorProfile `json:"orchestratorProfile,omitempty"`
 	MasterProfile       *MasterProfile       `json:"masterProfile,omitempty"`
-	AgentPoolProfiles   []AgentPoolProfile   `json:"agentPoolProfiles,omitempty"`
+	AgentPoolProfiles   []*AgentPoolProfile  `json:"agentPoolProfiles,omitempty"`
 	LinuxProfile        *LinuxProfile        `json:"linuxProfile,omitempty"`
 	WindowsProfile      *WindowsProfile      `json:"windowsProfile,omitempty"`
 

--- a/pkg/api/v20160330/validate.go
+++ b/pkg/api/v20160330/validate.go
@@ -138,7 +138,7 @@ func validateDNSName(dnsName string) error {
 	return nil
 }
 
-func validateUniqueProfileNames(profiles []AgentPoolProfile) error {
+func validateUniqueProfileNames(profiles []*AgentPoolProfile) error {
 	profileNames := make(map[string]bool)
 	for _, profile := range profiles {
 		if _, ok := profileNames[profile.Name]; ok {

--- a/pkg/api/v20160930/types.go
+++ b/pkg/api/v20160930/types.go
@@ -33,7 +33,7 @@ type Properties struct {
 	ProvisioningState       ProvisioningState        `json:"provisioningState,omitempty"`
 	OrchestratorProfile     *OrchestratorProfile     `json:"orchestratorProfile,omitempty"`
 	MasterProfile           *MasterProfile           `json:"masterProfile,omitempty"`
-	AgentPoolProfiles       []AgentPoolProfile       `json:"agentPoolProfiles,omitempty"`
+	AgentPoolProfiles       []*AgentPoolProfile      `json:"agentPoolProfiles,omitempty"`
 	LinuxProfile            *LinuxProfile            `json:"linuxProfile,omitempty"`
 	WindowsProfile          *WindowsProfile          `json:"windowsProfile,omitempty"`
 	DiagnosticsProfile      *DiagnosticsProfile      `json:"diagnosticsProfile,omitempty"`

--- a/pkg/api/v20160930/validate.go
+++ b/pkg/api/v20160930/validate.go
@@ -154,7 +154,7 @@ func validateDNSName(dnsName string) error {
 	return nil
 }
 
-func validateUniqueProfileNames(profiles []AgentPoolProfile) error {
+func validateUniqueProfileNames(profiles []*AgentPoolProfile) error {
 	profileNames := make(map[string]bool)
 	for _, profile := range profiles {
 		if _, ok := profileNames[profile.Name]; ok {

--- a/pkg/api/v20170131/types.go
+++ b/pkg/api/v20170131/types.go
@@ -33,7 +33,7 @@ type Properties struct {
 	ProvisioningState       ProvisioningState        `json:"provisioningState,omitempty"`
 	OrchestratorProfile     *OrchestratorProfile     `json:"orchestratorProfile,omitempty"`
 	MasterProfile           *MasterProfile           `json:"masterProfile,omitempty"`
-	AgentPoolProfiles       []AgentPoolProfile       `json:"agentPoolProfiles,omitempty"`
+	AgentPoolProfiles       []*AgentPoolProfile      `json:"agentPoolProfiles,omitempty"`
 	LinuxProfile            *LinuxProfile            `json:"linuxProfile,omitempty"`
 	WindowsProfile          *WindowsProfile          `json:"windowsProfile,omitempty"`
 	DiagnosticsProfile      *DiagnosticsProfile      `json:"diagnosticsProfile,omitempty"`

--- a/pkg/api/v20170131/validate.go
+++ b/pkg/api/v20170131/validate.go
@@ -156,7 +156,7 @@ func validateDNSName(dnsName string) error {
 	return nil
 }
 
-func validateUniqueProfileNames(profiles []AgentPoolProfile) error {
+func validateUniqueProfileNames(profiles []*AgentPoolProfile) error {
 	profileNames := make(map[string]bool)
 	for _, profile := range profiles {
 		if _, ok := profileNames[profile.Name]; ok {

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -32,7 +32,7 @@ type Properties struct {
 	ProvisioningState       ProvisioningState        `json:"provisioningState,omitempty"`
 	OrchestratorProfile     *OrchestratorProfile     `json:"orchestratorProfile,omitempty"`
 	MasterProfile           *MasterProfile           `json:"masterProfile,omitempty"`
-	AgentPoolProfiles       []AgentPoolProfile       `json:"agentPoolProfiles,omitempty"`
+	AgentPoolProfiles       []*AgentPoolProfile      `json:"agentPoolProfiles,omitempty"`
 	LinuxProfile            *LinuxProfile            `json:"linuxProfile,omitempty"`
 	WindowsProfile          *WindowsProfile          `json:"windowsProfile,omitempty"`
 	ServicePrincipalProfile *ServicePrincipalProfile `json:"servicePrincipalProfile,omitempty"`

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -343,7 +343,7 @@ func validateDNSName(dnsName string) error {
 	return nil
 }
 
-func validateUniqueProfileNames(profiles []AgentPoolProfile) error {
+func validateUniqueProfileNames(profiles []*AgentPoolProfile) error {
 	profileNames := make(map[string]bool)
 	for _, profile := range profiles {
 		if _, ok := profileNames[profile.Name]; ok {

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -28,7 +28,7 @@ func TestProperties_ValidateNetworkPolicy(t *testing.T) {
 	}
 
 	p.OrchestratorProfile.KubernetesConfig.NetworkPolicy = "calico"
-	p.AgentPoolProfiles = []AgentPoolProfile{
+	p.AgentPoolProfiles = []*AgentPoolProfile{
 		{
 			OSType: Windows,
 		},


### PR DESCRIPTION
change AgentPoolProfiles's type to []*AgentPoolProfile. It conforms with other properties fields. And also by making this change, it avoids complicated reference syntax, which is not necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/552)
<!-- Reviewable:end -->
