### PR TITLE
[Proposal] Release process

### DIFF
--- a/docs/roadmap/planning-process.md
+++ b/docs/roadmap/planning-process.md
@@ -1,0 +1,28 @@
+# Planning Process
+
+acs-engine features a lightweight process that emphasizes openness and ensures every community member can be an integral part of planning for the future.
+
+## The Role of Maintainers
+
+[Maintainers][] lead the acs-engine project. Their duties include proposing the Roadmap, reviewing and integrating contributions and maintaining the vision of the project.
+
+## Open Roadmap
+
+The [acs-engine Roadmap](roadmap.md) is a community document. While Maintainers propose the Roadmap, it gets discussed and refined in Release Planning Meetings.
+
+## Contributing to the Roadmap
+
+Proposals and issues can be opened by anyone. Every member of the community is welcome to participate in the discussion by providing feedback and/or offering counter-proposals.
+
+## Release Milestones
+
+The Roadmap gets delivered progressively via the [Release Schedule][].  Releases are defined during Release Planning Meetings and managed using GitHub Milestones which track specific deliverables and work-in-progress.
+
+## Release Planning Meetings
+
+Major decisions affecting the Roadmap are discussed during Release Planning Meetings on the first Thursday of each month, aligned with the [Release Schedule][].
+
+Release Planning Meetings are not currently open to non-Microsoft contributors, but we may change this in the future.
+
+[Maintainers]: https://github.com/Azure/acs-engine/blob/master/OWNERS
+[Release Schedule]: releases.md

--- a/docs/roadmap/planning-process.md
+++ b/docs/roadmap/planning-process.md
@@ -1,6 +1,6 @@
 # Planning Process
 
-acs-engine features a lightweight process that emphasizes openness and ensures every community member can be an integral part of planning for the future.
+acs-engine features a lightweight process that emphasizes openness and ensures every community member can see project goals for the future.
 
 ## The Role of Maintainers
 
@@ -20,7 +20,7 @@ The Roadmap gets delivered progressively via the [Release Schedule][].  Releases
 
 ## Release Planning Meetings
 
-Major decisions affecting the Roadmap are discussed during Release Planning Meetings on the first Thursday of each month, aligned with the [Release Schedule][].
+Major decisions affecting the Roadmap are discussed during Release Planning Meetings on the first Thursday of each month, aligned with the [Release Schedule][] and monthly objectives for the Microsoft ACS team.
 
 Release Planning Meetings are not currently open to non-Microsoft contributors, but we may change this in the future.
 

--- a/docs/roadmap/releases.md
+++ b/docs/roadmap/releases.md
@@ -1,0 +1,101 @@
+# Releases
+
+acs-engine uses a [continuous delivery][] approach for creating releases. Every merged commit that passes
+testing results in a deliverable that can be given a [semantic version][] tag and shipped.
+
+## Release as Needed
+
+The master `git` branch of a project should always work. Only changes considered ready to be
+released publicly are merged.
+
+acs-engine depends on components that release new versions as often as needed. Fixing
+a high priority bug requires the project maintainer to create a new patch release.
+Merging a backward-compatible feature implies a minor release.
+
+By releasing often, each component release becomes a safe and routine event. This makes it faster
+and easier for users to obtain specific fixes. Continuous delivery also reduces the work
+necessary to release a product such as acs-engine, which depends on several external projects.
+
+"Components" applies not just to ACS projects, but also to development and release
+tools, orchestrator versions (Kubernetes, DC/OS, Swarm),to Docker base images, and to other Azure
+projects that do [semantic version][] releases.
+
+## acs-engine Releases Each Month
+
+acs-engine has a regular, public release cadence. From v0.1.0 onward, new acs-engine feature
+releases arrive on the first Thursday of each month. Patch releases are created at any time,
+as needed. GitHub milestones are used to communicate the content and timing of major and minor
+releases, and longer-term planning is visible at [the Roadmap](roadmap.md).
+
+acs-engine release timing is not linked to specific features. If a feature is merged before the
+release date, it is included in the next release.
+
+See "[How to Release acs-engine](#how-to-release-acs-engine)" for more detail.
+
+## Semantic Versioning
+
+acs-engine releases comply with [semantic versioning][semantic version], with the "public API" broadly
+defined as:
+
+- REST, gRPC, or other API that is network-accessible
+- Library or framework API intended for public use
+- "Pluggable" socket-level protocols users can redirect
+- CLI commands and output formats
+- Integration with Azure public APIs such as ARM
+
+In general, changes to anything a user might reasonably link to, customize, or integrate with should
+be backward-compatible, or else require a major release. acs-engine users can be confident that upgrading
+to a patch or to a minor release will not break anything.
+
+## How to Release acs-engine
+
+This section leads a maintainer through creating an acs-engine release.
+
+### Step 1: Assemble Master Changelog
+A change log is a file which contains a curated, chronologically ordered list of changes
+for each version of acs-engine, which helps users and contributors see what notable changes
+have been made between each version of the project.
+
+The CHANGELOG should be driven by release milestones defined on Github, which track specific deliverables and
+work-in-progress.
+
+### Step 2: Manual Testing
+
+Now it's time to go above and beyond current CI tests. Create a testing matrix spreadsheet (copying
+from the previous document is a good start) and sign up testers to cover all permutations.
+
+Testers should pay special attention to the overall user experience, make sure upgrading from
+earlier versions is smooth, and cover various storage configurations and Kubernetes versions and
+infrastructure providers.
+
+When showstopper-level bugs are found, the process is as follows:
+
+1. Create an issue that describes the bug.
+1. Create an PR that fixes the bug.
+1. Once the PR passes and is reviewed, merge it and update the CHANGELOG
+
+
+### Step 3: Tag and Create a Release
+
+TBD
+
+
+### Step 4: Close GitHub Milestones
+
+TBD
+
+### Step 5: Let Everyone Know
+
+Let the rest of the team know they can start blogging and tweeting about the new acs-engine release.
+Post a message to the #company channel on Slack. Include a link to the released chart and to the
+master CHANGELOG:
+
+```
+@here acs-engine 0.1.0 is here!
+Master CHANGELOG: https://github.com/Azure/acs-engine/CHANGELOG.md
+```
+
+You're done with the release. Nice job!
+
+[continuous delivery]: https://en.wikipedia.org/wiki/Continuous_delivery
+[semantic version]: http://semver.org

--- a/docs/roadmap/releases.md
+++ b/docs/roadmap/releases.md
@@ -72,6 +72,8 @@ When showstopper-level bugs are found, the process is as follows:
 
 1. Create an issue that describes the bug.
 1. Create an PR that fixes the bug.
+  - PRs should always include tests (unit or e2e as appropriate) to add
+ automated coverage for the bug.
 1. Once the PR passes and is reviewed, merge it and update the CHANGELOG
 
 


### PR DESCRIPTION
# Background
---
A constant pain point for acs-engine users and internal teams at Microsoft using acs-engine has been lack of clearly defined versions that can be tracked for stability and feature completeness. Now that the project has agreed to [use SemVer for version numbers](https://github.com/Azure/acs-engine/pull/642), I'm proposing the following possible approach in defining releases of acs-engine.

For the first release, I propose the following:

1. Define/flesh out high-level roadmap (included in this PR) to be updated through the course of the project toward a "stable" `v1.0.0` release. 
1. Define the first official acs-engine release, `v0.1.0`, using GitHub Milestones
1. Define special CI release job that 1) runs all unit tests, functional/regression tests, any other additional tests pertinent for release verification and 2) uses the GitHub API to tag the repo and create a release 3) build and deploy any artifacts like Docker images (not clear this is needed)
1. Once we believe all issues/features are accepted for `v0.1.0` release kick off automated release testing
1. In addition to automated testing, conduct manual testing according to a regression test matrix (TBD)
1. If testing produces an issue needing a fix, PR the fix, get it reviewed and merged into master
1. Use automated CI job above to trigger release

Going forward, the release process would be:
1. Bi-monthly planning meetings to review project Roadmap and define release milestone
1. Once all issues/features are accepted for the release milestone, kick off automated release testing as well as manual testing
1. If testing produces an issue needing a fix, PR the fix, get it reviewed and merged into master
1. Use automated CI job to trigger release

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/667)
<!-- Reviewable:end -->

Fixes #55 