### PR TITLE
remove unnecessary deployment name suffix in azureclient

### DIFF
--- a/pkg/armhelpers/deployments.go
+++ b/pkg/armhelpers/deployments.go
@@ -1,20 +1,12 @@
 package armhelpers
 
 import (
-	"fmt"
-	"time"
-
 	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
 	"github.com/prometheus/common/log"
 )
 
 // DeployTemplate implements the TemplateDeployer interface for the AzureClient client
 func (az *AzureClient) DeployTemplate(resourceGroupName, deploymentName string, template map[string]interface{}, parameters map[string]interface{}, cancel <-chan struct{}) (*resources.DeploymentExtended, error) {
-	// this is needed because either ARM or the SDK can't distinguish between past
-	// deployments and current deployments with the same deploymentName.
-	uniqueSuffix := fmt.Sprintf("-%d", time.Now().Unix())
-	deploymentName = deploymentName + uniqueSuffix
-
 	deployment := resources.Deployment{
 		Properties: &resources.DeploymentProperties{
 			Template:   &template,

--- a/pkg/armhelpers/deployments.go
+++ b/pkg/armhelpers/deployments.go
@@ -48,6 +48,7 @@ func (az *AzureClient) ValidateTemplate(
 	return az.deploymentsClient.Validate(resourceGroupName, deploymentName, deployment)
 }
 
+// GetDeployment returns the template deployment
 func (az *AzureClient) GetDeployment(resourceGroupName, deploymentName string) (result resources.DeploymentExtended, err error) {
 	return az.deploymentsClient.Get(resourceGroupName, deploymentName)
 }

--- a/pkg/armhelpers/deployments.go
+++ b/pkg/armhelpers/deployments.go
@@ -47,3 +47,7 @@ func (az *AzureClient) ValidateTemplate(
 	}
 	return az.deploymentsClient.Validate(resourceGroupName, deploymentName, deployment)
 }
+
+func (az *AzureClient) GetDeployment(resourceGroupName, deploymentName string) (result resources.DeploymentExtended, err error) {
+	return az.deploymentsClient.Get(resourceGroupName, deploymentName)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Address [Issue 685](https://github.com/Azure/acs-engine/issues/685)
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Remove redundant deployment name suffix from AzureClient
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/686)
<!-- Reviewable:end -->
