### PR TITLE
ref(deploy): promote 'deploy' subcommand out from behind env flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,10 +40,10 @@ func NewRootCmd() *cobra.Command {
 
 	rootCmd.AddCommand(newVersionCmd())
 	rootCmd.AddCommand(newGenerateCmd())
+	rootCmd.AddCommand(newDeployCmd())
 
 	if val := os.Getenv("ACSENGINE_EXPERIMENTAL_FEATURES"); val == "1" {
 		rootCmd.AddCommand(newUpgradeCmd())
-		rootCmd.AddCommand(newDeployCmd())
 	}
 
 	return rootCmd


### PR DESCRIPTION
**What this PR does / why we need it**: Promotes the 'deploy' command out from behind an env flag. It will now be obvious to everyone looking at `acs-engine --help` now.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: n/a

**Special notes for your reviewer**: none

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
promote the `deploy` command
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/717)
<!-- Reviewable:end -->
