### PR TITLE
Add AUTOCLEAN to acs-engine-test

### DIFF
--- a/test/acs-engine-test/acse-features.json
+++ b/test/acs-engine-test/acse-features.json
@@ -38,7 +38,7 @@
     },
     {
       "cluster_definition": "disks-managed/swarm-preAttachedDisks-vmas-windows.json",
-      "location": "northcentralus"
+      "location": "centralus"
     },
     {
       "cluster_definition": "disks-managed/swarm-preAttachedDisks-vmss.json",
@@ -46,7 +46,7 @@
     },
     {
       "cluster_definition": "disks-managed/swarm-vmas-windows.json",
-      "location": "northeurope"
+      "location": "westeurope"
     },
     {
       "cluster_definition": "disks-managed/swarm-vmss.json",

--- a/test/acs-engine-test/main.go
+++ b/test/acs-engine-test/main.go
@@ -133,6 +133,10 @@ func (m *TestManager) testRun(d Deployment, index, attempt int, timeout time.Dur
 		if err != nil {
 			wrileLog(logFile, "Error [%s:%s] %v\nOutput: %s", step, resourceGroup, err, txt)
 			success = false
+			// check AUTOCLEAN flag: if set to 'n', don't remove deployment
+			if os.Getenv("AUTOCLEAN") == "n" {
+				env = append(env, "CLEANUP=n")
+			}
 			break
 		}
 		wrileLog(logFile, txt)


### PR DESCRIPTION
**What this PR does / why we need it**:

- implement "autoclean" logic in acs-engine-test:
  do not remove resource group if the test failed and AUTOCLEAN="n"
- temporarily remove "northcentralus" and "northeurope" locations
  from the regression test configuration (acse-features.json)
  due to DiskServiceInternalError (should be fixed by end July)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/728)
<!-- Reviewable:end -->
