### PR TITLE
add location setting for national cloud in sample setting files and enable CI for mooncake

### DIFF
--- a/examples/dcos.json
+++ b/examples/dcos.json
@@ -1,5 +1,6 @@
 {
   "apiVersion": "vlabs",
+  "location": "",
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "DCOS"

--- a/examples/kubernetes.json
+++ b/examples/kubernetes.json
@@ -1,5 +1,6 @@
 {
   "apiVersion": "vlabs",
+  "location": "",
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes"

--- a/examples/swarm.json
+++ b/examples/swarm.json
@@ -1,5 +1,6 @@
 {
   "apiVersion": "vlabs",
+  "location": "",
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Swarm"

--- a/examples/swarmmode.json
+++ b/examples/swarmmode.json
@@ -1,5 +1,6 @@
 {
   "apiVersion": "vlabs",
+  "location": "",
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "SwarmMode"

--- a/test/acsengine-ci.groovy
+++ b/test/acsengine-ci.groovy
@@ -34,13 +34,22 @@ node {
                   // Create log directory
                   sh("mkdir -p ${log_dir}")
                   // Create template, deploy and test
-                  env.SERVICE_PRINCIPAL_CLIENT_ID="${SPN_USER}"
-                  env.SERVICE_PRINCIPAL_CLIENT_SECRET="${SPN_PASSWORD}"
+                  //For Mooncake use cluster service prinicipal as service prinicipal to avoid mutiple credentials in Jenkins 
+                  String chinaCloud = "AzureChinaCloud"
+                  if(TARGET_ENVIRONMENT == chinaCloud) {
+                    env.SERVICE_PRINCIPAL_CLIENT_ID = "${CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID}"
+                    env.SERVICE_PRINCIPAL_CLIENT_SECRET = "${CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET}"  
+                  }
+                  else {
+                    env.SERVICE_PRINCIPAL_CLIENT_ID="${SPN_USER}"
+                    env.SERVICE_PRINCIPAL_CLIENT_SECRET="${SPN_PASSWORD}" 
+                  }
                   env.TENANT_ID="${TENANT_ID}"
                   env.SUBSCRIPTION_ID="${SUBSCRIPTION_ID}"
                   env.LOCATION = "${LOCATION}"
                   env.LOGFILE = "${log_dir}/${LOCATION}.log"
                   env.CLEANUP = "${CLEANUP}"
+                  env.TARGET_ENVIRONMENT = "${TARGET_ENVIRONMENT}"
 
                   env.INSTANCE_NAME = "test-acs-ci-${ORCHESTRATOR}-${env.LOCATION}-${env.BUILD_NUMBER}"
                   env.INSTANCE_NAME_PREFIX = "test-acs-ci"

--- a/test/cluster-tests/dcos/test.sh
+++ b/test/cluster-tests/dcos/test.sh
@@ -22,9 +22,12 @@ if [ -e "${ENV_FILE}" ]; then
 fi
 
 MARATHON_JSON="${MARATHON_JSON:-marathon.json}"
-
-remote_exec="ssh -i "${SSH_KEY}" -o ConnectTimeout=30 -o StrictHostKeyChecking=no azureuser@${INSTANCE_NAME}.${LOCATION}.cloudapp.azure.com -p2200"
-agentFQDN="${INSTANCE_NAME}0.${LOCATION}.cloudapp.azure.com"
+FQDNSuffix="cloudapp.azure.com"
+if [ "$TARGET_ENVIRONMENT" = "AzureChinaCloud" ]; then
+    FQDNSuffix="cloudapp.chinacloudapi.cn"
+fi
+remote_exec="ssh -i "${SSH_KEY}" -o ConnectTimeout=30 -o StrictHostKeyChecking=no azureuser@${INSTANCE_NAME}.${LOCATION}.${FQDNSuffix} -p2200"
+agentFQDN="${INSTANCE_NAME}0.${LOCATION}.${FQDNSuffix}"
 remote_cp="scp -i "${SSH_KEY}" -P 2200 -o StrictHostKeyChecking=no"
 
 function teardown {
@@ -61,7 +64,7 @@ if [[ "$?" != "0" ]]; then log "Failed to configure dcos"; exit 1; fi
 
 log "Copying marathon.json"
 
-${remote_cp} "${DIR}/${MARATHON_JSON}" azureuser@${INSTANCE_NAME}.${LOCATION}.cloudapp.azure.com:marathon.json
+${remote_cp} "${DIR}/${MARATHON_JSON}" azureuser@${INSTANCE_NAME}.${LOCATION}.${FQDNSuffix}:marathon.json
 if [[ "$?" != "0" ]]; then log "Failed to copy marathon.json"; exit 1; fi
 
 # feed agentFQDN to marathon.json

--- a/test/cluster-tests/kubernetes/test.sh
+++ b/test/cluster-tests/kubernetes/test.sh
@@ -185,6 +185,10 @@ log "Testing deployments"
 kubectl create namespace ${namespace}
 
 NGINX="docker.io/library/nginx:latest"
+if [ "$TARGET_ENVIRONMENT" = "AzureChinaCloud" ]
+then
+    NGINX="mirror.azure.cn:5000/library/nginx:latest"
+fi
 IMAGE="${NGINX}" # default to the library image unless we're in TEST_ACR mode
 if [[ "${TEST_ACR}" == "y" ]]; then
 	# force it to pull from ACR

--- a/test/cluster-tests/swarmmode/test.sh
+++ b/test/cluster-tests/swarmmode/test.sh
@@ -16,8 +16,12 @@ set -u
 
 
 source "$DIR/../utils.sh"
-
-ssh_args="-i ${SSH_KEY} -o ConnectTimeout=30 -o StrictHostKeyChecking=no -p2200 azureuser@${INSTANCE_NAME}.${LOCATION}.cloudapp.azure.com"
+FQDNSuffix="cloudapp.azure.com"
+if [ "$TARGET_ENVIRONMENT" = "AzureChinaCloud" ]
+then
+    FQDNSuffix="cloudapp.chinacloudapi.cn"
+fi
+ssh_args="-i ${SSH_KEY} -o ConnectTimeout=30 -o StrictHostKeyChecking=no -p2200 azureuser@${INSTANCE_NAME}.${LOCATION}.${FQDNSuffix}"
 
 function teardown {
   ssh ${ssh_args} docker service rm nginx
@@ -69,7 +73,7 @@ wait=5
 count=12
 while (( $count > 0 )); do
   log "  ... counting down $count"
-  curl --fail "http://${INSTANCE_NAME}0.${LOCATION}.cloudapp.azure.com:80/"
+  curl --fail "http://${INSTANCE_NAME}0.${LOCATION}.${FQDNSuffix}:80/"
   retval=$?
   if [[ "$retval" == "0" ]]; then break; fi
   sleep $wait

--- a/test/user.env.example
+++ b/test/user.env.example
@@ -4,6 +4,7 @@ export SUBSCRIPTION_ID=23d59db5-7c0e-4825-b738-5859cec6b1a1
 export TENANT_ID=04af9d99-4c30-4f32-95cd-3d14ceb7214d
 export SERVICE_PRINCIPAL_CLIENT_ID=245bd80a-dbd4-4e21-95a4-ae1216a9621d
 export SERVICE_PRINCIPAL_CLIENT_SECRET=99cfd46a-eae4-4fb6-a828-29cc9bf52d03
+export TARGET_ENVIRONMENT=AzureCloud
 
 # optional (used for the OIDC proxy)
 export OIDC_CLIENT_ID=


### PR DESCRIPTION
Add location setting in sample configuration files to support national clouds. The default value is empty, so public cloud is used. For national cloud, use the data center name of national cloud. For China the value is chinaeast or chinanorth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/732)
<!-- Reviewable:end -->
