### PR TITLE
More unit tests for Kubernetes upgrade failure scenarios

### DIFF
--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -1,6 +1,7 @@
 package kubernetesupgrade
 
 import (
+	"os"
 	"testing"
 
 	"github.com/Azure/acs-engine/pkg/api"
@@ -19,6 +20,11 @@ func TestUpgradeCluster(t *testing.T) {
 }
 
 var _ = Describe("Upgrade Kubernetes cluster tests", func() {
+	AfterEach(func() {
+		// delete temp template directory
+		os.RemoveAll("_output")
+	})
+
 	It("Should return error message when failing to list VMs during upgrade operation", func() {
 		cs := api.ContainerService{}
 		ucs := api.UpgradeContainerService{}
@@ -55,6 +61,90 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		err := uc.UpgradeCluster(subID, "TestRg", cs, &ucs, "12345678")
 
 		Expect(err.Error()).To(Equal("DeleteVirtualMachine failed"))
+	})
+
+	It("Should return error message when failing to deploy template during upgrade operation", func() {
+		cs := createContainerService("testcluster", 1, 1)
+
+		ucs := api.UpgradeContainerService{}
+		ucs.OrchestratorProfile = &api.OrchestratorProfile{}
+		ucs.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		ucs.OrchestratorProfile.OrchestratorVersion = api.Kubernetes162
+
+		uc := UpgradeCluster{}
+
+		mockClient := armhelpers.MockACSEngineClient{}
+		mockClient.FailDeployTemplate = true
+		uc.Client = &mockClient
+
+		subID, _ := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
+
+		err := uc.UpgradeCluster(subID, "TestRg", cs, &ucs, "12345678")
+
+		Expect(err.Error()).To(Equal("DeployTemplate failed"))
+	})
+
+	It("Should return error message when failing to get a virtual machine during upgrade operation", func() {
+		cs := createContainerService("testcluster", 1, 6)
+
+		ucs := api.UpgradeContainerService{}
+		ucs.OrchestratorProfile = &api.OrchestratorProfile{}
+		ucs.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		ucs.OrchestratorProfile.OrchestratorVersion = api.Kubernetes162
+
+		uc := UpgradeCluster{}
+
+		mockClient := armhelpers.MockACSEngineClient{}
+		mockClient.FailGetVirtualMachine = true
+		uc.Client = &mockClient
+
+		subID, _ := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
+
+		err := uc.UpgradeCluster(subID, "TestRg", cs, &ucs, "12345678")
+
+		Expect(err.Error()).To(Equal("GetVirtualMachine failed"))
+	})
+
+	It("Should return error message when failing to get storage client during upgrade operation", func() {
+		cs := createContainerService("testcluster", 5, 1)
+
+		ucs := api.UpgradeContainerService{}
+		ucs.OrchestratorProfile = &api.OrchestratorProfile{}
+		ucs.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		ucs.OrchestratorProfile.OrchestratorVersion = api.Kubernetes162
+
+		uc := UpgradeCluster{}
+
+		mockClient := armhelpers.MockACSEngineClient{}
+		mockClient.FailGetStorageClient = true
+		uc.Client = &mockClient
+
+		subID, _ := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
+
+		err := uc.UpgradeCluster(subID, "TestRg", cs, &ucs, "12345678")
+
+		Expect(err.Error()).To(Equal("GetStorageClient failed"))
+	})
+
+	It("Should return error message when failing to delete network interface during upgrade operation", func() {
+		cs := createContainerService("testcluster", 3, 2)
+
+		ucs := api.UpgradeContainerService{}
+		ucs.OrchestratorProfile = &api.OrchestratorProfile{}
+		ucs.OrchestratorProfile.OrchestratorType = api.Kubernetes
+		ucs.OrchestratorProfile.OrchestratorVersion = api.Kubernetes162
+
+		uc := UpgradeCluster{}
+
+		mockClient := armhelpers.MockACSEngineClient{}
+		mockClient.FailDeleteNetworkInterface = true
+		uc.Client = &mockClient
+
+		subID, _ := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
+
+		err := uc.UpgradeCluster(subID, "TestRg", cs, &ucs, "12345678")
+
+		Expect(err.Error()).To(Equal("DeleteNetworkInterface failed"))
 	})
 })
 

--- a/pkg/operations/kubernetesupgrade/v162upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/v162upgradeagentnode.go
@@ -29,7 +29,6 @@ type UpgradeAgentNode struct {
 // the node
 func (kan *UpgradeAgentNode) DeleteNode(vmName *string) error {
 	if err := operations.CleanDeleteVirtualMachine(kan.Client, log.NewEntry(log.New()), kan.ResourceGroup, *vmName); err != nil {
-		log.Fatalln(err)
 		return err
 	}
 
@@ -61,7 +60,6 @@ func (kan *UpgradeAgentNode) CreateNode(poolName string, agentNo int) error {
 		nil)
 
 	if err != nil {
-		log.Fatalln(err)
 		return err
 	}
 

--- a/pkg/operations/kubernetesupgrade/v162upgrademasternode.go
+++ b/pkg/operations/kubernetesupgrade/v162upgrademasternode.go
@@ -59,7 +59,6 @@ func (kmn *UpgradeMasterNode) CreateNode(poolName string, masterNo int) error {
 		nil)
 
 	if err != nil {
-		log.Fatalln(err)
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add unit tests for the following Kubernetes upgrade failure scenarios:
1) DeleteNetworkInterface
2) GetStorageClient
3) GetVirtualMachine
4) DeployTemplate

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/751)
<!-- Reviewable:end -->
