### PR TITLE
adding auth headers to vmss list operations

### DIFF
--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -243,6 +243,7 @@ func getClient(env azure.Environment, subscriptionID string, armSpt *adal.Servic
 	c.groupsClient.Authorizer = authorizer
 	c.providersClient.Authorizer = authorizer
 	c.virtualMachinesClient.Authorizer = authorizer
+	c.virtualMachineScaleSetsClient.Authorizer = authorizer
 
 	c.deploymentsClient.PollingDelay = time.Second * 5
 


### PR DESCRIPTION
Why we need this:
fixes a bug in my last PR. This gets an auth header so we can call the vmss operations. Will be needed for scale up and down work for vmss agent pools in the future

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/762)
<!-- Reviewable:end -->
