### PR TITLE
bump k8s to 1.6.6

### DIFF
--- a/examples/kubernetesversions/kubernetes1.6.6.json
+++ b/examples/kubernetesversions/kubernetes1.6.6.json
@@ -1,0 +1,36 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorVersion": "1.6.6"
+    },
+    "masterProfile": {
+      "count": 3,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "servicePrincipalClientID": "",
+      "servicePrincipalClientSecret": ""
+    }
+  }
+}

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -51,6 +51,18 @@ const (
 )
 
 var KubeImages = map[api.OrchestratorVersion]map[string]string{
+	api.Kubernetes166: {
+		"hyperkube":    "hyperkube-amd64:v1.6.6",
+		"dashboard":    "kubernetes-dashboard-amd64:v1.6.0",
+		"exechealthz":  "exechealthz-amd64:1.2",
+		"addonresizer": "addon-resizer:1.6",
+		"heapster":     "heapster:v1.2.0",
+		"dns":          "kubedns-amd64:1.7",
+		"addonmanager": "kube-addon-manager-amd64:v6.2",
+		"dnsmasq":      "kube-dnsmasq-amd64:1.3",
+		"pause":        "pause-amd64:3.0",
+		"windowszip":   "v1.6.6intwinnat.zip",
+	},
 	api.Kubernetes162: {
 		"hyperkube":    "hyperkube-amd64:v1.6.2",
 		"dashboard":    "kubernetes-dashboard-amd64:v1.6.0",

--- a/pkg/acsengine/engine_test.go
+++ b/pkg/acsengine/engine_test.go
@@ -199,11 +199,14 @@ func addTestCertificateProfile(api *api.CertificateProfile) {
 
 func TestVersionOrdinal(t *testing.T) {
 	RegisterTestingT(t)
+	v166 := api.OrchestratorVersion("1.6.6")
 	v162 := api.OrchestratorVersion("1.6.2")
 	v160 := api.OrchestratorVersion("1.6.0")
 	v153 := api.OrchestratorVersion("1.5.3")
 	v16 := api.OrchestratorVersion("1.6")
 
+	Expect(v166 > v162).To(BeTrue())
+	Expect(v162 < v166).To(BeTrue())
 	Expect(v162 > v160).To(BeTrue())
 	Expect(v160 < v162).To(BeTrue())
 	Expect(v153 < v160).To(BeTrue())

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -59,8 +59,10 @@ const (
 	Kubernetes160 OrchestratorVersion = "1.6.0"
 	// Kubernetes162 is the string constant for Kubernetes 1.6.2
 	Kubernetes162 OrchestratorVersion = "1.6.2"
+	// Kubernetes166 is the string constant for Kubernetes 1.6.6
+	Kubernetes166 OrchestratorVersion = "1.6.6"
 	// KubernetesLatest is the string constant for latest Kubernetes version
-	KubernetesLatest OrchestratorVersion = Kubernetes162
+	KubernetesLatest OrchestratorVersion = Kubernetes166
 )
 
 const (

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -385,7 +385,7 @@ func convertV20160330OrchestratorProfile(v20160330 *v20160330.OrchestratorProfil
 func convertV20170131OrchestratorProfile(v20170131 *v20170131.OrchestratorProfile, api *OrchestratorProfile) {
 	api.OrchestratorType = OrchestratorType(v20170131.OrchestratorType)
 	if api.OrchestratorType == Kubernetes {
-		api.OrchestratorVersion = Kubernetes162
+		api.OrchestratorVersion = KubernetesLatest
 	} else if api.OrchestratorType == DCOS {
 		api.OrchestratorVersion = DCOS190
 	}
@@ -400,6 +400,8 @@ func convertVLabsOrchestratorProfile(vlabscs *vlabs.OrchestratorProfile, api *Or
 		}
 
 		switch vlabscs.OrchestratorVersion {
+		case vlabs.Kubernetes166:
+			api.OrchestratorVersion = Kubernetes166
 		case vlabs.Kubernetes162:
 			api.OrchestratorVersion = Kubernetes162
 		case vlabs.Kubernetes160:

--- a/pkg/api/vlabs/const.go
+++ b/pkg/api/vlabs/const.go
@@ -90,6 +90,8 @@ const (
 	Kubernetes160 OrchestratorVersion = "1.6.0"
 	// Kubernetes162 is the string constant for Kubernetes 1.6.2
 	Kubernetes162 OrchestratorVersion = "1.6.2"
+	// Kubernetes166 is the string constant for Kubernetes 1.6.6
+	Kubernetes166 OrchestratorVersion = "1.6.6"
 	// KubernetesLatest is the string constant for latest Kubernetes version
-	KubernetesLatest OrchestratorVersion = Kubernetes162
+	KubernetesLatest OrchestratorVersion = Kubernetes166
 )

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -28,6 +28,7 @@ func (o *OrchestratorProfile) Validate() error {
 
 	case Kubernetes:
 		switch o.OrchestratorVersion {
+		case Kubernetes166:
 		case Kubernetes162:
 		case Kubernetes160:
 		case Kubernetes157:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Bump k8s version to latet 1.6.6

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Release k8s 1.6.6
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/796)
<!-- Reviewable:end -->
