### PR TITLE
Fix deployment command for azure-cli in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $ az group deployment create \
     --name "<DEPLOYMENT NAME>" \
     --resource-group "<RESOURCE_GROUP_NAME>" \
     --template-file "./_output/<INSTANCE>/azuredeploy.json" \
-    --parameters "@./_output/<INSTANCE>/azuredeploy.parameters.json"
+    --parameters "./_output/<INSTANCE>/azuredeploy.parameters.json"
 ```
 
 ### Deploying with Powershell


### PR DESCRIPTION
With `azure-cli` `2.0.7` and above, when doing `az group deployment create` the `--parameters` argument takes a path to a json file instead of the content of the file, so the `@` prefix should be removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/802)
<!-- Reviewable:end -->
