### PR TITLE
added a method to create armhelper using in-memory key pair

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -102,7 +102,7 @@ func (authArgs *authArgs) getClient() (*armhelpers.AzureClient, error) {
 	case "client_secret":
 		return armhelpers.NewAzureClientWithClientSecret(env, authArgs.SubscriptionID.String(), authArgs.ClientID.String(), authArgs.ClientSecret)
 	case "client_certificate":
-		return armhelpers.NewAzureClientWithClientCertificate(env, authArgs.SubscriptionID.String(), authArgs.ClientID.String(), authArgs.CertificatePath, authArgs.PrivateKeyPath)
+		return armhelpers.NewAzureClientWithClientCertificateFile(env, authArgs.SubscriptionID.String(), authArgs.ClientID.String(), authArgs.CertificatePath, authArgs.PrivateKeyPath)
 	default:
 		log.Fatalf("--auth-method: ERROR: method unsupported. method=%q.", authArgs.AuthMethod)
 	}

--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -140,11 +140,6 @@ func NewAzureClientWithClientSecret(env azure.Environment, subscriptionID, clien
 
 // NewAzureClientWithClientCertificateFile returns an AzureClient via client_id and jwt certificate assertion
 func NewAzureClientWithClientCertificateFile(env azure.Environment, subscriptionID, clientID, certificatePath, privateKeyPath string) (*AzureClient, error) {
-	oauthConfig, _, err := getOAuthConfig(env, subscriptionID)
-	if err != nil {
-		return nil, err
-	}
-
 	certificateData, err := ioutil.ReadFile(certificatePath)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read certificate: %q", err)
@@ -165,16 +160,7 @@ func NewAzureClientWithClientCertificateFile(env azure.Environment, subscription
 		return nil, fmt.Errorf("Failed to parse rsa private key: %q", err)
 	}
 
-	armSpt, err := adal.NewServicePrincipalTokenFromCertificate(*oauthConfig, clientID, certificate, privateKey, env.ServiceManagementEndpoint)
-	if err != nil {
-		return nil, err
-	}
-	adSpt, err := adal.NewServicePrincipalTokenFromCertificate(*oauthConfig, clientID, certificate, privateKey, env.GraphEndpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	return getClient(env, subscriptionID, armSpt, adSpt)
+	return NewAzureClientWithClientCertificate(env, subscriptionID, clientID, certificate, privateKey)
 }
 
 // NewAzureClientWithClientCertificate returns an AzureClient via client_id and jwt certificate assertion


### PR DESCRIPTION
this is to streamline the armhelper usage in the new RP

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This is to streamline to armhelper usage from the RP

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
It's just a refactor

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/804)
<!-- Reviewable:end -->
