### PR TITLE
Removing "storageProfile": "StorageAccount" for managed disk

### DIFF
--- a/examples/windows/kubernetes-manageddisks.json
+++ b/examples/windows/kubernetes-manageddisks.json
@@ -17,7 +17,6 @@
         "vmSize": "Standard_D2_v2",
         "storageProfile" : "ManagedDisks",
         "availabilityProfile": "AvailabilitySet",
-        "storageProfile": "StorageAccount",
         "OSDiskSizeGB": 200,
         "diskSizesGB": [128, 128, 128, 128],
         "osType": "Windows"


### PR DESCRIPTION
Having two "storageProfile": tag in JSON  is going to simply overwrite previous value and we dont need it "storageProfile": "StorageAccount", for managed disks.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/824)
<!-- Reviewable:end -->
