### PR TITLE
Fix Azure CLI in docker by installing with the bundled installer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
-acs-engine
-acs-engine.exe
-_output/
-.git/
+./acs-engine
+./acs-engine.exe
+./_output
+./.git
+./test/acs-engine-test/acs-engine-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,28 @@
 FROM buildpack-deps:xenial
 
-ENV GO_VERSION 1.8
-ENV KUBECTL_VERSION 1.6.0
-
-# See: https://github.com/Azure/azure-cli/blob/master/packaged_releases/bundled/README.md#using-the-bundled-installer
-ENV AZURE_CLI_BUNDLE_VERSION 0.2.9
-
 RUN apt-get update \
     && apt-get -y upgrade \
     && apt-get -y install python-pip make build-essential curl openssl vim jq \
     && rm -rf /var/lib/apt/lists/*
 
+ENV GO_VERSION 1.8
 RUN mkdir /tmp/godeb \
     && curl "https://godeb.s3.amazonaws.com/godeb-amd64.tar.gz" > /tmp/godeb/godeb.tar.gz \
     && (cd /tmp/godeb; tar zvxf godeb.tar.gz; ./godeb install "${GO_VERSION}") \
     && rm -rf /tmp/godeb
 
+# See: https://github.com/Azure/azure-cli/blob/master/packaged_releases/bundled/README.md#using-the-bundled-installer
+ENV AZURE_CLI_BUNDLE_VERSION 0.2.9
 RUN mkdir /tmp/azurecli \
     && curl "https://azurecliprod.blob.core.windows.net/bundled/azure-cli_bundle_${AZURE_CLI_BUNDLE_VERSION}.tar.gz" > /tmp/azurecli/azure-cli_bundle.tar.gz \
-    && (cd /tmp/azurecli && tar -xvzf azure-cli_bundle.tar.gz && azure-cli_bundle_*/installer) \
+    && (cd /tmp/azurecli \
+      && tar -xvzf azure-cli_bundle.tar.gz \
+      && azure-cli_bundle_*/installer --bin-dir /usr/local/bin) \
     && rm -rf /tmp/azurecli
 
 RUN curl -fsSL https://get.docker.com/ | sh
 
+ENV KUBECTL_VERSION 1.6.0
 RUN curl "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" > /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM buildpack-deps:xenial
 
 ENV GO_VERSION 1.8
 ENV KUBECTL_VERSION 1.6.0
-ENV AZURE_CLI_VERSION 2.0.7
+
+# See: https://github.com/Azure/azure-cli/blob/master/packaged_releases/bundled/README.md#using-the-bundled-installer
+ENV AZURE_CLI_BUNDLE_VERSION 0.2.9
 
 RUN apt-get update \
     && apt-get -y upgrade \
@@ -14,7 +16,10 @@ RUN mkdir /tmp/godeb \
     && (cd /tmp/godeb; tar zvxf godeb.tar.gz; ./godeb install "${GO_VERSION}") \
     && rm -rf /tmp/godeb
 
-RUN pip install "azure-cli==${AZURE_CLI_VERSION}"
+RUN mkdir /tmp/azurecli \
+    && curl "https://azurecliprod.blob.core.windows.net/bundled/azure-cli_bundle_${AZURE_CLI_BUNDLE_VERSION}.tar.gz" > /tmp/azurecli/azure-cli_bundle.tar.gz \
+    && (cd /tmp/azurecli && tar -xvzf azure-cli_bundle.tar.gz && azure-cli_bundle_*/installer) \
+    && rm -rf /tmp/azurecli
 
 RUN curl -fsSL https://get.docker.com/ | sh
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This fixes the recent breakage of `az` under the acs-engine devenv docker container. This uses the reproducible bundled installer rather than relying on pip and transitive unpinned dependencies.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: n/a  

**Special notes for your reviewer**: none 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
* more correctly pin version of azure-cli in devenv docker container
```

Note, this installs the `0.2.9` bundle because the `0.2.10` bundle doesn't install correctly (this is [bug #3800 on azure-cli](https://github.com/Azure/azure-cli/issues/3800))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/826)
<!-- Reviewable:end -->
