### PR TITLE
Removing the requirement for same vNet in Kubernetes

### DIFF
--- a/examples/vnet/README.md
+++ b/examples/vnet/README.md
@@ -4,8 +4,6 @@
 
 These examples show you how to build a customized Docker enabled cluster on Microsoft Azure where you can provide your own VNET.
 
-**Note**: Kubernetes must have the custom VNET deployed in the same resource group as Kubernetes.
-
 To try: 
 
 1. first deploy a custom vnet.  An example of an arm template that does this is under directory vnetarmtemplate.


### PR DESCRIPTION
As per https://github.com/Azure/acs-engine/issues/272 - this is no longer necessary.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/850)
<!-- Reviewable:end -->
