### PR TITLE
ensure only one public pool

### DIFF
--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -834,6 +834,7 @@ func addDCOSPublicAgentPool(api *Properties) {
 	api.AgentPoolProfiles[0].DNSPrefix = ""
 	publicPool.VMSize = api.AgentPoolProfiles[0].VMSize // - use same VMsize for public pool
 	publicPool.OSType = api.AgentPoolProfiles[0].OSType // - use same OSType for public pool
+	api.AgentPoolProfiles[0].Ports = nil
 	for _, port := range [3]int{80, 443, 8080} {
 		publicPool.Ports = append(publicPool.Ports, port)
 	}


### PR DESCRIPTION
When we add a public agent pool for DCOS API versions, we want to ensure that the “private” agent pool doesn’t expose ports.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

During public pool addition for DCOS, we are adding `Ports` to the public agent pool; but we need to explicitly remove any other `Ports` added to the "private" agent pool that may have occurred as a part of another conversion task.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Please double-check that `addDCOSPublicAgentPool` is the correct place to enforce this logic.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
`rationalize public pool ports for DCOS clusters`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/851)
<!-- Reviewable:end -->
