### PR TITLE
No more underscores in agent pool name string

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -81,4 +81,4 @@ const (
 )
 
 // To identify programmatically generated public agent pools
-const publicAgentPoolSuffix = "_public"
+const publicAgentPoolSuffix = "-public"

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -174,7 +174,7 @@ func convertPropertiesToV20160930(api *Properties, p *v20160930.Properties) {
 	if api.OrchestratorProfile.IsDCOS() && len(api.AgentPoolProfiles) == 2 {
 		var privIndex, pubIndex int
 		for i, apiProfile := range api.AgentPoolProfiles {
-			// We added a pool with a "_public" suffix when converting to API model;
+			// We added a pool with a "-public" suffix when converting to API model;
 			// we don't want to include that when converting back to a version-specific model
 			matched, err := regexp.MatchString(publicAgentPoolSuffix+"$", apiProfile.Name)
 			if !matched && err == nil {
@@ -236,7 +236,7 @@ func convertPropertiesToV20160330(api *Properties, p *v20160330.Properties) {
 	if api.OrchestratorProfile.IsDCOS() && len(api.AgentPoolProfiles) == 2 {
 		var privIndex, pubIndex int
 		for i, apiProfile := range api.AgentPoolProfiles {
-			// We added a pool with a "_public" suffix when converting to API model;
+			// We added a pool with a "-public" suffix when converting to API model;
 			// we don't want to include that when converting back to a version-specific model
 			matched, err := regexp.MatchString(publicAgentPoolSuffix+"$", apiProfile.Name)
 			if !matched && err == nil {
@@ -290,7 +290,7 @@ func convertPropertiesToV20170131(api *Properties, p *v20170131.Properties) {
 	if api.OrchestratorProfile.IsDCOS() && len(api.AgentPoolProfiles) == 2 {
 		var privIndex, pubIndex int
 		for i, apiProfile := range api.AgentPoolProfiles {
-			// We added a pool with a "_public" suffix when converting to API model;
+			// We added a pool with a "-public" suffix when converting to API model;
 			// we don't want to include that when converting back to a version-specific model
 			matched, err := regexp.MatchString(publicAgentPoolSuffix+"$", apiProfile.Name)
 			if !matched && err == nil {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Inserting a “_” into the pool name string eventually becomes part of the concatenated output that becomes a vm name. A vm name string is not allowed to have an underscore character in it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

DCOS tests using a `_public` suffix for its public agent pool were yielding the following error:

```
{ "error": { "code": "InvalidParameter", "target": "computerNamePrefix", "message": "Linux host name prefix cannot exceed 58 characters in length or contain the following characters: ` ~ ! @ # $ % ^ & * ( ) = + _ [ ] { } \\ | ; : ' \" , < > / ?." } }
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
`removing underscores from agent pool metadata`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/852)
<!-- Reviewable:end -->
