### PR TITLE
Delay wrapping of parameters

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -144,11 +144,12 @@ func (dc *deployCmd) run() error {
 	if template, err = acsengine.PrettyPrintArmTemplate(template); err != nil {
 		log.Fatalf("error pretty printing template: %s \n", err.Error())
 	}
-	if parameters, err = acsengine.PrettyPrintJSON(parameters); err != nil {
+	var parametersFile string
+	if parametersFile, err = acsengine.BuildAzureParametersFile(parameters); err != nil {
 		log.Fatalf("error pretty printing template parameters: %s \n", err.Error())
 	}
 
-	if err = acsengine.WriteArtifacts(dc.containerService, dc.apiVersion, template, parameters, dc.outputDirectory, certsgenerated, dc.parametersOnly); err != nil {
+	if err = acsengine.WriteArtifacts(dc.containerService, dc.apiVersion, template, parametersFile, dc.outputDirectory, certsgenerated, dc.parametersOnly); err != nil {
 		log.Fatalf("error writing artifacts: %s \n", err.Error())
 	}
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -128,7 +128,7 @@ func (gc *generateCmd) run() error {
 		if template, err = acsengine.PrettyPrintArmTemplate(template); err != nil {
 			log.Fatalf("error pretty printing template: %s \n", err.Error())
 		}
-		if parameters, err = acsengine.PrettyPrintJSON(parameters); err != nil {
+		if parameters, err = acsengine.BuildAzureParametersFile(parameters); err != nil {
 			log.Fatalf("error pretty printing template parameters: %s \n", err.Error())
 		}
 	}

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -348,7 +348,6 @@ func GetCloudTargetEnv(location string) string {
 func getParameters(cs *api.ContainerService, isClassicMode bool) (map[string]interface{}, error) {
 	properties := cs.Properties
 	location := cs.Location
-	parametersAll := map[string]interface{}{}
 	parametersMap := map[string]interface{}{}
 
 	// Master Parameters
@@ -454,12 +453,7 @@ func getParameters(cs *api.ContainerService, isClassicMode bool) (map[string]int
 		}
 	}
 
-	// add the header
-	parametersAll["$schema"] = "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#"
-	parametersAll["contentVersion"] = "1.0.0.0"
-	parametersAll["parameters"] = parametersMap
-
-	return parametersAll, nil
+	return parametersMap, nil
 }
 
 func addValue(m map[string]interface{}, k string, v interface{}) {

--- a/pkg/acsengine/json.go
+++ b/pkg/acsengine/json.go
@@ -41,6 +41,24 @@ func PrettyPrintJSON(content string) (string, error) {
 	return string(prettyprint), nil
 }
 
+// BuildAzureParametersFile will add the correct schema and contentversion information
+func BuildAzureParametersFile(content string) (string, error) {
+	var parametersMap map[string]interface{}
+	if err := json.Unmarshal([]byte(content), &parametersMap); err != nil {
+		return "", err
+	}
+	parametersAll := map[string]interface{}{}
+	parametersAll["$schema"] = "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#"
+	parametersAll["contentVersion"] = "1.0.0.0"
+	parametersAll["parameters"] = parametersMap
+
+	prettyprint, err := json.MarshalIndent(parametersAll, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(prettyprint), nil
+}
+
 func translateJSON(content string, translateParams [][]string, reverseTranslate bool) string {
 	for _, tuple := range translateParams {
 		if len(tuple) != 2 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: The parameters were wrapped too early with the schema and content version causing problems for the deploy and upgrade command.  This delays the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/861)
<!-- Reviewable:end -->
