### PR TITLE
apiloader sets default orchestrator to DCOS if nil

### DIFF
--- a/pkg/acsengine/testdata/v20160330/defaults.json
+++ b/pkg/acsengine/testdata/v20160330/defaults.json
@@ -1,0 +1,28 @@
+{
+  "apiVersion": "2016-03-30",
+  "properties": {
+    "masterProfile": {
+      "count": 3,
+      "dnsPrefix": "masterdns1"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentprivate",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "dnsPrefix": "test-dcos-pool",
+        "osType": "Linux"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": "ssh-rsa PUBLICKEY azureuser@linuxvm"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/pkg/acsengine/testdata/v20160930/defaults.json
+++ b/pkg/acsengine/testdata/v20160930/defaults.json
@@ -1,0 +1,28 @@
+{
+  "apiVersion": "2016-09-30",
+  "properties": {
+    "masterProfile": {
+      "count": 3,
+      "dnsPrefix": "masterdns1"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentprivate",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "dnsPrefix": "test-dcos-pool",
+        "osType": "Linux"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": "ssh-rsa PUBLICKEY azureuser@linuxvm"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/pkg/acsengine/testdata/v20170131/defaults.json
+++ b/pkg/acsengine/testdata/v20170131/defaults.json
@@ -1,0 +1,28 @@
+{
+  "apiVersion": "2017-01-31",
+  "properties": {
+    "masterProfile": {
+      "count": 3,
+      "dnsPrefix": "masterdns1"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentprivate",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "dnsPrefix": "test-dcos-pool",
+        "osType": "Linux"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": "ssh-rsa PUBLICKEY azureuser@linuxvm"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/pkg/api/apiloader.go
+++ b/pkg/api/apiloader.go
@@ -41,6 +41,7 @@ func LoadContainerService(contents []byte, version string) (*ContainerService, e
 		if e := json.Unmarshal(contents, &containerService); e != nil {
 			return nil, e
 		}
+		setContainerServiceDefaultsv20160930(containerService)
 		if e := containerService.Properties.Validate(); e != nil {
 			return nil, e
 		}
@@ -51,6 +52,7 @@ func LoadContainerService(contents []byte, version string) (*ContainerService, e
 		if e := json.Unmarshal(contents, &containerService); e != nil {
 			return nil, e
 		}
+		setContainerServiceDefaultsv20160330(containerService)
 		if e := containerService.Properties.Validate(); e != nil {
 			return nil, e
 		}
@@ -61,6 +63,7 @@ func LoadContainerService(contents []byte, version string) (*ContainerService, e
 		if e := json.Unmarshal(contents, &containerService); e != nil {
 			return nil, e
 		}
+		setContainerServiceDefaultsv20170131(containerService)
 		if e := containerService.Properties.Validate(); e != nil {
 			return nil, e
 		}
@@ -151,5 +154,32 @@ func SerializeContainerService(containerService *ContainerService, version strin
 
 	default:
 		return nil, fmt.Errorf("invalid version %s for conversion back from unversioned object", version)
+	}
+}
+
+// Sets default container service property values for any appropriate zero values
+func setContainerServiceDefaultsv20160930(c *v20160930.ContainerService) {
+	if c.Properties.OrchestratorProfile == nil {
+		c.Properties.OrchestratorProfile = &v20160930.OrchestratorProfile{
+			OrchestratorType: v20160930.DCOS,
+		}
+	}
+}
+
+// Sets default container service property values for any appropriate zero values
+func setContainerServiceDefaultsv20160330(c *v20160330.ContainerService) {
+	if c.Properties.OrchestratorProfile == nil {
+		c.Properties.OrchestratorProfile = &v20160330.OrchestratorProfile{
+			OrchestratorType: v20160330.DCOS,
+		}
+	}
+}
+
+// Sets default container service property values for any appropriate zero values
+func setContainerServiceDefaultsv20170131(c *v20170131.ContainerService) {
+	if c.Properties.OrchestratorProfile == nil {
+		c.Properties.OrchestratorProfile = &v20170131.OrchestratorProfile{
+			OrchestratorType: v20170131.DCOS,
+		}
 	}
 }

--- a/test/acs-engine-test/acs-engine-test.json
+++ b/test/acs-engine-test/acs-engine-test.json
@@ -15,6 +15,10 @@
     {
       "cluster_definition": "swarmmode.json",
       "location": "westus2"
+    },
+    {
+      "cluster_definition": "defaults.json",
+      "location": "westus2"
     }
   ]
 }

--- a/test/acs-engine-test/acs-engine-test.json
+++ b/test/acs-engine-test/acs-engine-test.json
@@ -15,10 +15,6 @@
     {
       "cluster_definition": "swarmmode.json",
       "location": "westus2"
-    },
-    {
-      "cluster_definition": "defaults.json",
-      "location": "westus2"
     }
   ]
 }


### PR DESCRIPTION
This affects API versions v20160330, v20160930, and v20170131.

Also evolved the current tests in a minor way so we have a notion of a “default” spec. Currently the provided `defaults.json` specs in the version-specific `testdata` dirs have an empty (nil) orchestratorProfile. The invocations of api.setContainerServiceDefaultsv<api version>() in apiloader.go enable those default configurations to be processed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Processes a deployment config that doesn't include an `"orchestratorProfile"` property, and creates a default one automatically that looks like this:

```"orchestratorProfile": {
    "orchestratorType": "DCOS"
}```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Related to #857 and PR #856 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```apiloader sets default orchestrator to DCOS for API versions v20160330, v20160930, and v20170131
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/862)
<!-- Reviewable:end -->
