### PR TITLE
add support for kubernetes on Azure Stack

### DIFF
--- a/parts/kubernetesmastercustomscript.sh
+++ b/parts/kubernetesmastercustomscript.sh
@@ -277,6 +277,10 @@ function writeKubeConfig() {
     then
         FQDNSuffix="cloudapp.chinacloudapi.cn"
     fi
+    if [ "$TARGET_ENVIRONMENT" = "AzureStack" ]
+    then
+        FQDNSuffix="cloudapp.azurestack.external"
+    fi
     # disable logging after secret output
     set +x
     echo "

--- a/pkg/acsengine/Get-AzureConstants.py
+++ b/pkg/acsengine/Get-AzureConstants.py
@@ -69,6 +69,8 @@ def getLocations():
     # Adding two Canary locations
     locationList.append('centraluseuap')
     locationList.append('eastus2euap')
+    #add azure stack location
+    locationList.append('local')
 
     locationList = sorted(locationList)
     return locationList    

--- a/pkg/acsengine/azureconst.go
+++ b/pkg/acsengine/azureconst.go
@@ -9,6 +9,8 @@ const (
 	AzurePublicProdFQDNFormat = "%s.%s.cloudapp.azure.com"
 	//AzureChinaProdFQDNFormat specify the endpoint of Azure China Cloud
 	AzureChinaProdFQDNFormat = "%s.%s.cloudapp.chinacloudapi.cn"
+	//AzureStackProdFQDNFormat specify the endpoint of Azure Stack
+	AzureStackProdFQDNFormat = "%s.%s.cloudapp.azurestack.external"
 )
 
 // AzureLocations provides all azure regions in prod.
@@ -45,6 +47,7 @@ var AzureLocations = []string{
 	"westindia",
 	"westus",
 	"westus2",
+	"local",
 }
 
 // FormatAzureProdFQDNs constructs all possible Azure prod fqdn
@@ -61,6 +64,9 @@ func FormatAzureProdFQDN(fqdnPrefix string, location string) string {
 	FQDNFormat := AzurePublicProdFQDNFormat
 	if location == "chinaeast" || location == "chinanorth" {
 		FQDNFormat = AzureChinaProdFQDNFormat
+	}
+	if location == "local" {
+		FQDNFormat = AzureStackProdFQDNFormat
 	}
 	return fmt.Sprintf(FQDNFormat, fqdnPrefix, location)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
add support for Azure Stack

**Special notes for your reviewer**:
The deployment scripts are working now, there is one blocking issue here, it says "certificate signed by unknown authority" in the log, I am not sure whether there are work items for adding certs for azure stack in acs-engine, 
ResourceManagerEndpoint:      "https://management.local.azurestack.external/" 

Below are the error logs
E0627 01:46:01.053706    1810 kubelet.go:1318] Kubelet failed to get node info: failed to get external ID from cloud provider: compute.VirtualMachinesClient#Get: Failure sending request: StatusCode=0 -- Original Error: Get https://management.local.azurestack.external/subscriptions/a3368291-e427-41b0-b790-66b7be21017b/resourceGroups/andyazurestack3/providers/Microsoft.Compute/virtualMachines/k8s-master-13534591-0?api-version=2016-03-30: x509: certificate signed by unknown authority

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/876)
<!-- Reviewable:end -->
