### PR TITLE
Allocate static IP addresses from the last /24 of cluster subnet

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -261,16 +261,17 @@ func getFirstConsecutiveStaticIPAddress(subnetStr string) string {
 		return DefaultFirstConsecutiveKubernetesStaticIP
 	}
 
-	// Round up the prefix length to the nearest octet boundary.
+	// Find the first and last octet of the host bits.
 	ones, bits := subnet.Mask.Size()
-	if ones%8 != 0 {
-		ones += 8 - ones%8
-	}
+	firstOctet := ones / 8
+	lastOctet := bits/8 - 1
+
+	// Set the remaining host bits in the first octet.
+	subnet.IP[firstOctet] |= (1 << byte((8 - (ones % 8)))) - 1
 
 	// Fill the intermediate octets with 1s and last octet with offset. This is done so to match
 	// the existing behavior of allocating static IP addresses from the last /24 of the subnet.
-	lastOctet := bits/8 - 1
-	for i := ones / 8; i < lastOctet; i++ {
+	for i := firstOctet + 1; i < lastOctet; i++ {
 		subnet.IP[i] = 255
 	}
 	subnet.IP[lastOctet] = DefaultKubernetesFirstConsecutiveStaticIPOffset

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -318,9 +318,14 @@ func (a *Properties) Validate() error {
 // Validate validates the KubernetesConfig.
 func (a *KubernetesConfig) Validate() error {
 	if a.ClusterSubnet != "" {
-		_, _, err := net.ParseCIDR(a.ClusterSubnet)
+		_, subnet, err := net.ParseCIDR(a.ClusterSubnet)
 		if err != nil {
 			return fmt.Errorf("OrchestratorProfile.KubernetesConfig.ClusterSubnet '%s' is an invalid subnet", a.ClusterSubnet)
+		}
+
+		ones, bits := subnet.Mask.Size()
+		if bits-ones <= 8 {
+			return fmt.Errorf("OrchestratorProfile.KubernetesConfig.ClusterSubnet '%s' must reserve at least 9 bits for nodes", a.ClusterSubnet)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When VNET integration is enabled (pods are assigned private IP addresses from VNET address space), static (for masters) and dynamic (for agents and pods) addresses are being allocated from the same subnet. This results in race conditions where a dynamic address allocation can execute before a static address allocation for the same IP address. In that case, the static allocation will fail and result in deployment failures.

This PR fixes 
* When the cluster subnet prefix is /17 or longer, getFirstConsecutiveStaticIPAddress returns IP addresses from the same /24 as the pods. Update that function to return from the very last /24 subnet, clearly separating static addresses from dynamic addresses.
* Update validation code to fail if the cluster subnet is too small (less than 9 bits for host IDs). The last 8 bits are used for dynamic addresses for all nodes and pods. The 9th bit is set for static addresses.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
fixes #882

**Special notes for your reviewer**:

**Release note**:
NONE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/883)
<!-- Reviewable:end -->
