### PR TITLE
update azure-cli bundle version to 0.2.10-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir /tmp/godeb \
     && rm -rf /tmp/godeb
 
 # See: https://github.com/Azure/azure-cli/blob/master/packaged_releases/bundled/README.md#using-the-bundled-installer
-ENV AZURE_CLI_BUNDLE_VERSION 0.2.9
+ENV AZURE_CLI_BUNDLE_VERSION 0.2.10-1
 RUN mkdir /tmp/azurecli \
     && curl "https://azurecliprod.blob.core.windows.net/bundled/azure-cli_bundle_${AZURE_CLI_BUNDLE_VERSION}.tar.gz" > /tmp/azurecli/azure-cli_bundle.tar.gz \
     && (cd /tmp/azurecli \


### PR DESCRIPTION
update azure-cli bundle version to 0.2.10-1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/907)
<!-- Reviewable:end -->
