### PR TITLE
Fix syntax of passing files to --parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $ az group deployment create \
     --name "<DEPLOYMENT NAME>" \
     --resource-group "<RESOURCE_GROUP_NAME>" \
     --template-file "./_output/<INSTANCE>/azuredeploy.json" \
-    --parameters "./_output/<INSTANCE>/azuredeploy.parameters.json"
+    --parameters @"./_output/<INSTANCE>/azuredeploy.parameters.json"
 ```
 
 ### Deploying with Powershell


### PR DESCRIPTION
Without this it'll give you a very non-descriptive `invalid syntax: ./_output/datahubfa17/azuredeploy.parameters.json`
error!

**What this PR does / why we need it**:

I spent quite a bit of time trying to understand this mysterious error message :( I'd have liked to not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/931)
<!-- Reviewable:end -->
