### PR TITLE
populate default value in unmarshal

### DIFF
--- a/pkg/api/v20160330/types.go
+++ b/pkg/api/v20160330/types.go
@@ -1,6 +1,7 @@
 package v20160330
 
 import (
+	"encoding/json"
 	"fmt"
 	neturl "net/url"
 	"strings"
@@ -102,6 +103,23 @@ type MasterProfile struct {
 	subnet string
 }
 
+// UnmarshalJSON unmarshal json using the default behavior
+// And do fields manipulation, such as populating default value
+func (m *MasterProfile) UnmarshalJSON(b []byte) error {
+	// Need to have a alias type to avoid circular unmarshal
+	type aliasMasterProfile MasterProfile
+	mm := aliasMasterProfile{}
+	if e := json.Unmarshal(b, &mm); e != nil {
+		return e
+	}
+	*m = MasterProfile(mm)
+	if m.Count == 0 {
+		// if MasterProfile.Count is missing or 0, set to default 1
+		m.Count = 1
+	}
+	return nil
+}
+
 // AgentPoolProfile represents configuration of VMs running agent
 // daemons that register with the master and offer resources to
 // host applications in containers.
@@ -114,6 +132,31 @@ type AgentPoolProfile struct {
 	OSType    OSType `json:"osType"` // TODO: This field is versioned to "2016-03-30"
 	// subnet is internal
 	subnet string
+}
+
+// UnmarshalJSON unmarshal json using the default behavior
+// And do fields manipulation, such as populating default value
+func (a *AgentPoolProfile) UnmarshalJSON(b []byte) error {
+	// Need to have a alias type to avoid circular unmarshal
+	type aliasAgentPoolProfile AgentPoolProfile
+	aa := aliasAgentPoolProfile{}
+	if e := json.Unmarshal(b, &aa); e != nil {
+		return e
+	}
+	*a = AgentPoolProfile(aa)
+	if a.Count == 0 {
+		// if AgentPoolProfile.Count is missing or 0, set it to default 1
+		a.Count = 1
+	}
+
+	if string(a.OSType) == "" {
+		// OSType is the operating system type for agents
+		// Set as nullable to support backward compat because
+		// this property was added later.
+		// If the value is null or not set, it defaulted to Linux.
+		a.OSType = Linux
+	}
+	return nil
 }
 
 // JumpboxProfile dscribes properties of the jumpbox setup

--- a/pkg/api/v20160930/types.go
+++ b/pkg/api/v20160930/types.go
@@ -1,6 +1,7 @@
 package v20160930
 
 import (
+	"encoding/json"
 	"fmt"
 	neturl "net/url"
 	"strings"
@@ -109,6 +110,23 @@ type MasterProfile struct {
 	subnet string
 }
 
+// UnmarshalJSON unmarshal json using the default behavior
+// And do fields manipulation, such as populating default value
+func (m *MasterProfile) UnmarshalJSON(b []byte) error {
+	// Need to have a alias type to avoid circular unmarshal
+	type aliasMasterProfile MasterProfile
+	mm := aliasMasterProfile{}
+	if e := json.Unmarshal(b, &mm); e != nil {
+		return e
+	}
+	*m = MasterProfile(mm)
+	if m.Count == 0 {
+		// if MasterProfile.Count is missing or 0, set to default 1
+		m.Count = 1
+	}
+	return nil
+}
+
 // AgentPoolProfile represents configuration of VMs running agent
 // daemons that register with the master and offer resources to
 // host applications in containers.
@@ -127,6 +145,31 @@ type AgentPoolProfile struct {
 
 	// subnet is internal
 	subnet string
+}
+
+// UnmarshalJSON unmarshal json using the default behavior
+// And do fields manipulation, such as populating default value
+func (a *AgentPoolProfile) UnmarshalJSON(b []byte) error {
+	// Need to have a alias type to avoid circular unmarshal
+	type aliasAgentPoolProfile AgentPoolProfile
+	aa := aliasAgentPoolProfile{}
+	if e := json.Unmarshal(b, &aa); e != nil {
+		return e
+	}
+	*a = AgentPoolProfile(aa)
+	if a.Count == 0 {
+		// if AgentPoolProfile.Count is missing or 0, set it to default 1
+		a.Count = 1
+	}
+
+	if string(a.OSType) == "" {
+		// OSType is the operating system type for agents
+		// Set as nullable to support backward compat because
+		// this property was added later.
+		// If the value is null or not set, it defaulted to Linux.
+		a.OSType = Linux
+	}
+	return nil
 }
 
 // JumpboxProfile dscribes properties of the jumpbox setup

--- a/pkg/api/v20160930/types_test.go
+++ b/pkg/api/v20160930/types_test.go
@@ -1,6 +1,7 @@
 package v20160930
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -16,5 +17,34 @@ func TestIsDCOS(t *testing.T) {
 	}
 	if kubernetesProfile.IsDCOS() {
 		t.Fatalf("unexpectedly detected DCOS orchestrator profile from OrchestratorType=%s", kubernetesProfile.OrchestratorType)
+	}
+}
+
+func TestMasterProfile(t *testing.T) {
+	MasterProfileText := "{\"count\" : 0}"
+	mp := &MasterProfile{}
+	if e := json.Unmarshal([]byte(MasterProfileText), mp); e != nil {
+		t.Fatalf("unexpectedly detected unmarshal failure for MasterProfile, %+v", e)
+	}
+
+	if mp.Count != 1 {
+		t.Fatalf("unexpectedly detected MasterProfile.Count != 1 after unmarshal")
+	}
+}
+
+func TestAgentPoolProfile(t *testing.T) {
+	// With osType not specified
+	AgentPoolProfileText := "{\"count\" : 0}"
+	ap := &AgentPoolProfile{}
+	if e := json.Unmarshal([]byte(AgentPoolProfileText), ap); e != nil {
+		t.Fatalf("unexpectedly detected unmarshal failure for AgentPoolProfile, %+v", e)
+	}
+
+	if ap.Count != 1 {
+		t.Fatalf("unexpectedly detected AgentPoolProfile.Count != 1 after unmarshal")
+	}
+
+	if ap.OSType != Linux {
+		t.Fatalf("unexpectedly detected AgentPoolProfile.OSType != Linux after unmarshal")
 	}
 }

--- a/pkg/api/v20170131/types.go
+++ b/pkg/api/v20170131/types.go
@@ -121,7 +121,7 @@ func (m *MasterProfile) UnmarshalJSON(b []byte) error {
 	}
 	*m = MasterProfile(mm)
 	if m.Count == 0 {
-		// When MasterProfile.Count is missing or 0, set to default 1
+		// if MasterProfile.Count is missing or 0, set to default 1
 		m.Count = 1
 	}
 	return nil
@@ -145,6 +145,31 @@ type AgentPoolProfile struct {
 
 	// subnet is internal
 	subnet string
+}
+
+// UnmarshalJSON unmarshal json using the default behavior
+// And do fields manipulation, such as populating default value
+func (a *AgentPoolProfile) UnmarshalJSON(b []byte) error {
+	// Need to have a alias type to avoid circular unmarshal
+	type aliasAgentPoolProfile AgentPoolProfile
+	aa := aliasAgentPoolProfile{}
+	if e := json.Unmarshal(b, &aa); e != nil {
+		return e
+	}
+	*a = AgentPoolProfile(aa)
+	if a.Count == 0 {
+		// if AgentPoolProfile.Count is missing or 0, set it to default 1
+		a.Count = 1
+	}
+
+	if string(a.OSType) == "" {
+		// OSType is the operating system type for agents
+		// Set as nullable to support backward compat because
+		// this property was added later.
+		// If the value is null or not set, it defaulted to Linux.
+		a.OSType = Linux
+	}
+	return nil
 }
 
 // JumpboxProfile dscribes properties of the jumpbox setup

--- a/pkg/api/v20170131/types.go
+++ b/pkg/api/v20170131/types.go
@@ -1,6 +1,7 @@
 package v20170131
 
 import (
+	"encoding/json"
 	"fmt"
 	neturl "net/url"
 	"strings"
@@ -107,6 +108,23 @@ type MasterProfile struct {
 
 	// subnet is internal
 	subnet string
+}
+
+// UnmarshalJSON unmarshal json using the default behavior
+// And do fields manipulation, such as populating default value
+func (m *MasterProfile) UnmarshalJSON(b []byte) error {
+	// Need to have a alias type to avoid circular unmarshal
+	type aliasMasterProfile MasterProfile
+	mm := aliasMasterProfile{}
+	if e := json.Unmarshal(b, &mm); e != nil {
+		return e
+	}
+	*m = MasterProfile(mm)
+	if m.Count == 0 {
+		// When MasterProfile.Count is missing or 0, set to default 1
+		m.Count = 1
+	}
+	return nil
 }
 
 // AgentPoolProfile represents configuration of VMs running agent

--- a/pkg/api/v20170131/types_test.go
+++ b/pkg/api/v20170131/types_test.go
@@ -1,6 +1,7 @@
 package v20170131
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -16,5 +17,17 @@ func TestIsDCOS(t *testing.T) {
 	}
 	if kubernetesProfile.IsDCOS() {
 		t.Fatalf("unexpectedly detected DCOS orchestrator profile from OrchestratorType=%s", kubernetesProfile.OrchestratorType)
+	}
+}
+
+func TestMasterCount(t *testing.T) {
+	MasterProfileText := "{\"count\" : 0}"
+	mp := &MasterProfile{}
+	if e := json.Unmarshal([]byte(MasterProfileText), mp); e != nil {
+		t.Fatalf("unexpectedly detected unmarshal failure for MasterProfile, %+v", e)
+	}
+
+	if mp.Count != 1 {
+		t.Fatalf("unexpectedly detected MasterProfile.Count != 1 after unmarshal")
 	}
 }

--- a/pkg/api/v20170131/types_test.go
+++ b/pkg/api/v20170131/types_test.go
@@ -20,7 +20,7 @@ func TestIsDCOS(t *testing.T) {
 	}
 }
 
-func TestMasterCount(t *testing.T) {
+func TestMasterProfile(t *testing.T) {
 	MasterProfileText := "{\"count\" : 0}"
 	mp := &MasterProfile{}
 	if e := json.Unmarshal([]byte(MasterProfileText), mp); e != nil {
@@ -29,5 +29,22 @@ func TestMasterCount(t *testing.T) {
 
 	if mp.Count != 1 {
 		t.Fatalf("unexpectedly detected MasterProfile.Count != 1 after unmarshal")
+	}
+}
+
+func TestAgentPoolProfile(t *testing.T) {
+	// With osType not specified
+	AgentPoolProfileText := "{\"count\" : 0}"
+	ap := &AgentPoolProfile{}
+	if e := json.Unmarshal([]byte(AgentPoolProfileText), ap); e != nil {
+		t.Fatalf("unexpectedly detected unmarshal failure for AgentPoolProfile, %+v", e)
+	}
+
+	if ap.Count != 1 {
+		t.Fatalf("unexpectedly detected AgentPoolProfile.Count != 1 after unmarshal")
+	}
+
+	if ap.OSType != Linux {
+		t.Fatalf("unexpectedly detected AgentPoolProfile.OSType != Linux after unmarshal")
 	}
 }

--- a/pkg/api/v20170701/types_test.go
+++ b/pkg/api/v20170701/types_test.go
@@ -1,0 +1,35 @@
+package v20170701
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMasterProfile(t *testing.T) {
+	MasterProfileText := "{\"count\" : 0}"
+	mp := &MasterProfile{}
+	if e := json.Unmarshal([]byte(MasterProfileText), mp); e != nil {
+		t.Fatalf("unexpectedly detected unmarshal failure for MasterProfile, %+v", e)
+	}
+
+	if mp.Count != 1 {
+		t.Fatalf("unexpectedly detected MasterProfile.Count != 1 after unmarshal")
+	}
+}
+
+func TestAgentPoolProfile(t *testing.T) {
+	// With osType not specified
+	AgentPoolProfileText := "{\"count\" : 0}"
+	ap := &AgentPoolProfile{}
+	if e := json.Unmarshal([]byte(AgentPoolProfileText), ap); e != nil {
+		t.Fatalf("unexpectedly detected unmarshal failure for AgentPoolProfile, %+v", e)
+	}
+
+	if ap.Count != 1 {
+		t.Fatalf("unexpectedly detected AgentPoolProfile.Count != 1 after unmarshal")
+	}
+
+	if ap.OSType != Linux {
+		t.Fatalf("unexpectedly detected AgentPoolProfile.OSType != Linux after unmarshal")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
close api definition gap to public document

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #936 

**Special notes for your reviewer**:
One sample for masterCount, if looks good, I will apply to all the other fields.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/939)
<!-- Reviewable:end -->
