### PR TITLE
need to populate more default values for 2017-07-01

### DIFF
--- a/pkg/api/v20170701/types.go
+++ b/pkg/api/v20170701/types.go
@@ -149,8 +149,8 @@ func (m *MasterProfile) UnmarshalJSON(b []byte) error {
 		m.StorageProfile = StorageAccount
 	}
 
-	// OSDiskSizeGB
-	// The current behavior is, when OSDiskSizeGB is 0, we just don't pass it in the arm template
+	// OSDiskSizeGB is an override value. vm sizes have default OS disk sizes.
+	// If it is not set. The user should get the default for the vm size
 	return nil
 }
 
@@ -205,8 +205,8 @@ func (a *AgentPoolProfile) UnmarshalJSON(b []byte) error {
 		a.OSType = Linux
 	}
 
-	// OSDiskSizeGB
-	// The current behavior is, when OSDiskSizeGB is 0, we just don't pass it in the arm template
+	// OSDiskSizeGB is an override value. vm sizes have default OS disk sizes.
+	// If it is not set. The user should get the default for the vm size
 	return nil
 }
 

--- a/pkg/api/v20170701/types.go
+++ b/pkg/api/v20170701/types.go
@@ -139,9 +139,18 @@ func (m *MasterProfile) UnmarshalJSON(b []byte) error {
 		m.Count = 1
 	}
 
-	// TODO:
-	// Need to set default values for
-	// OSDiskSizeGB, FirstConsecutiveStaticIP, StorageProfile
+	if m.FirstConsecutiveStaticIP == "" {
+		// if FirstConsecutiveStaticIP is missing, set to default 10.240.255.5
+		m.FirstConsecutiveStaticIP = "10.240.255.5"
+	}
+
+	if m.StorageProfile == "" {
+		// if StorageProfile is missing, set to default StorageAccount
+		m.StorageProfile = StorageAccount
+	}
+
+	// OSDiskSizeGB
+	// The current behavior is, when OSDiskSizeGB is 0, we just don't pass it in the arm template
 	return nil
 }
 
@@ -183,6 +192,11 @@ func (a *AgentPoolProfile) UnmarshalJSON(b []byte) error {
 		a.Count = 1
 	}
 
+	if a.StorageProfile == "" {
+		// if StorageProfile is missing, set to default StorageAccount
+		a.StorageProfile = StorageAccount
+	}
+
 	if string(a.OSType) == "" {
 		// OSType is the operating system type for agents
 		// Set as nullable to support backward compat because
@@ -190,9 +204,9 @@ func (a *AgentPoolProfile) UnmarshalJSON(b []byte) error {
 		// If the value is null or not set, it defaulted to Linux.
 		a.OSType = Linux
 	}
-	// TODO:
-	// Need to set default values for
-	// OSDiskSizeGB, StorageProfile
+
+	// OSDiskSizeGB
+	// The current behavior is, when OSDiskSizeGB is 0, we just don't pass it in the arm template
 	return nil
 }
 

--- a/pkg/api/v20170701/types_test.go
+++ b/pkg/api/v20170701/types_test.go
@@ -15,6 +15,14 @@ func TestMasterProfile(t *testing.T) {
 	if mp.Count != 1 {
 		t.Fatalf("unexpectedly detected MasterProfile.Count != 1 after unmarshal")
 	}
+
+	if !mp.IsStorageAccount() {
+		t.Fatalf("unexpectedly detected MasterProfile.StorageProfile != StorageAccount after unmarshal")
+	}
+
+	if mp.FirstConsecutiveStaticIP != "10.240.255.5" {
+		t.Fatalf("unexpectedly detected MasterProfile.FirstConsecutiveStaticIP != 10.240.255.5 after unmarshal")
+	}
 }
 
 func TestAgentPoolProfile(t *testing.T) {
@@ -31,5 +39,9 @@ func TestAgentPoolProfile(t *testing.T) {
 
 	if ap.OSType != Linux {
 		t.Fatalf("unexpectedly detected AgentPoolProfile.OSType != Linux after unmarshal")
+	}
+
+	if !ap.IsStorageAccount() {
+		t.Fatalf("unexpectedly detected AgentPoolProfile.StorageProfile != StorageAccount after unmarshal")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Need to populate more default values for 2017-07-01

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #936 

**Special notes for your reviewer**:
Ready to review

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/951)
<!-- Reviewable:end -->
