### PR TITLE
Replace docker daemon to dockerd in swarmmode cluster

### DIFF
--- a/parts/configure-swarmmode-cluster.sh
+++ b/parts/configure-swarmmode-cluster.sh
@@ -179,7 +179,7 @@ updateDockerDaemonOptions()
     # also have it bind to the unix socket at /var/run/docker.sock
     sudo bash -c 'echo "[Service]
     ExecStart=
-    ExecStart=/usr/bin/docker daemon -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock
+    ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock
   " > /etc/systemd/system/docker.service.d/override.conf'
 }
 time updateDockerDaemonOptions


### PR DESCRIPTION
**What this PR does / why we need it**:

Docker service start fails and the error message is the following: 
```
`docker daemon` is not supported on Linux. Please run `dockerd` directly`
```

The project is full with `docker daemon` calls, maybe other parts also affected.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/982)
<!-- Reviewable:end -->

Fixes #985 