### PR TITLE
break the tie between dnsprefix and ports

### DIFF
--- a/pkg/api/v20170701/validate.go
+++ b/pkg/api/v20170701/validate.go
@@ -77,18 +77,17 @@ func (a *AgentPoolProfile) Validate(orchestratorType OrchestratorType) error {
 		if e := validateDNSName(a.DNSPrefix); e != nil {
 			return e
 		}
-		if len(a.Ports) > 0 {
-			if e := validateUniquePorts(a.Ports, a.Name); e != nil {
-				return e
-			}
-		} else {
-			a.Ports = []int{80, 443, 8080}
+	}
+	// ports doesn't need to be tied with dnsprefix
+	// if ports not specified, use {80, 443, 8080} as default
+	if len(a.Ports) > 0 {
+		if e := validateUniquePorts(a.Ports, a.Name); e != nil {
+			return e
 		}
 	} else {
-		if len(a.Ports) > 0 {
-			return fmt.Errorf("AgentPoolProfile.Ports must be empty when AgentPoolProfile.DNSPrefix is empty")
-		}
+		a.Ports = []int{80, 443, 8080}
 	}
+
 	return nil
 }
 

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -103,22 +103,20 @@ func (a *AgentPoolProfile) Validate(orchestratorType OrchestratorType) error {
 		if e := validateDNSName(a.DNSPrefix); e != nil {
 			return e
 		}
-		if len(a.Ports) > 0 {
-			if e := validateUniquePorts(a.Ports, a.Name); e != nil {
-				return e
+	}
+	// ports doesn't need to be tied with dnsprefix
+	// if ports not specified, use {80, 443, 8080} as default
+	if len(a.Ports) > 0 {
+		if e := validateUniquePorts(a.Ports, a.Name); e != nil {
+			return e
+		}
+		for _, port := range a.Ports {
+			if port < MinPort || port > MaxPort {
+				return fmt.Errorf("AgentPoolProfile Ports must be in the range[%d, %d]", MinPort, MaxPort)
 			}
-			for _, port := range a.Ports {
-				if port < MinPort || port > MaxPort {
-					return fmt.Errorf("AgentPoolProfile Ports must be in the range[%d, %d]", MinPort, MaxPort)
-				}
-			}
-		} else {
-			a.Ports = []int{80, 443, 8080}
 		}
 	} else {
-		if len(a.Ports) > 0 {
-			return fmt.Errorf("AgentPoolProfile.Ports must be empty when AgentPoolProfile.DNSPrefix is empty")
-		}
+		a.Ports = []int{80, 443, 8080}
 	}
 
 	// for Kubernetes, we don't support AgentPoolProfile.DNSPrefix


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #990 

**Special notes for your reviewer**:
Ready
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/991)
<!-- Reviewable:end -->
