### PR TITLE
return more meaningful validation error message

### DIFF
--- a/pkg/api/v20170701/validate.go
+++ b/pkg/api/v20170701/validate.go
@@ -65,12 +65,16 @@ func (a *AgentPoolProfile) Validate(orchestratorType OrchestratorType) error {
 	if e := validatePoolName(a.Name); e != nil {
 		return e
 	}
-	// Kubernetes don't allow agent DNSPrefix
+	// Kubernetes don't allow agent DNSPrefix and ports
 	if orchestratorType == Kubernetes {
-		// The line below need to be removed after June 2017
+		// The two lines below need to be removed after August 2017
 		a.DNSPrefix = ""
+		a.Ports = []int{}
 		if e := validate.Var(a.DNSPrefix, "len=0"); e != nil {
-			return e
+			return fmt.Errorf("AgentPoolProfile.DNSPrefix must be empty for Kubernetes")
+		}
+		if e := validate.Var(a.Ports, "len=0"); e != nil {
+			return fmt.Errorf("AgentPoolProfile.Ports must be empty for Kubernetes")
 		}
 	}
 	if a.DNSPrefix != "" {
@@ -85,8 +89,8 @@ func (a *AgentPoolProfile) Validate(orchestratorType OrchestratorType) error {
 			a.Ports = []int{80, 443, 8080}
 		}
 	} else {
-		if len(a.Ports) > 0 {
-			return fmt.Errorf("AgentPoolProfile.Ports must be empty when AgentPoolProfile.DNSPrefix is empty")
+		if e := validate.Var(a.Ports, "len=0"); e != nil {
+			return fmt.Errorf("AgentPoolProfile.Ports must be empty when AgentPoolProfile.DNSPrefix is empty for Orchestrator: %s", string(orchestratorType))
 		}
 	}
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Return more meaningful error message for validate ports, especially for k8s.
I was confused when i saw 
`AgentPoolProfile.Ports must be empty when AgentPoolProfile.DNSPrefix is empty`
I was trying to add DNSPrefix. 

However, it should be the `DNSPrefix` or `Ports` for k8s are not allowed at all

And also, the comment is outdated.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Ready to review

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/992)
<!-- Reviewable:end -->
