### PR TITLE
typo(deploy): error is for location, not subscription-id

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -103,7 +103,7 @@ func (dc *deployCmd) validate(cmd *cobra.Command, args []string) {
 	}
 
 	if dc.location == "" {
-		log.Fatalf("--subscription-id must be specified")
+		log.Fatalf("--location must be specified")
 	}
 
 	if dc.containerService.Properties.LinuxProfile.AdminUsername == "" {


### PR DESCRIPTION
Small cleanup I noticed when looking through the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1009)
<!-- Reviewable:end -->
