### PR TITLE
add anti-affinity to kube-dns deployment

### DIFF
--- a/parts/kubernetesmasteraddons-kube-dns-deployment.yaml
+++ b/parts/kubernetesmasteraddons-kube-dns-deployment.yaml
@@ -22,6 +22,18 @@ spec:
         kubernetes.io/cluster-service: "true"
         version: v20
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - kube-dns
+              topologyKey: kubernetes.io/hostname
       volumes:
       - name: kube-dns-config
         configMap:


### PR DESCRIPTION
Currently kube-dns pods could be placed on the same node. This change adds anti-affinity to prefer that pods be scheduled to different nodes that match the label k8s-app=kube-dns

Note that this change only is supported in Kubernetes 1.6 and beyond
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1014)
<!-- Reviewable:end -->
