### PR TITLE
Add flags for activating the kubernetes cert signing API.

### DIFF
--- a/parts/kubernetesmaster-kube-controller-manager.yaml
+++ b/parts/kubernetesmaster-kube-controller-manager.yaml
@@ -21,6 +21,8 @@ spec:
         - "--cloud-provider=azure"
         - "--cloud-config=/etc/kubernetes/azure.json"
         - "--root-ca-file=/etc/kubernetes/certs/ca.crt"
+        - "--cluster-signing-cert-file=/etc/kubernetes/certs/ca.crt"
+        - "--cluster-signing-key-file=/etc/kubernetes/certs/ca.key"
         - "--service-account-private-key-file=/etc/kubernetes/certs/apiserver.key"
         - "--leader-elect=true"
         - "--v=2"


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds cert-signing functionality to acs-engine

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1026

**Special notes for your reviewer**:

**Release note**:
```release-note
Add support for certificate signing to the master.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1025)
<!-- Reviewable:end -->
