### PR TITLE
fix using user supplied serviceprinciple in apimodel

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -181,36 +181,41 @@ func autofillApimodel(dc *deployCmd) {
 	if !useManagedIdentity {
 		spp := dc.containerService.Properties.ServicePrincipalProfile
 		if spp != nil && !(spp.ClientID == "" && spp.Secret == "") {
-			log.Fatal("apimodel invalid: ServicePrincipalProfile is missing either the clientid or secret.")
-		}
+			log.Info("using user supplied ServicePrincipalProfile in apimodel.")
 
-		log.Warnln("apimodel: ServicePrincipalProfile was empty, creating application...")
-
-		// TODO: consider caching the creds here so they persist between subsequent runs of 'deploy'
-		appName := dc.containerService.Properties.MasterProfile.DNSPrefix
-		appURL := fmt.Sprintf("https://%s/", appName)
-		applicationID, servicePrincipalObjectID, secret, err := dc.client.CreateApp(appName, appURL)
-		if err != nil {
-			log.Fatalf("apimodel invalid: ServicePrincipalProfile was empty, and we failed to create valid credentials: %q", err)
-		}
-		log.Warnf("created application with applicationID (%s) and servicePrincipalObjectID (%s).", applicationID, servicePrincipalObjectID)
-
-		log.Warnln("apimodel: ServicePrincipalProfile was empty, assigning role to application...")
-		for {
-			err = dc.client.CreateRoleAssignmentSimple(dc.resourceGroup, servicePrincipalObjectID)
-			if err != nil {
-				log.Warnf("Failed to create role assignment (will retry): %q", err)
-				time.Sleep(3 * time.Second)
-				continue
+			dc.containerService.Properties.ServicePrincipalProfile = &api.ServicePrincipalProfile{
+			ClientID: spp.ClientID,
+			Secret:   spp.Secret,
 			}
-			break
-		}
+		} else {
 
-		dc.containerService.Properties.ServicePrincipalProfile = &api.ServicePrincipalProfile{
-			ClientID: applicationID,
-			Secret:   secret,
-		}
+			log.Warnln("apimodel: ServicePrincipalProfile was empty, creating application...")
 
+			// TODO: consider caching the creds here so they persist between subsequent runs of 'deploy'
+			appName := dc.containerService.Properties.MasterProfile.DNSPrefix
+			appURL := fmt.Sprintf("https://%s/", appName)
+			applicationID, servicePrincipalObjectID, secret, err := dc.client.CreateApp(appName, appURL)
+			if err != nil {
+				log.Fatalf("apimodel invalid: ServicePrincipalProfile was empty, and we failed to create valid credentials: %q", err)
+			}
+			log.Warnf("created application with applicationID (%s) and servicePrincipalObjectID (%s).", applicationID, servicePrincipalObjectID)
+
+			log.Warnln("apimodel: ServicePrincipalProfile was empty, assigning role to application...")
+			for {
+				err = dc.client.CreateRoleAssignmentSimple(dc.resourceGroup, servicePrincipalObjectID)
+				if err != nil {
+					log.Warnf("Failed to create role assignment (will retry): %q", err)
+					time.Sleep(3 * time.Second)
+					continue
+				}
+				break
+			}
+
+			dc.containerService.Properties.ServicePrincipalProfile = &api.ServicePrincipalProfile{
+				ClientID: applicationID,
+				Secret:   secret,
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes the use of user supplied SP credentials in the API model. If supplied in apimodel this is current experience
```
./acs-engine deploy --subscription-id xxx --location eastus --resource-group xxx --api-model examples/classic/cluster.json
FATA[0005] apimodel invalid: ServicePrincipalProfile is missing either the clientid or secret.
```

```
    "servicePrincipalProfile": {
      "servicePrincipalClientID": "xxxx",
      "servicePrincipalClientSecret": "xxxx"
    }
```


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1039)
<!-- Reviewable:end -->
