### PR TITLE
fix(deploy): fix SP cred handling in deploy

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -180,37 +180,40 @@ func autofillApimodel(dc *deployCmd) {
 
 	if !useManagedIdentity {
 		spp := dc.containerService.Properties.ServicePrincipalProfile
-		if spp != nil && !(spp.ClientID == "" && spp.Secret == "") {
-			log.Fatal("apimodel invalid: ServicePrincipalProfile is missing either the clientid or secret.")
-		}
-
-		log.Warnln("apimodel: ServicePrincipalProfile was empty, creating application...")
-
-		// TODO: consider caching the creds here so they persist between subsequent runs of 'deploy'
-		appName := dc.containerService.Properties.MasterProfile.DNSPrefix
-		appURL := fmt.Sprintf("https://%s/", appName)
-		applicationID, servicePrincipalObjectID, secret, err := dc.client.CreateApp(appName, appURL)
-		if err != nil {
-			log.Fatalf("apimodel invalid: ServicePrincipalProfile was empty, and we failed to create valid credentials: %q", err)
-		}
-		log.Warnf("created application with applicationID (%s) and servicePrincipalObjectID (%s).", applicationID, servicePrincipalObjectID)
-
-		log.Warnln("apimodel: ServicePrincipalProfile was empty, assigning role to application...")
-		for {
-			err = dc.client.CreateRoleAssignmentSimple(dc.resourceGroup, servicePrincipalObjectID)
-			if err != nil {
-				log.Warnf("Failed to create role assignment (will retry): %q", err)
-				time.Sleep(3 * time.Second)
-				continue
+		if spp != nil && (spp.ClientID == "" || spp.Secret == "") {
+			// they didn't specify one or the other
+			if spp != nil && !(spp.ClientID == "" && spp.Secret == "") {
+				// they didn't specify just one
+				log.Fatal("apimodel invalid: ServicePrincipalProfile is missing either the clientid or secret.")
 			}
-			break
-		}
 
-		dc.containerService.Properties.ServicePrincipalProfile = &api.ServicePrincipalProfile{
-			ClientID: applicationID,
-			Secret:   secret,
-		}
+			log.Warnln("apimodel: ServicePrincipalProfile was missing or empty, creating application...")
 
+			// TODO: consider caching the creds here so they persist between subsequent runs of 'deploy'
+			appName := dc.containerService.Properties.MasterProfile.DNSPrefix
+			appURL := fmt.Sprintf("https://%s/", appName)
+			applicationID, servicePrincipalObjectID, secret, err := dc.client.CreateApp(appName, appURL)
+			if err != nil {
+				log.Fatalf("apimodel invalid: ServicePrincipalProfile was empty, and we failed to create valid credentials: %q", err)
+			}
+			log.Warnf("created application with applicationID (%s) and servicePrincipalObjectID (%s).", applicationID, servicePrincipalObjectID)
+
+			log.Warnln("apimodel: ServicePrincipalProfile was empty, assigning role to application...")
+			for {
+				err = dc.client.CreateRoleAssignmentSimple(dc.resourceGroup, servicePrincipalObjectID)
+				if err != nil {
+					log.Warnf("Failed to create role assignment (will retry): %q", err)
+					time.Sleep(3 * time.Second)
+					continue
+				}
+				break
+			}
+
+			dc.containerService.Properties.ServicePrincipalProfile = &api.ServicePrincipalProfile{
+				ClientID: applicationID,
+				Secret:   secret,
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Fixes the regression in #1051 by fixing the logic for checking if SPP is empty or missing one value.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1051

**Special notes for your reviewer**: none

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```



Before the fix (with the new test I added):

```
=== RUN   TestAutofillApimodelAllowsPrespecifiedCreds
WARN[0004] apimodel: missing masterProfile.dnsPrefix will use "dnsPrefix1" 
WARN[0004] --resource-group was not specified. Using the DNS prefix from the apimodel as the resource group name: dnsPrefix1 
FATA[0005] apimodel invalid: ServicePrincipalProfile is missing either the clientid or secret. 
exit status 1
FAIL    github.com/Azure/acs-engine/cmd 5.883s
```

After this PR:

```
=== RUN   TestAutofillApimodelAllowsPrespecifiedCreds
WARN[0000] apimodel: missing masterProfile.dnsPrefix will use "dnsPrefix1" 
WARN[0000] --resource-group was not specified. Using the DNS prefix from the apimodel as the resource group name: dnsPrefix1 
--- PASS: TestAutofillApimodelAllowsPrespecifiedCreds (0.81s)
```

cc: @seanknox @lachie83

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1052)
<!-- Reviewable:end -->
