### PR TITLE
bumped addon-manager tag to be consistent with other releases

### DIFF
--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -109,7 +109,7 @@ var KubeImages = map[api.OrchestratorVersion]map[string]string{
 		"addonresizer": "addon-resizer:2.0",
 		"heapster":     "heapster:v1.4.0",
 		"dns":          "k8s-dns-kube-dns-amd64:1.14.4",
-		"addonmanager": "kube-addon-manager-amd64:v6.1.2",
+		"addonmanager": "kube-addon-manager-amd64:v6.4-beta.2",
 		"dnsmasq":      "k8s-dns-dnsmasq-amd64:1.14.4",
 		"pause":        "pause-amd64:3.0",
 		"windowszip":   "v1.7.0intwinnat.zip",


### PR DESCRIPTION
This bumps the addon-manager image tag to support kubectl 1.6 resource types. It was a regression that was created as part of merging in Kubernetes 1.7 contants

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1063)
<!-- Reviewable:end -->
