### PR TITLE
chore(coverage): add `make coverage` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ test-style:
 	@scripts/validate-go.sh
 
 ci: prereqs build test lint
+	./scripts/coverage.sh --coveralls
+
+.PHONY: coverage
+coverage:
+	@scripts/coverage.sh
 
 devenv:
 	./scripts/devenv.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Microsoft Azure Container Service Engine - Builds Docker Enabled Clusters
+[![Coverage Status](https://coveralls.io/repos/github/Azure/acs-engine/badge.svg?branch=master)](https://coveralls.io/github/Azure/acs-engine?branch=master)
 
 ## Overview
 
@@ -10,7 +11,7 @@ The cluster definition file enables the following customizations to your Docker 
  * standard or premium VM Sizes,
  * node count,
  * Virtual Machine ScaleSets or Availability Sets,
- * Storage Account Disks or Managed Disks (under private preview),
+ * Storage Account Disks or Managed Disks (under private preview)
 * Docker cluster sizes of 1200
 * Custom VNET
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+covermode=${COVERMODE:-atomic}
+coverdir=$(mktemp -d /tmp/coverage.XXXXXXXXXX)
+profile="${coverdir}/cover.out"
+
+hash goveralls 2>/dev/null || go get github.com/mattn/goveralls
+hash godir 2>/dev/null || go get github.com/Masterminds/godir
+
+generate_cover_data() {
+  for d in $(godir) ; do
+    (
+      local output="${coverdir}/${d//\//-}.cover"
+      go test -coverprofile="${output}" -covermode="$covermode" "$d"
+    )
+  done
+
+  echo "mode: $covermode" >"$profile"
+  grep -h -v "^mode:" "$coverdir"/*.cover >>"$profile"
+}
+
+push_to_coveralls() {
+  goveralls -coverprofile="${profile}" -repotoken $COVERALLS_TOKEN
+}
+
+generate_cover_data
+go tool cover -func "${profile}"
+
+case "${1-}" in
+  --html)
+    go tool cover -html "${profile}"
+    ;;
+  --coveralls)
+		if [ -z $COVERALLS_TOKEN ]; then
+			echo '$COVERALLS_TOKEN not set. Skipping pushing coverage report to coveralls.io'
+			exit
+		fi
+    push_to_coveralls
+    ;;
+esac
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: adds `make coverage` to generate test coverage report, and optionally send coverage reports to coveralls.io.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1070 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
can run `make coverage` to generate test coverage report
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1080)
<!-- Reviewable:end -->
