### PR TITLE
auto create sp when kv ref is not used

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -180,7 +180,7 @@ func autofillApimodel(dc *deployCmd) {
 
 	if !useManagedIdentity {
 		spp := dc.containerService.Properties.ServicePrincipalProfile
-		if spp != nil && (spp.ClientID == "" || spp.Secret == "") {
+		if spp != nil && spp.KeyvaultSecretRef == "" && (spp.ClientID == "" || spp.Secret == "") {
 			// they didn't specify one or the other
 			if spp != nil && !(spp.ClientID == "" && spp.Secret == "") {
 				// they didn't specify just one

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -180,13 +180,7 @@ func autofillApimodel(dc *deployCmd) {
 
 	if !useManagedIdentity {
 		spp := dc.containerService.Properties.ServicePrincipalProfile
-		if spp != nil && spp.KeyvaultSecretRef == "" && (spp.ClientID == "" || spp.Secret == "") {
-			// they didn't specify one or the other
-			if spp != nil && !(spp.ClientID == "" && spp.Secret == "") {
-				// they didn't specify just one
-				log.Fatal("apimodel invalid: ServicePrincipalProfile is missing either the clientid or secret.")
-			}
-
+		if spp != nil && spp.ClientID == "" && spp.Secret == "" && spp.KeyvaultSecretRef == "" {
 			log.Warnln("apimodel: ServicePrincipalProfile was missing or empty, creating application...")
 
 			// TODO: consider caching the creds here so they persist between subsequent runs of 'deploy'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Skip the auto create SP logic when KV secret is used.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1092 
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1093)
<!-- Reviewable:end -->
