### PR TITLE
remove unnecessary customized types

### DIFF
--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -79,7 +79,7 @@ const (
 )
 
 // KubeImages represents Docker images used for Kubernetes components based on Kubernetes version
-var KubeImages = map[api.OrchestratorVersion]map[string]string{
+var KubeImages = map[string]map[string]string{
 	api.Kubernetes171: {
 		"hyperkube":       "hyperkube-amd64:v1.7.1",
 		"dashboard":       "kubernetes-dashboard-amd64:v1.6.1",
@@ -103,16 +103,16 @@ var KubeImages = map[api.OrchestratorVersion]map[string]string{
 		"ratelimitbucket": strconv.Itoa(DefaultKubernetesCloudProviderRateLimitBucket),
 	},
 	api.Kubernetes170: {
-		"hyperkube":    "hyperkube-amd64:v1.7.0",
-		"dashboard":    "kubernetes-dashboard-amd64:v1.6.1",
-		"exechealthz":  "exechealthz-amd64:1.2",
-		"addonresizer": "addon-resizer:2.0",
-		"heapster":     "heapster:v1.4.0",
-		"dns":          "k8s-dns-kube-dns-amd64:1.14.4",
-		"addonmanager": "kube-addon-manager-amd64:v6.4-beta.2",
-		"dnsmasq":      "k8s-dns-dnsmasq-amd64:1.14.4",
-		"pause":        "pause-amd64:3.0",
-		"windowszip":   "v1.7.0intwinnat.zip",
+		"hyperkube":       "hyperkube-amd64:v1.7.0",
+		"dashboard":       "kubernetes-dashboard-amd64:v1.6.1",
+		"exechealthz":     "exechealthz-amd64:1.2",
+		"addonresizer":    "addon-resizer:2.0",
+		"heapster":        "heapster:v1.4.0",
+		"dns":             "k8s-dns-kube-dns-amd64:1.14.4",
+		"addonmanager":    "kube-addon-manager-amd64:v6.4-beta.2",
+		"dnsmasq":         "k8s-dns-dnsmasq-amd64:1.14.4",
+		"pause":           "pause-amd64:3.0",
+		"windowszip":      "v1.7.0intwinnat.zip",
 		"nodestatusfreq":  DefaultKubernetesNodeStatusUpdateFrequency,
 		"nodegraceperiod": DefaultKubernetesCtrlMgrNodeMonitorGracePeriod,
 		"podeviction":     DefaultKubernetesCtrlMgrPodEvictionTimeout,

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -521,7 +521,7 @@ func addSecret(m map[string]interface{}, k string, v interface{}, encode bool) {
 }
 
 // https://stackoverflow.com/a/18411978
-func VersionOrdinal(version api.OrchestratorVersion) string {
+func VersionOrdinal(version string) string {
 	// ISO/IEC 14651:2011
 	const maxByte = 1<<8 - 1
 	vo := make([]byte, 0, len(version)+8)
@@ -574,7 +574,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) map[str
 				cs.Properties.OrchestratorProfile.OrchestratorVersion == api.DCOS190
 		},
 		"IsKubernetesVersionGe": func(version string) bool {
-			targetVersion := api.OrchestratorVersion(version)
+			targetVersion := version
 			targetVersionOrdinal := VersionOrdinal(targetVersion)
 			orchestratorVersionOrdinal := VersionOrdinal(cs.Properties.OrchestratorProfile.OrchestratorVersion)
 			return cs.Properties.OrchestratorProfile.OrchestratorType == api.Kubernetes &&
@@ -607,7 +607,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) map[str
 		"UseManagedIdentity": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity
 		},
-                "UseInstanceMetadata": func() bool {
+		"UseInstanceMetadata": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata
 		},
 		"GetVNETSubnetDependencies": func() string {
@@ -910,7 +910,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) map[str
 	}
 }
 
-func getPackageGUID(orchestratorType api.OrchestratorType, orchestratorVersion api.OrchestratorVersion, masterCount int) string {
+func getPackageGUID(orchestratorType string, orchestratorVersion string, masterCount int) string {
 	if orchestratorType == api.DCOS && orchestratorVersion == api.DCOS190 {
 		switch masterCount {
 		case 1:
@@ -960,7 +960,7 @@ func getPackageGUID(orchestratorType api.OrchestratorType, orchestratorVersion a
 	return ""
 }
 
-func getDCOSCustomDataPublicIPStr(orchestratorType api.OrchestratorType, masterCount int) string {
+func getDCOSCustomDataPublicIPStr(orchestratorType string, masterCount int) string {
 	if orchestratorType == api.DCOS {
 		var buf bytes.Buffer
 		for i := 0; i < masterCount; i++ {
@@ -1275,7 +1275,7 @@ touch /etc/mesosphere/roles/azure_master`
 }
 
 // getSingleLineForTemplate returns the file as a single line for embedding in an arm template
-func getSingleLineDCOSCustomData(orchestratorType api.OrchestratorType, orchestratorVersion api.OrchestratorVersion, masterCount int, provisionContent string, attributeContents string) string {
+func getSingleLineDCOSCustomData(orchestratorType string, orchestratorVersion string, masterCount int, provisionContent string, attributeContents string) string {
 	yamlFilename := ""
 	switch orchestratorType {
 	case api.DCOS:

--- a/pkg/acsengine/engine_test.go
+++ b/pkg/acsengine/engine_test.go
@@ -198,14 +198,13 @@ func addTestCertificateProfile(api *api.CertificateProfile) {
 
 func TestVersionOrdinal(t *testing.T) {
 	RegisterTestingT(t)
-	v171 := api.OrchestratorVersion("1.7.1")
-	v170 := api.OrchestratorVersion("1.7.0")
-	v166 := api.OrchestratorVersion("1.6.6")
-	v162 := api.OrchestratorVersion("1.6.2")
-	v160 := api.OrchestratorVersion("1.6.0")
-	v153 := api.OrchestratorVersion("1.5.3")
-	v16 := api.OrchestratorVersion("1.6")
-
+	v171 := "1.7.1"
+	v170 := "1.7.0"
+	v166 := "1.6.6"
+	v162 := "1.6.2"
+	v160 := "1.6.0"
+	v153 := "1.5.3"
+	v16 := "1.6"
 
 	Expect(v170 < v171).To(BeTrue())
 	Expect(v166 < v170).To(BeTrue())

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -3,15 +3,15 @@ package api
 // the orchestrators supported by vlabs
 const (
 	// Mesos is the string constant for MESOS orchestrator type
-	Mesos OrchestratorType = "Mesos"
+	Mesos string = "Mesos"
 	// DCOS is the string constant for DCOS orchestrator type and defaults to DCOS188
-	DCOS OrchestratorType = "DCOS"
+	DCOS string = "DCOS"
 	// Swarm is the string constant for the Swarm orchestrator type
-	Swarm OrchestratorType = "Swarm"
+	Swarm string = "Swarm"
 	// Kubernetes is the string constant for the Kubernetes orchestrator type
-	Kubernetes OrchestratorType = "Kubernetes"
+	Kubernetes string = "Kubernetes"
 	// SwarmMode is the string constant for the Swarm Mode orchestrator type
-	SwarmMode OrchestratorType = "SwarmMode"
+	SwarmMode string = "SwarmMode"
 )
 
 // the OSTypes supported by vlabs
@@ -52,36 +52,36 @@ const (
 
 const (
 	// Kubernetes153 is the string constant for Kubernetes 1.5.3
-	Kubernetes153 OrchestratorVersion = "1.5.3"
+	Kubernetes153 string = "1.5.3"
 	// Kubernetes157 is the string constant for Kubernetes 1.5.7
-	Kubernetes157 OrchestratorVersion = "1.5.7"
+	Kubernetes157 string = "1.5.7"
 	// Kubernetes160 is the string constant for Kubernetes 1.6.0
-	Kubernetes160 OrchestratorVersion = "1.6.0"
+	Kubernetes160 string = "1.6.0"
 	// Kubernetes162 is the string constant for Kubernetes 1.6.2
-	Kubernetes162 OrchestratorVersion = "1.6.2"
+	Kubernetes162 string = "1.6.2"
 	// Kubernetes166 is the string constant for Kubernetes 1.6.6
-	Kubernetes166 OrchestratorVersion = "1.6.6"
+	Kubernetes166 string = "1.6.6"
 	// Kubernetes166 is the string constant for Kubernetes 1.7.0
-	Kubernetes170 OrchestratorVersion = "1.7.0"
+	Kubernetes170 string = "1.7.0"
 	// Kubernetes166 is the string constant for Kubernetes 1.7.1
-	Kubernetes171 OrchestratorVersion = "1.7.1"
+	Kubernetes171 string = "1.7.1"
 	// KubernetesDefaultVersion is the string constant for current Kubernetes version
-	KubernetesDefaultVersion OrchestratorVersion = Kubernetes166
+	KubernetesDefaultVersion string = Kubernetes166
 )
 
 const (
 	// DCOS190 is the string constant for DCOS 1.9.0
-	DCOS190 OrchestratorVersion = "1.9.0"
+	DCOS190 string = "1.9.0"
 	// DCOS188 is the string constant for DCOS 1.8.8
-	DCOS188 OrchestratorVersion = "1.8.8"
+	DCOS188 string = "1.8.8"
 	// DCOS187 is the string constant for DCOS 1.8.7
-	DCOS187 OrchestratorVersion = "1.8.7"
+	DCOS187 string = "1.8.7"
 	// DCOS184 is the string constant for DCOS 1.8.4
-	DCOS184 OrchestratorVersion = "1.8.4"
+	DCOS184 string = "1.8.4"
 	// DCOS173 is the string constant for DCOS 1.7.3
-	DCOS173 OrchestratorVersion = "1.7.3"
+	DCOS173 string = "1.7.3"
 	// DCOSLatest is the string constant for latest DCOS version
-	DCOSLatest OrchestratorVersion = DCOS190
+	DCOSLatest string = DCOS190
 )
 
 // To identify programmatically generated public agent pools

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -495,26 +495,26 @@ func convertWindowsProfileToVLabs(api *WindowsProfile, vlabsProfile *vlabs.Windo
 }
 
 func convertOrchestratorProfileToV20160930(api *OrchestratorProfile, o *v20160930.OrchestratorProfile) {
-	if strings.HasPrefix(string(api.OrchestratorType), string(v20160930.DCOS)) {
-		o.OrchestratorType = v20160930.OrchestratorType(v20160930.DCOS)
+	if strings.HasPrefix(api.OrchestratorType, v20160930.DCOS) {
+		o.OrchestratorType = v20160930.DCOS
 	} else {
-		o.OrchestratorType = v20160930.OrchestratorType(api.OrchestratorType)
+		o.OrchestratorType = api.OrchestratorType
 	}
 }
 
 func convertOrchestratorProfileToV20160330(api *OrchestratorProfile, o *v20160330.OrchestratorProfile) {
-	if strings.HasPrefix(string(api.OrchestratorType), string(v20160330.DCOS)) {
-		o.OrchestratorType = v20160330.OrchestratorType(v20160930.DCOS)
+	if strings.HasPrefix(api.OrchestratorType, v20160330.DCOS) {
+		o.OrchestratorType = v20160330.DCOS
 	} else {
-		o.OrchestratorType = v20160330.OrchestratorType(api.OrchestratorType)
+		o.OrchestratorType = api.OrchestratorType
 	}
 }
 
 func convertOrchestratorProfileToV20170131(api *OrchestratorProfile, o *v20170131.OrchestratorProfile) {
-	if strings.HasPrefix(string(api.OrchestratorType), string(v20170131.DCOS)) {
-		o.OrchestratorType = v20170131.OrchestratorType(v20170131.DCOS)
+	if strings.HasPrefix(api.OrchestratorType, v20170131.DCOS) {
+		o.OrchestratorType = v20170131.DCOS
 	} else {
-		o.OrchestratorType = v20170131.OrchestratorType(api.OrchestratorType)
+		o.OrchestratorType = api.OrchestratorType
 	}
 }
 
@@ -522,19 +522,19 @@ func convertOrchestratorProfileToV20170701(api *OrchestratorProfile, o *v2017070
 	if api.OrchestratorType == SwarmMode {
 		o.OrchestratorType = v20170701.DockerCE
 	} else {
-		o.OrchestratorType = v20170701.OrchestratorType(api.OrchestratorType)
+		o.OrchestratorType = api.OrchestratorType
 	}
 
 	if api.OrchestratorVersion != "" {
-		o.OrchestratorVersion = v20170701.OrchestratorVersion(api.OrchestratorVersion)
+		o.OrchestratorVersion = api.OrchestratorVersion
 	}
 }
 
 func convertOrchestratorProfileToVLabs(api *OrchestratorProfile, o *vlabs.OrchestratorProfile) {
-	o.OrchestratorType = vlabs.OrchestratorType(api.OrchestratorType)
+	o.OrchestratorType = api.OrchestratorType
 
 	if api.OrchestratorVersion != "" {
-		o.OrchestratorVersion = vlabs.OrchestratorVersion(api.OrchestratorVersion)
+		o.OrchestratorVersion = api.OrchestratorVersion
 	}
 
 	if api.KubernetesConfig != nil {

--- a/pkg/api/converterfromupgradeapi.go
+++ b/pkg/api/converterfromupgradeapi.go
@@ -19,9 +19,9 @@ func ConvertUpgradeContainerServiceToVLabs(api *UpgradeContainerService) *vlabs.
 }
 
 func convertUpgradeOrchestratorProfileToVLabs(api *OrchestratorProfile, o *vlabs.OrchestratorProfile) {
-	o.OrchestratorType = vlabs.OrchestratorType(api.OrchestratorType)
+	o.OrchestratorType = api.OrchestratorType
 
 	if api.OrchestratorVersion != "" {
-		o.OrchestratorVersion = vlabs.OrchestratorVersion(api.OrchestratorVersion)
+		o.OrchestratorVersion = api.OrchestratorVersion
 	}
 }

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -467,7 +467,7 @@ func convertVLabsWindowsProfile(vlabs *vlabs.WindowsProfile, api *WindowsProfile
 }
 
 func convertV20160930OrchestratorProfile(v20160930 *v20160930.OrchestratorProfile, api *OrchestratorProfile) {
-	api.OrchestratorType = OrchestratorType(v20160930.OrchestratorType)
+	api.OrchestratorType = v20160930.OrchestratorType
 	if api.OrchestratorType == Kubernetes {
 		api.OrchestratorVersion = Kubernetes153
 	} else if api.OrchestratorType == DCOS {
@@ -476,14 +476,14 @@ func convertV20160930OrchestratorProfile(v20160930 *v20160930.OrchestratorProfil
 }
 
 func convertV20160330OrchestratorProfile(v20160330 *v20160330.OrchestratorProfile, api *OrchestratorProfile) {
-	api.OrchestratorType = OrchestratorType(v20160330.OrchestratorType)
+	api.OrchestratorType = v20160330.OrchestratorType
 	if api.OrchestratorType == DCOS {
 		api.OrchestratorVersion = DCOS190
 	}
 }
 
 func convertV20170131OrchestratorProfile(v20170131 *v20170131.OrchestratorProfile, api *OrchestratorProfile) {
-	api.OrchestratorType = OrchestratorType(v20170131.OrchestratorType)
+	api.OrchestratorType = v20170131.OrchestratorType
 	if api.OrchestratorType == Kubernetes {
 		api.OrchestratorVersion = KubernetesDefaultVersion
 	} else if api.OrchestratorType == DCOS {
@@ -495,7 +495,7 @@ func convertV20170701OrchestratorProfile(v20170701cs *v20170701.OrchestratorProf
 	if v20170701cs.OrchestratorType == v20170701.DockerCE {
 		api.OrchestratorType = SwarmMode
 	} else {
-		api.OrchestratorType = OrchestratorType(v20170701cs.OrchestratorType)
+		api.OrchestratorType = v20170701cs.OrchestratorType
 	}
 
 	if api.OrchestratorType == Kubernetes {
@@ -523,7 +523,7 @@ func convertV20170701OrchestratorProfile(v20170701cs *v20170701.OrchestratorProf
 }
 
 func convertVLabsOrchestratorProfile(vlabscs *vlabs.OrchestratorProfile, api *OrchestratorProfile) {
-	api.OrchestratorType = OrchestratorType(vlabscs.OrchestratorType)
+	api.OrchestratorType = vlabscs.OrchestratorType
 	if api.OrchestratorType == Kubernetes {
 		if vlabscs.KubernetesConfig != nil {
 			api.KubernetesConfig = &KubernetesConfig{}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -122,9 +122,9 @@ const (
 
 // OrchestratorProfile contains Orchestrator properties
 type OrchestratorProfile struct {
-	OrchestratorType    OrchestratorType    `json:"orchestratorType"`
-	OrchestratorVersion OrchestratorVersion `json:"orchestratorVersion"`
-	KubernetesConfig    *KubernetesConfig   `json:"kubernetesConfig,omitempty"`
+	OrchestratorType    string            `json:"orchestratorType"`
+	OrchestratorVersion string            `json:"orchestratorVersion"`
+	KubernetesConfig    *KubernetesConfig `json:"kubernetesConfig,omitempty"`
 }
 
 // KubernetesConfig contains the Kubernetes config structure, containing
@@ -148,7 +148,7 @@ type KubernetesConfig struct {
 	CloudProviderRateLimitBucket     int     `json:"cloudProviderRateLimitBucket,omitempty"`
 	UseManagedIdentity               bool    `json:"useManagedIdentity,omitempty"`
 	CustomHyperkubeImage             string  `json:"customHyperkubeImage,omitempty"`
-	UseInstanceMetadata		 bool    `json:"useInstanceMetadata,omitempty"`
+	UseInstanceMetadata              bool    `json:"useInstanceMetadata,omitempty"`
 }
 
 // MasterProfile represents the definition of the master cluster
@@ -164,7 +164,7 @@ type MasterProfile struct {
 	StorageProfile           string `json:"storageProfile,omitempty"`
 	HttpSourceAddressPrefix  string `json:"httpSourceAddressPrefix,omitempty"`
 	OAuthEnabled             bool   `json:"oauthEnabled"`
-	
+
 	// Master LB public endpoint/FQDN with port
 	// The format will be FQDN:2376
 	// Not used during PUT, returned as part of GET
@@ -210,12 +210,6 @@ type VMDiagnostics struct {
 	// for the customer.
 	StorageURL *neturl.URL `json:"storageUrl"`
 }
-
-// OrchestratorType defines orchestrators supported by ACS
-type OrchestratorType string
-
-// OrchestratorVersion defines the version for orchestratorType
-type OrchestratorVersion string
 
 // JumpboxProfile dscribes properties of the jumpbox setup
 // in the ACS container cluster.

--- a/pkg/api/v20160330/const.go
+++ b/pkg/api/v20160330/const.go
@@ -7,9 +7,9 @@ const (
 
 // v20160330 supports orchestrators Mesos, Swarm, DCOS
 const (
-	Mesos OrchestratorType = "Mesos"
-	Swarm OrchestratorType = "Swarm"
-	DCOS  OrchestratorType = "DCOS"
+	Mesos string = "Mesos"
+	Swarm string = "Swarm"
+	DCOS  string = "DCOS"
 )
 
 // v20160330 supports OSTypes Windows and Linux

--- a/pkg/api/v20160330/types.go
+++ b/pkg/api/v20160330/types.go
@@ -89,7 +89,7 @@ const (
 
 // OrchestratorProfile contains Orchestrator properties
 type OrchestratorProfile struct {
-	OrchestratorType OrchestratorType `json:"orchestratorType"`
+	OrchestratorType string `json:"orchestratorType"`
 }
 
 // MasterProfile represents the definition of master cluster
@@ -194,24 +194,29 @@ type VMDiagnostics struct {
 	StorageURL *neturl.URL `json:"storageUrl"`
 }
 
-// OrchestratorType defines orchestrators supported by ACS
-type OrchestratorType string
-
-// UnmarshalText decodes OrchestratorType text, do a case insensitive comparison with
-// the defined OrchestratorType constant and set to it if they equal
-func (o *OrchestratorType) UnmarshalText(text []byte) error {
-	s := string(text)
-	switch {
-	case strings.EqualFold(s, string(DCOS)):
-		*o = DCOS
-	case strings.EqualFold(s, string(Mesos)):
-		*o = Mesos
-	case strings.EqualFold(s, string(Swarm)):
-		*o = Swarm
-	default:
-		return fmt.Errorf("OrchestratorType has unknown orchestrator: %s", s)
+// UnmarshalJSON unmarshal json using the default behavior
+// And do fields manipulation, such as populating default value
+func (o *OrchestratorProfile) UnmarshalJSON(b []byte) error {
+	// Need to have a alias type to avoid circular unmarshal
+	type aliasOrchestratorProfile OrchestratorProfile
+	op := aliasOrchestratorProfile{}
+	if e := json.Unmarshal(b, &op); e != nil {
+		return e
 	}
+	*o = OrchestratorProfile(op)
 
+	// Unmarshal OrchestratorType, format it as well
+	orchestratorType := o.OrchestratorType
+	switch {
+	case strings.EqualFold(orchestratorType, DCOS):
+		o.OrchestratorType = DCOS
+	case strings.EqualFold(orchestratorType, Swarm):
+		o.OrchestratorType = Swarm
+	case strings.EqualFold(orchestratorType, Mesos):
+		o.OrchestratorType = Mesos
+	default:
+		return fmt.Errorf("OrchestratorType has unknown orchestrator: %s", orchestratorType)
+	}
 	return nil
 }
 

--- a/pkg/api/v20160930/const.go
+++ b/pkg/api/v20160930/const.go
@@ -8,13 +8,13 @@ const (
 // the orchestrators supported by 2016-09-30
 const (
 	// Mesos is the string constant for the Mesos orchestrator type
-	Mesos OrchestratorType = "Mesos"
+	Mesos string = "Mesos"
 	// DCOS is the string constant for DCOS orchestrator type and defaults to DCOS187
-	DCOS OrchestratorType = "DCOS"
+	DCOS string = "DCOS"
 	// Swarm is the string constant for the Swarm orchestrator type
-	Swarm OrchestratorType = "Swarm"
+	Swarm string = "Swarm"
 	// Kubernetes is the string constant for the Kubernetes orchestrator type
-	Kubernetes OrchestratorType = "Kubernetes"
+	Kubernetes string = "Kubernetes"
 )
 
 const (

--- a/pkg/api/v20160930/types.go
+++ b/pkg/api/v20160930/types.go
@@ -96,7 +96,7 @@ const (
 
 // OrchestratorProfile contains Orchestrator properties
 type OrchestratorProfile struct {
-	OrchestratorType OrchestratorType `json:"orchestratorType"`
+	OrchestratorType string `json:"orchestratorType"`
 }
 
 // MasterProfile represents the definition of master cluster
@@ -207,26 +207,31 @@ type VMDiagnostics struct {
 	StorageURL *neturl.URL `json:"storageUrl"`
 }
 
-// OrchestratorType defines orchestrators supported by ACS
-type OrchestratorType string
-
-// UnmarshalText decodes OrchestratorType text, do a case insensitive comparison with
-// the defined OrchestratorType constant and set to it if they equal
-func (o *OrchestratorType) UnmarshalText(text []byte) error {
-	s := string(text)
-	switch {
-	case strings.EqualFold(s, string(DCOS)):
-		*o = DCOS
-	case strings.EqualFold(s, string(Mesos)):
-		*o = Mesos
-	case strings.EqualFold(s, string(Swarm)):
-		*o = Swarm
-	case strings.EqualFold(s, string(Kubernetes)):
-		*o = Kubernetes
-	default:
-		return fmt.Errorf("OrchestratorType has unknown orchestrator: %s", s)
+// UnmarshalJSON unmarshal json using the default behavior
+// And do fields manipulation, such as populating default value
+func (o *OrchestratorProfile) UnmarshalJSON(b []byte) error {
+	// Need to have a alias type to avoid circular unmarshal
+	type aliasOrchestratorProfile OrchestratorProfile
+	op := aliasOrchestratorProfile{}
+	if e := json.Unmarshal(b, &op); e != nil {
+		return e
 	}
+	*o = OrchestratorProfile(op)
 
+	// Unmarshal OrchestratorType, format it as well
+	orchestratorType := o.OrchestratorType
+	switch {
+	case strings.EqualFold(orchestratorType, DCOS):
+		o.OrchestratorType = DCOS
+	case strings.EqualFold(orchestratorType, Swarm):
+		o.OrchestratorType = Swarm
+	case strings.EqualFold(orchestratorType, Kubernetes):
+		o.OrchestratorType = Kubernetes
+	case strings.EqualFold(orchestratorType, Mesos):
+		o.OrchestratorType = Mesos
+	default:
+		return fmt.Errorf("OrchestratorType has unknown orchestrator: %s", orchestratorType)
+	}
 	return nil
 }
 

--- a/pkg/api/v20160930/validate.go
+++ b/pkg/api/v20160930/validate.go
@@ -35,7 +35,7 @@ func (m *MasterProfile) Validate() error {
 }
 
 // Validate implements APIObject
-func (a *AgentPoolProfile) Validate(orchestratorType OrchestratorType) error {
+func (a *AgentPoolProfile) Validate(orchestratorType string) error {
 	if e := validateName(a.Name, "AgentPoolProfile.Name"); e != nil {
 		return e
 	}

--- a/pkg/api/v20170131/const.go
+++ b/pkg/api/v20170131/const.go
@@ -8,15 +8,15 @@ const (
 // the orchestrators supported by 2017-01-31
 const (
 	// Mesos is the string constant for the Mesos orchestrator type
-	Mesos OrchestratorType = "Mesos"
+	Mesos string = "Mesos"
 	// DCOS is the string constant for DCOS orchestrator type and defaults to DCOS187
-	DCOS OrchestratorType = "DCOS"
+	DCOS string = "DCOS"
 	// Swarm is the string constant for the Swarm orchestrator type
-	Swarm OrchestratorType = "Swarm"
+	Swarm string = "Swarm"
 	// Kubernetes is the string constant for the Kubernetes orchestrator type
-	Kubernetes OrchestratorType = "Kubernetes"
+	Kubernetes string = "Kubernetes"
 	// SwarmMode is the string constant for the Swarm Mode orchestrator type
-	SwarmMode OrchestratorType = "SwarmMode"
+	SwarmMode string = "SwarmMode"
 )
 
 const (

--- a/pkg/api/v20170131/types.go
+++ b/pkg/api/v20170131/types.go
@@ -96,7 +96,7 @@ const (
 
 // OrchestratorProfile contains Orchestrator properties
 type OrchestratorProfile struct {
-	OrchestratorType OrchestratorType `json:"orchestratorType"`
+	OrchestratorType string `json:"orchestratorType"`
 }
 
 // MasterProfile represents the definition of master cluster
@@ -207,28 +207,33 @@ type VMDiagnostics struct {
 	StorageURL *neturl.URL `json:"storageUrl"`
 }
 
-// OrchestratorType defines orchestrators supported by ACS
-type OrchestratorType string
-
-// UnmarshalText decodes OrchestratorType text, do a case insensitive comparison with
-// the defined OrchestratorType constant and set to it if they equal
-func (o *OrchestratorType) UnmarshalText(text []byte) error {
-	s := string(text)
-	switch {
-	case strings.EqualFold(s, string(DCOS)):
-		*o = DCOS
-	case strings.EqualFold(s, string(Mesos)):
-		*o = Mesos
-	case strings.EqualFold(s, string(Swarm)):
-		*o = Swarm
-	case strings.EqualFold(s, string(Kubernetes)):
-		*o = Kubernetes
-	case strings.EqualFold(s, string(SwarmMode)):
-		*o = SwarmMode
-	default:
-		return fmt.Errorf("OrchestratorType has unknown orchestrator: %s", s)
+// UnmarshalJSON unmarshal json using the default behavior
+// And do fields manipulation, such as populating default value
+func (o *OrchestratorProfile) UnmarshalJSON(b []byte) error {
+	// Need to have a alias type to avoid circular unmarshal
+	type aliasOrchestratorProfile OrchestratorProfile
+	op := aliasOrchestratorProfile{}
+	if e := json.Unmarshal(b, &op); e != nil {
+		return e
 	}
+	*o = OrchestratorProfile(op)
 
+	// Unmarshal OrchestratorType, format it as well
+	orchestratorType := o.OrchestratorType
+	switch {
+	case strings.EqualFold(orchestratorType, DCOS):
+		o.OrchestratorType = DCOS
+	case strings.EqualFold(orchestratorType, Swarm):
+		o.OrchestratorType = Swarm
+	case strings.EqualFold(orchestratorType, Kubernetes):
+		o.OrchestratorType = Kubernetes
+	case strings.EqualFold(orchestratorType, Mesos):
+		o.OrchestratorType = Mesos
+	case strings.EqualFold(orchestratorType, SwarmMode):
+		o.OrchestratorType = SwarmMode
+	default:
+		return fmt.Errorf("OrchestratorType has unknown orchestrator: %s", orchestratorType)
+	}
 	return nil
 }
 

--- a/pkg/api/v20170131/validate.go
+++ b/pkg/api/v20170131/validate.go
@@ -36,7 +36,7 @@ func (m *MasterProfile) Validate() error {
 }
 
 // Validate implements APIObject
-func (a *AgentPoolProfile) Validate(orchestratorType OrchestratorType) error {
+func (a *AgentPoolProfile) Validate(orchestratorType string) error {
 	if e := validateName(a.Name, "AgentPoolProfile.Name"); e != nil {
 		return e
 	}

--- a/pkg/api/v20170701/const.go
+++ b/pkg/api/v20170701/const.go
@@ -8,13 +8,13 @@ const (
 // the orchestrators supported by 2017-07-01
 const (
 	// DCOS is the string constant for DCOS orchestrator type and defaults to DCOS187
-	DCOS OrchestratorType = "DCOS"
+	DCOS string = "DCOS"
 	// Swarm is the string constant for the Swarm orchestrator type
-	Swarm OrchestratorType = "Swarm"
+	Swarm string = "Swarm"
 	// Kubernetes is the string constant for the Kubernetes orchestrator type
-	Kubernetes OrchestratorType = "Kubernetes"
+	Kubernetes string = "Kubernetes"
 	// DockerCE is the string constant for the Docker CE orchestrator type
-	DockerCE OrchestratorType = "DockerCE"
+	DockerCE string = "DockerCE"
 )
 
 const (
@@ -48,30 +48,30 @@ const (
 
 const (
 	// DCOS190 is the string constant for DCOS 1.9.0
-	DCOS190 OrchestratorVersion = "1.9.0"
+	DCOS190 string = "1.9.0"
 	// DCOS188 is the string constant for DCOS 1.8.8
-	DCOS188 OrchestratorVersion = "1.8.8"
+	DCOS188 string = "1.8.8"
 	// DCOS187 is the string constant for DCOS 1.8.7
-	DCOS187 OrchestratorVersion = "1.8.7"
+	DCOS187 string = "1.8.7"
 	// DCOS184 is the string constant for DCOS 1.8.4
-	DCOS184 OrchestratorVersion = "1.8.4"
+	DCOS184 string = "1.8.4"
 	// DCOS173 is the string constant for DCOS 1.7.3
-	DCOS173 OrchestratorVersion = "1.7.3"
+	DCOS173 string = "1.7.3"
 	// DCOSLatest is the string constant for latest DCOS version
-	DCOSLatest OrchestratorVersion = DCOS190
+	DCOSLatest string = DCOS190
 )
 
 const (
 	// Kubernetes153 is the string constant for Kubernetes 1.5.3
-	Kubernetes153 OrchestratorVersion = "1.5.3"
+	Kubernetes153 string = "1.5.3"
 	// Kubernetes157 is the string constant for Kubernetes 1.5.3
-	Kubernetes157 OrchestratorVersion = "1.5.7"
+	Kubernetes157 string = "1.5.7"
 	// Kubernetes160 is the string constant for Kubernetes 1.6.0
-	Kubernetes160 OrchestratorVersion = "1.6.0"
+	Kubernetes160 string = "1.6.0"
 	// Kubernetes162 is the string constant for Kubernetes 1.6.2
-	Kubernetes162 OrchestratorVersion = "1.6.2"
+	Kubernetes162 string = "1.6.2"
 	// Kubernetes166 is the string constant for Kubernetes 1.6.6
-	Kubernetes166 OrchestratorVersion = "1.6.6"
+	Kubernetes166 string = "1.6.6"
 	// KubernetesDefaultVersion is the string constant for current Kubernetes version
-	KubernetesDefaultVersion OrchestratorVersion = Kubernetes166
+	KubernetesDefaultVersion string = Kubernetes166
 )

--- a/pkg/api/v20170701/types.go
+++ b/pkg/api/v20170701/types.go
@@ -107,8 +107,8 @@ const (
 
 // OrchestratorProfile contains Orchestrator properties
 type OrchestratorProfile struct {
-	OrchestratorType    OrchestratorType    `json:"orchestratorType" validate:"required"`
-	OrchestratorVersion OrchestratorVersion `json:"orchestratorVersion"`
+	OrchestratorType    string `json:"orchestratorType" validate:"required"`
+	OrchestratorVersion string `json:"orchestratorVersion"`
 }
 
 // MasterProfile represents the definition of master cluster
@@ -215,29 +215,31 @@ func (a *AgentPoolProfile) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// OrchestratorType defines orchestrators supported by ACS
-type OrchestratorType string
-
-// OrchestratorVersion defines the version for orchestratorType
-type OrchestratorVersion string
-
-// UnmarshalText decodes OrchestratorType text, do a case insensitive comparison with
-// the defined OrchestratorType constant and set to it if they equal
-func (o *OrchestratorType) UnmarshalText(text []byte) error {
-	s := string(text)
-	switch {
-	case strings.EqualFold(s, string(DCOS)):
-		*o = DCOS
-	case strings.EqualFold(s, string(Kubernetes)):
-		*o = Kubernetes
-	case strings.EqualFold(s, string(Swarm)):
-		*o = Swarm
-	case strings.EqualFold(s, string(DockerCE)):
-		*o = DockerCE
-	default:
-		return fmt.Errorf("OrchestratorType has unknown orchestrator: %s", s)
+// UnmarshalJSON unmarshal json using the default behavior
+// And do fields manipulation, such as populating default value
+func (o *OrchestratorProfile) UnmarshalJSON(b []byte) error {
+	// Need to have a alias type to avoid circular unmarshal
+	type aliasOrchestratorProfile OrchestratorProfile
+	op := aliasOrchestratorProfile{}
+	if e := json.Unmarshal(b, &op); e != nil {
+		return e
 	}
+	*o = OrchestratorProfile(op)
 
+	// Unmarshal OrchestratorType, format it as well
+	orchestratorType := o.OrchestratorType
+	switch {
+	case strings.EqualFold(orchestratorType, DCOS):
+		o.OrchestratorType = DCOS
+	case strings.EqualFold(orchestratorType, Kubernetes):
+		o.OrchestratorType = Kubernetes
+	case strings.EqualFold(orchestratorType, Swarm):
+		o.OrchestratorType = Swarm
+	case strings.EqualFold(orchestratorType, DockerCE):
+		o.OrchestratorType = DockerCE
+	default:
+		return fmt.Errorf("OrchestratorType has unknown orchestrator: %s", orchestratorType)
+	}
 	return nil
 }
 

--- a/pkg/api/v20170701/validate.go
+++ b/pkg/api/v20170701/validate.go
@@ -63,7 +63,7 @@ func (m *MasterProfile) Validate() error {
 }
 
 // Validate implements APIObject
-func (a *AgentPoolProfile) Validate(orchestratorType OrchestratorType) error {
+func (a *AgentPoolProfile) Validate(orchestratorType string) error {
 	// Don't need to call validate.Struct(a)
 	// It is handled by Properties.Validate()
 	if e := validatePoolName(a.Name); e != nil {

--- a/pkg/api/vlabs/const.go
+++ b/pkg/api/vlabs/const.go
@@ -8,13 +8,13 @@ const (
 // the orchestrators supported by vlabs
 const (
 	// DCOS is the string constant for DCOS orchestrator type and defaults to DCOS188
-	DCOS OrchestratorType = "DCOS"
+	DCOS string = "DCOS"
 	// Swarm is the string constant for the Swarm orchestrator type
-	Swarm OrchestratorType = "Swarm"
+	Swarm string = "Swarm"
 	// Kubernetes is the string constant for the Kubernetes orchestrator type
-	Kubernetes OrchestratorType = "Kubernetes"
+	Kubernetes string = "Kubernetes"
 	// SwarmMode is the string constant for the Swarm Mode orchestrator type
-	SwarmMode OrchestratorType = "SwarmMode"
+	SwarmMode string = "SwarmMode"
 )
 
 // the OSTypes supported by vlabs
@@ -68,36 +68,36 @@ var (
 
 const (
 	// DCOS190 is the string constant for DCOS 1.9.0
-	DCOS190 OrchestratorVersion = "1.9.0"
+	DCOS190 string = "1.9.0"
 	// DCOS188 is the string constant for DCOS 1.8.8
-	DCOS188 OrchestratorVersion = "1.8.8"
+	DCOS188 string = "1.8.8"
 	// DCOS187 is the string constant for DCOS 1.8.7
-	DCOS187 OrchestratorVersion = "1.8.7"
+	DCOS187 string = "1.8.7"
 	// DCOS184 is the string constant for DCOS 1.8.4
-	DCOS184 OrchestratorVersion = "1.8.4"
+	DCOS184 string = "1.8.4"
 	// DCOS173 is the string constant for DCOS 1.7.3
-	DCOS173 OrchestratorVersion = "1.7.3"
+	DCOS173 string = "1.7.3"
 	// DCOSLatest is the string constant for latest DCOS version
-	DCOSLatest OrchestratorVersion = DCOS190
+	DCOSLatest string = DCOS190
 )
 
 const (
 	// Kubernetes153 is the string constant for Kubernetes 1.5.3
-	Kubernetes153 OrchestratorVersion = "1.5.3"
+	Kubernetes153 string = "1.5.3"
 	// Kubernetes157 is the string constant for Kubernetes 1.5.7
-	Kubernetes157 OrchestratorVersion = "1.5.7"
+	Kubernetes157 string = "1.5.7"
 	// Kubernetes160 is the string constant for Kubernetes 1.6.0
-	Kubernetes160 OrchestratorVersion = "1.6.0"
+	Kubernetes160 string = "1.6.0"
 	// Kubernetes162 is the string constant for Kubernetes 1.6.2
-	Kubernetes162 OrchestratorVersion = "1.6.2"
+	Kubernetes162 string = "1.6.2"
 	// Kubernetes166 is the string constant for Kubernetes 1.6.6
-	Kubernetes166 OrchestratorVersion = "1.6.6"
+	Kubernetes166 string = "1.6.6"
 	// Kubernetes170 is the string constant for Kubernetes 1.7.0
-	Kubernetes170 OrchestratorVersion = "1.7.0"
+	Kubernetes170 string = "1.7.0"
 	// Kubernetes171 is the string constant for Kubernetes 1.7.1
-	Kubernetes171 OrchestratorVersion = "1.7.1"
+	Kubernetes171 string = "1.7.1"
 	// KubernetesLatest is the string constant for latest Kubernetes version
-	KubernetesLatest OrchestratorVersion = Kubernetes166
+	KubernetesLatest string = Kubernetes166
 	// KubernetesDefaultVersion is the string constant for current Kubernetes version
-	KubernetesDefaultVersion OrchestratorVersion = Kubernetes166
+	KubernetesDefaultVersion string = Kubernetes166
 )

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -92,7 +92,7 @@ func (m *MasterProfile) Validate() error {
 }
 
 // Validate implements APIObject
-func (a *AgentPoolProfile) Validate(orchestratorType OrchestratorType) error {
+func (a *AgentPoolProfile) Validate(orchestratorType string) error {
 	if e := validateName(a.Name, "AgentPoolProfile.Name"); e != nil {
 		return e
 	}
@@ -341,11 +341,11 @@ func (a *Properties) Validate() error {
 }
 
 // Validate validates the KubernetesConfig.
-func (a *KubernetesConfig) Validate(k8sVersion OrchestratorVersion) error {
+func (a *KubernetesConfig) Validate(k8sVersion string) error {
 	// number of minimum retries allowed for kubelet to post node status
 	const minKubeletRetries = 4
 	// k8s versions that have cloudprovider backoff enabled
-	var backoffEnabledVersions = map[OrchestratorVersion]bool{
+	var backoffEnabledVersions = map[string]bool{
 		Kubernetes171: true,
 		Kubernetes166: true,
 		Kubernetes170: true,

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -35,7 +35,7 @@ func Test_OrchestratorProfile_Validate(t *testing.T) {
 
 func Test_KubernetesConfig_Validate(t *testing.T) {
 	// Tests that should pass across all versions
-	for _, k8sVersion := range []OrchestratorVersion{Kubernetes153, Kubernetes157, Kubernetes160, Kubernetes162, Kubernetes166, Kubernetes170, Kubernetes171} {
+	for _, k8sVersion := range []string{Kubernetes153, Kubernetes157, Kubernetes160, Kubernetes162, Kubernetes166, Kubernetes170, Kubernetes171} {
 		c := KubernetesConfig{}
 		if err := c.Validate(k8sVersion); err != nil {
 			t.Errorf("should not error on empty KubernetesConfig: %v, version %s", err, k8sVersion)
@@ -113,7 +113,7 @@ func Test_KubernetesConfig_Validate(t *testing.T) {
 	}
 
 	// Tests that apply to pre-1.6.6 versions
-	for _, k8sVersion := range []OrchestratorVersion{Kubernetes153, Kubernetes157, Kubernetes160, Kubernetes162} {
+	for _, k8sVersion := range []string{Kubernetes153, Kubernetes157, Kubernetes160, Kubernetes162} {
 		c := KubernetesConfig{
 			CloudProviderBackoff:   true,
 			CloudProviderRateLimit: true,
@@ -124,7 +124,7 @@ func Test_KubernetesConfig_Validate(t *testing.T) {
 	}
 
 	// Tests that apply to 1.6.6 and later versions
-	for _, k8sVersion := range []OrchestratorVersion{Kubernetes166, Kubernetes170, Kubernetes171} {
+	for _, k8sVersion := range []string{Kubernetes166, Kubernetes170, Kubernetes171} {
 		c := KubernetesConfig{
 			CloudProviderBackoff:   true,
 			CloudProviderRateLimit: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
To fix #921, i need to lay out things a little bit. I noticed, OrchestratorType, OrchestratorVersion are defined as custom type. If i want to add OrchestratorVersionHint, won't it be another custom type? I don't think so. They could all be strings. Avoid unnecessary types. This is not fully solved issue #921. But it can be checked in independently, without any behavior change.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: relates #921 

**Special notes for your reviewer**:
Ready to review
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1094)
<!-- Reviewable:end -->
