### PR TITLE
use validate tag for vlab version as well

### DIFF
--- a/pkg/api/v20170701/validate.go
+++ b/pkg/api/v20170701/validate.go
@@ -114,10 +114,11 @@ func handleValidationErrors(e validator.ValidationErrors) error {
 	err := e[0]
 	ns := err.Namespace()
 	switch ns {
-	case "Properties.OrchestratorProfile", "Properties.MasterProfile",
+	case "Properties.OrchestratorProfile", "Properties.OrchestratorProfile.OrchestratorType",
+		"Properties.MasterProfile",
 		"Properties.MasterProfile.DNSPrefix", "Properties.MasterProfile.VMSize",
 		"Properties.LinuxProfile", "Properties.ServicePrincipalProfile.ClientID",
-		"Properties.ServicePrincipalProfile.Secret", "Properties.WindowsProfile.AdminUsername",
+		"Properties.WindowsProfile.AdminUsername",
 		"Properties.WindowsProfile.AdminPassword":
 		return fmt.Errorf("missing %s", ns)
 	case "Properties.MasterProfile.Count":

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -31,10 +31,10 @@ type ContainerService struct {
 // Properties represents the ACS cluster definition
 type Properties struct {
 	ProvisioningState       ProvisioningState        `json:"provisioningState,omitempty"`
-	OrchestratorProfile     *OrchestratorProfile     `json:"orchestratorProfile,omitempty"`
-	MasterProfile           *MasterProfile           `json:"masterProfile,omitempty"`
-	AgentPoolProfiles       []*AgentPoolProfile      `json:"agentPoolProfiles,omitempty"`
-	LinuxProfile            *LinuxProfile            `json:"linuxProfile,omitempty"`
+	OrchestratorProfile     *OrchestratorProfile     `json:"orchestratorProfile,omitempty" validate:"required"`
+	MasterProfile           *MasterProfile           `json:"masterProfile,omitempty" validate:"required"`
+	AgentPoolProfiles       []*AgentPoolProfile      `json:"agentPoolProfiles,omitempty" validate:"dive,required"`
+	LinuxProfile            *LinuxProfile            `json:"linuxProfile,omitempty" validate:"required"`
 	WindowsProfile          *WindowsProfile          `json:"windowsProfile,omitempty"`
 	ServicePrincipalProfile *ServicePrincipalProfile `json:"servicePrincipalProfile,omitempty"`
 	CertificateProfile      *CertificateProfile      `json:"certificateProfile,omitempty"`
@@ -88,10 +88,10 @@ type CertificateProfile struct {
 
 // LinuxProfile represents the linux parameters passed to the cluster
 type LinuxProfile struct {
-	AdminUsername string `json:"adminUsername"`
+	AdminUsername string `json:"adminUsername" validate:"required"`
 	SSH           struct {
-		PublicKeys []PublicKey `json:"publicKeys"`
-	} `json:"ssh"`
+		PublicKeys []PublicKey `json:"publicKeys" validate:"required,len=1"`
+	} `json:"ssh" validate:"required"`
 	Secrets []KeyVaultSecrets `json:"secrets,omitempty"`
 }
 
@@ -128,7 +128,7 @@ const (
 
 // OrchestratorProfile contains Orchestrator properties
 type OrchestratorProfile struct {
-	OrchestratorType    string            `json:"orchestratorType"`
+	OrchestratorType    string            `json:"orchestratorType" validate:"required"`
 	OrchestratorVersion string            `json:"orchestratorVersion"`
 	KubernetesConfig    *KubernetesConfig `json:"kubernetesConfig,omitempty"`
 }
@@ -186,14 +186,14 @@ type KubernetesConfig struct {
 
 // MasterProfile represents the definition of the master cluster
 type MasterProfile struct {
-	Count                    int    `json:"count"`
-	DNSPrefix                string `json:"dnsPrefix"`
-	VMSize                   string `json:"vmSize"`
-	OSDiskSizeGB             int    `json:"osDiskSizeGB,omitempty"`
+	Count                    int    `json:"count" validate:"required,eq=1|eq=3|eq=5"`
+	DNSPrefix                string `json:"dnsPrefix" validate:"required"`
+	VMSize                   string `json:"vmSize" validate:"required"`
+	OSDiskSizeGB             int    `json:"osDiskSizeGB,omitempty" validate:"min=0,max=1023"`
 	VnetSubnetID             string `json:"vnetSubnetID,omitempty"`
 	FirstConsecutiveStaticIP string `json:"firstConsecutiveStaticIP,omitempty"`
-	IPAddressCount           int    `json:"ipAddressCount,omitempty"`
-	StorageProfile           string `json:"storageProfile,omitempty"`
+	IPAddressCount           int    `json:"ipAddressCount,omitempty" validate:"min=0,max=256"`
+	StorageProfile           string `json:"storageProfile,omitempty" validate:"eq=StorageAccount|eq=ManagedDisks|len=0"`
 	HttpSourceAddressPrefix  string `json:"httpSourceAddressPrefix,omitempty"`
 	OAuthEnabled             bool   `json:"oauthEnabled"`
 
@@ -211,18 +211,18 @@ type ClassicAgentPoolProfileType string
 
 // AgentPoolProfile represents an agent pool definition
 type AgentPoolProfile struct {
-	Name                string `json:"name"`
-	Count               int    `json:"count"`
-	VMSize              string `json:"vmSize"`
-	OSDiskSizeGB        int    `json:"osDiskSizeGB,omitempty"`
+	Name                string `json:"name" validate:"required"`
+	Count               int    `json:"count" validate:"required,min=1,max=100"`
+	VMSize              string `json:"vmSize" validate:"required"`
+	OSDiskSizeGB        int    `json:"osDiskSizeGB,omitempty" validate:"min=0,max=1023"`
 	DNSPrefix           string `json:"dnsPrefix,omitempty"`
 	OSType              OSType `json:"osType,omitempty"`
-	Ports               []int  `json:"ports,omitempty"`
+	Ports               []int  `json:"ports,omitempty" validate:"dive,min=1,max=65535"`
 	AvailabilityProfile string `json:"availabilityProfile"`
-	StorageProfile      string `json:"storageProfile"`
-	DiskSizesGB         []int  `json:"diskSizesGB,omitempty"`
+	StorageProfile      string `json:"storageProfile" validate:"eq=StorageAccount|eq=ManagedDisks|len=0"`
+	DiskSizesGB         []int  `json:"diskSizesGB,omitempty" validate:"max=4,dive,min=1,max=1023"`
 	VnetSubnetID        string `json:"vnetSubnetID,omitempty"`
-	IPAddressCount      int    `json:"ipAddressCount,omitempty"`
+	IPAddressCount      int    `json:"ipAddressCount,omitempty" validate:"min=0,max=256"`
 
 	// subnet is internal
 	subnet string

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -6,12 +6,19 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"strings"
 	"time"
+
+	validator "gopkg.in/go-playground/validator.v9"
 )
 
-var keyvaultSecretPathRegex *regexp.Regexp
+var (
+	validate                *validator.Validate
+	keyvaultSecretPathRegex *regexp.Regexp
+)
 
 func init() {
+	validate = validator.New()
 	keyvaultSecretPathRegex = regexp.MustCompile(`^(/subscriptions/\S+/resourceGroups/\S+/providers/Microsoft.KeyVault/vaults/\S+)/secrets/([^/\s]+)(/(\S+))?$`)
 }
 
@@ -67,25 +74,7 @@ func (o *OrchestratorProfile) Validate() error {
 
 // Validate implements APIObject
 func (m *MasterProfile) Validate() error {
-	if m.Count != 1 && m.Count != 3 && m.Count != 5 {
-		return fmt.Errorf("MasterProfile count needs to be 1, 3, or 5")
-	}
-	if e := validateName(m.DNSPrefix, "MasterProfile.DNSPrefix"); e != nil {
-		return e
-	}
 	if e := validateDNSName(m.DNSPrefix); e != nil {
-		return e
-	}
-	if e := validateName(m.VMSize, "MasterProfile.VMSize"); e != nil {
-		return e
-	}
-	if m.OSDiskSizeGB != 0 && (m.OSDiskSizeGB < MinDiskSizeGB || m.OSDiskSizeGB > MaxDiskSizeGB) {
-		return fmt.Errorf("Invalid master os disk size of %d specified.  The range of valid values are [%d, %d]", m.OSDiskSizeGB, MinDiskSizeGB, MaxDiskSizeGB)
-	}
-	if m.IPAddressCount != 0 && (m.IPAddressCount < MinIPAddressCount || m.IPAddressCount > MaxIPAddressCount) {
-		return fmt.Errorf("MasterProfile.IPAddressCount needs to be in the range [%d,%d]", MinIPAddressCount, MaxIPAddressCount)
-	}
-	if e := validateStorageProfile(m.StorageProfile); e != nil {
 		return e
 	}
 	return nil
@@ -93,21 +82,22 @@ func (m *MasterProfile) Validate() error {
 
 // Validate implements APIObject
 func (a *AgentPoolProfile) Validate(orchestratorType string) error {
-	if e := validateName(a.Name, "AgentPoolProfile.Name"); e != nil {
-		return e
-	}
+	// Don't need to call validate.Struct(a)
+	// It is handled by Properties.Validate()
 	if e := validatePoolName(a.Name); e != nil {
 		return e
 	}
-	if a.Count < MinAgentCount || a.Count > MaxAgentCount {
-		return fmt.Errorf("AgentPoolProfile count needs to be in the range [%d,%d]", MinAgentCount, MaxAgentCount)
+
+	// for Kubernetes, we don't support AgentPoolProfile.DNSPrefix
+	if orchestratorType == Kubernetes {
+		if e := validate.Var(a.DNSPrefix, "len=0"); e != nil {
+			return fmt.Errorf("AgentPoolProfile.DNSPrefix must be empty for Kubernetes")
+		}
+		if e := validate.Var(a.Ports, "len=0"); e != nil {
+			return fmt.Errorf("AgentPoolProfile.Ports must be empty for Kubernetes")
+		}
 	}
-	if e := validateName(a.VMSize, "AgentPoolProfile.VMSize"); e != nil {
-		return e
-	}
-	if a.OSDiskSizeGB != 0 && (a.OSDiskSizeGB < MinDiskSizeGB || a.OSDiskSizeGB > MaxDiskSizeGB) {
-		return fmt.Errorf("Invalid os disk size of %d specified.  The range of valid values are [%d, %d]", a.OSDiskSizeGB, MinDiskSizeGB, MaxDiskSizeGB)
-	}
+
 	if a.DNSPrefix != "" {
 		if e := validateDNSName(a.DNSPrefix); e != nil {
 			return e
@@ -116,54 +106,28 @@ func (a *AgentPoolProfile) Validate(orchestratorType string) error {
 			if e := validateUniquePorts(a.Ports, a.Name); e != nil {
 				return e
 			}
-			for _, port := range a.Ports {
-				if port < MinPort || port > MaxPort {
-					return fmt.Errorf("AgentPoolProfile Ports must be in the range[%d, %d]", MinPort, MaxPort)
-				}
-			}
 		} else {
 			a.Ports = []int{80, 443, 8080}
 		}
 	} else {
-		if len(a.Ports) > 0 {
-			return fmt.Errorf("AgentPoolProfile.Ports must be empty when AgentPoolProfile.DNSPrefix is empty")
-		}
-	}
-
-	// for Kubernetes, we don't support AgentPoolProfile.DNSPrefix
-	if orchestratorType == Kubernetes {
-		if e := validateNameEmpty(a.DNSPrefix, "AgentPoolProfile.DNSPrefix"); e != nil {
-			return e
+		if e := validate.Var(a.Ports, "len=0"); e != nil {
+			return fmt.Errorf("AgentPoolProfile.Ports must be empty when AgentPoolProfile.DNSPrefix is empty for Orchestrator: %s", string(orchestratorType))
 		}
 	}
 
 	if len(a.DiskSizesGB) > 0 {
-		if len(a.StorageProfile) == 0 {
+		if e := validate.Var(a.StorageProfile, "eq=StorageAccount|eq=ManagedDisks"); e != nil {
 			return fmt.Errorf("property 'StorageProfile' must be set to either '%s' or '%s' when attaching disks", StorageAccount, ManagedDisks)
 		}
-		if len(a.AvailabilityProfile) == 0 {
+		if e := validate.Var(a.AvailabilityProfile, "eq=VirtualMachineScaleSets|eq=AvailabilitySet"); e != nil {
 			return fmt.Errorf("property 'AvailabilityProfile' must be set to either '%s' or '%s' when attaching disks", VirtualMachineScaleSets, AvailabilitySet)
 		}
 		if a.StorageProfile == StorageAccount && (a.AvailabilityProfile == VirtualMachineScaleSets) {
 			return fmt.Errorf("VirtualMachineScaleSets does not support storage account attached disks.  Instead specify 'StorageAccount': '%s' or specify AvailabilityProfile '%s'", ManagedDisks, AvailabilitySet)
 		}
 	}
-	for _, s := range a.DiskSizesGB {
-		if s < MinDiskSizeGB || s > MaxDiskSizeGB {
-			return fmt.Errorf("Invalid disk size %d specified for cluster cluster named '%s'.  The range of valid values are [%d, %d]", s, a.Name, MinDiskSizeGB, MaxDiskSizeGB)
-		}
-	}
-	if len(a.DiskSizesGB) > MaxDisks {
-		return fmt.Errorf("A maximum of %d disks may be specified.  %d disks were specified for cluster named '%s'", MaxDisks, len(a.DiskSizesGB), a.Name)
-	}
 	if len(a.Ports) == 0 && len(a.DNSPrefix) > 0 {
 		return fmt.Errorf("AgentPoolProfile.Ports must be non empty when AgentPoolProfile.DNSPrefix is specified")
-	}
-	if a.IPAddressCount != 0 && (a.IPAddressCount < MinIPAddressCount || a.IPAddressCount > MaxIPAddressCount) {
-		return fmt.Errorf("AgentPoolProfile.IPAddressCount needs to be in the range [%d,%d]", MinIPAddressCount, MaxIPAddressCount)
-	}
-	if e := validateStorageProfile(a.StorageProfile); e != nil {
-		return e
 	}
 	return nil
 }
@@ -193,14 +157,10 @@ func validateKeyVaultSecrets(secrets []KeyVaultSecrets, requireCertificateStore 
 
 // Validate implements APIObject
 func (l *LinuxProfile) Validate() error {
-	if e := validateName(l.AdminUsername, "LinuxProfile.AdminUsername"); e != nil {
-		return e
-	}
-	if len(l.SSH.PublicKeys) != 1 {
-		return errors.New("LinuxProfile.PublicKeys requires only 1 SSH Key")
-	}
-	if e := validateName(l.SSH.PublicKeys[0].KeyData, "LinuxProfile.PublicKeys.KeyData"); e != nil {
-		return e
+	// Don't need to call validate.Struct(l)
+	// It is handled by Properties.Validate()
+	if e := validate.Var(l.SSH.PublicKeys[0].KeyData, "required"); e != nil {
+		return fmt.Errorf("KeyData in LinuxProfile.SSH.PublicKeys cannot be empty string")
 	}
 	if e := validateKeyVaultSecrets(l.Secrets, false); e != nil {
 		return e
@@ -208,16 +168,52 @@ func (l *LinuxProfile) Validate() error {
 	return nil
 }
 
+func handleValidationErrors(e validator.ValidationErrors) error {
+	err := e[0]
+	ns := err.Namespace()
+	switch ns {
+	case "Properties.OrchestratorProfile", "Properties.OrchestratorProfile.OrchestratorType",
+		"Properties.MasterProfile", "Properties.MasterProfile.DNSPrefix", "Properties.MasterProfile.VMSize",
+		"Properties.LinuxProfile", "Properties.WindowsProfile.AdminUsername",
+		"Properties.WindowsProfile.AdminPassword":
+		return fmt.Errorf("missing %s", ns)
+	case "Properties.MasterProfile.Count":
+		return fmt.Errorf("MasterProfile count needs to be 1, 3, or 5")
+	case "Properties.MasterProfile.OSDiskSizeGB":
+		return fmt.Errorf("Invalid os disk size of %d specified.  The range of valid values are [%d, %d]", err.Value().(int), MinDiskSizeGB, MaxDiskSizeGB)
+	case "Properties.MasterProfile.IPAddressCount":
+		return fmt.Errorf("MasterProfile.IPAddressCount needs to be in the range [%d,%d]", MinIPAddressCount, MaxIPAddressCount)
+	case "Properties.MasterProfile.StorageProfile":
+		return fmt.Errorf("Unknown storageProfile '%s'. Specify either %s or %s", err.Value().(string), StorageAccount, ManagedDisks)
+	default:
+		if strings.HasPrefix(ns, "Properties.AgentPoolProfiles") {
+			switch {
+			case strings.HasSuffix(ns, ".Name") || strings.HasSuffix(ns, "VMSize"):
+				return fmt.Errorf("missing %s", ns)
+			case strings.HasSuffix(ns, ".Count"):
+				return fmt.Errorf("AgentPoolProfile count needs to be in the range [%d,%d]", MinAgentCount, MaxAgentCount)
+			case strings.HasSuffix(ns, ".OSDiskSizeGB"):
+				return fmt.Errorf("Invalid os disk size of %d specified.  The range of valid values are [%d, %d]", err.Value().(int), MinDiskSizeGB, MaxDiskSizeGB)
+			case strings.Contains(ns, ".Ports"):
+				return fmt.Errorf("AgentPoolProfile Ports must be in the range[%d, %d]", MinPort, MaxPort)
+			case strings.HasSuffix(ns, ".StorageProfile"):
+				return fmt.Errorf("Unknown storageProfile '%s'. Specify either %s or %s", err.Value().(string), StorageAccount, ManagedDisks)
+			case strings.Contains(ns, ".DiskSizesGB"):
+				return fmt.Errorf("A maximum of %d disks may be specified, The range of valid disk size values are [%d, %d]", MaxDisks, MinDiskSizeGB, MaxDiskSizeGB)
+			case strings.HasSuffix(ns, ".IPAddressCount"):
+				return fmt.Errorf("AgentPoolProfile.IPAddressCount needs to be in the range [%d,%d]", MinIPAddressCount, MaxIPAddressCount)
+			default:
+				break
+			}
+		}
+	}
+	return fmt.Errorf("Namespace %s is not caught, %+v", ns, e)
+}
+
 // Validate implements APIObject
 func (a *Properties) Validate() error {
-	if a.OrchestratorProfile == nil {
-		return fmt.Errorf("missing OrchestratorProfile")
-	}
-	if a.MasterProfile == nil {
-		return fmt.Errorf("missing MasterProfile")
-	}
-	if a.LinuxProfile == nil {
-		return fmt.Errorf("missing LinuxProfile")
+	if e := validate.Struct(a); e != nil {
+		return handleValidationErrors(e.(validator.ValidationErrors))
 	}
 	if e := a.OrchestratorProfile.Validate(); e != nil {
 		return e
@@ -237,10 +233,9 @@ func (a *Properties) Validate() error {
 			a.OrchestratorProfile.KubernetesConfig.UseManagedIdentity)
 
 		if !useManagedIdentity {
-			if len(a.ServicePrincipalProfile.ClientID) == 0 {
+			if e := validate.Var(a.ServicePrincipalProfile.ClientID, "required"); e != nil {
 				return fmt.Errorf("the service principal client ID must be specified with Orchestrator %s", a.OrchestratorProfile.OrchestratorType)
 			}
-
 			if (len(a.ServicePrincipalProfile.Secret) == 0 && len(a.ServicePrincipalProfile.KeyvaultSecretRef) == 0) ||
 				(len(a.ServicePrincipalProfile.Secret) != 0 && len(a.ServicePrincipalProfile.KeyvaultSecretRef) != 0) {
 				return fmt.Errorf("either the service principal client secret or keyvault secret reference must be specified with Orchestrator %s", a.OrchestratorProfile.OrchestratorType)
@@ -268,17 +263,8 @@ func (a *Properties) Validate() error {
 				return fmt.Errorf("unknown availability profile type '%s' for agent pool '%s'.  Specify either %s, or %s", agentPoolProfile.AvailabilityProfile, agentPoolProfile.Name, AvailabilitySet, VirtualMachineScaleSets)
 			}
 		}
-		switch agentPoolProfile.StorageProfile {
-		case StorageAccount:
-		case ManagedDisks:
-		case "":
-		default:
-			{
-				return fmt.Errorf("unknown storage type '%s' for agent pool '%s'.  Specify either %s, or %s", agentPoolProfile.StorageProfile, agentPoolProfile.Name, StorageAccount, ManagedDisks)
-			}
-		}
-		/* this switch statement is left to protect newly added orchestrators until they support Managed Disks*/
 
+		/* this switch statement is left to protect newly added orchestrators until they support Managed Disks*/
 		if agentPoolProfile.StorageProfile == ManagedDisks {
 			switch a.OrchestratorProfile.OrchestratorType {
 			case DCOS:
@@ -301,12 +287,9 @@ func (a *Properties) Validate() error {
 		if a.OrchestratorProfile.OrchestratorType == Kubernetes && (agentPoolProfile.AvailabilityProfile == VirtualMachineScaleSets || len(agentPoolProfile.AvailabilityProfile) == 0) {
 			return fmt.Errorf("VirtualMachineScaleSets are not supported with Kubernetes since Kubernetes requires the ability to attach/detach disks.  To fix specify \"AvailabilityProfile\":\"%s\"", AvailabilitySet)
 		}
-		if a.OrchestratorProfile.OrchestratorType == Kubernetes && len(agentPoolProfile.DNSPrefix) > 0 {
-			return errors.New("DNSPrefix not support for agent pools in Kubernetes - Kubernetes marks its own clusters public")
-		}
 		if agentPoolProfile.OSType == Windows {
-			if a.WindowsProfile == nil {
-				return fmt.Errorf("missing WindowsProfile")
+			if e := validate.Var(a.WindowsProfile, "required"); e != nil {
+				return fmt.Errorf("WindowsProfile must not be empty since agent pool '%s' specifies windows", agentPoolProfile.Name)
 			}
 			switch a.OrchestratorProfile.OrchestratorType {
 			case Swarm:
@@ -315,16 +298,11 @@ func (a *Properties) Validate() error {
 			default:
 				return fmt.Errorf("Orchestrator %s does not support Windows", a.OrchestratorProfile.OrchestratorType)
 			}
-
-			if a.WindowsProfile == nil {
-				return fmt.Errorf("WindowsProfile must not be empty since agent pool '%s' specifies windows", agentPoolProfile.Name)
+			if e := validate.Var(a.WindowsProfile.AdminUsername, "required"); e != nil {
+				return fmt.Errorf("WindowsProfile.AdminUsername is required, when agent pool specifies windows")
 			}
-
-			if len(a.WindowsProfile.AdminUsername) == 0 {
-				return fmt.Errorf("WindowsProfile.AdminUsername must not be empty since agent pool '%s' specifies windows", agentPoolProfile.Name)
-			}
-			if len(a.WindowsProfile.AdminPassword) == 0 {
-				return fmt.Errorf("WindowsProfile.AdminPassword must not be empty since agent pool '%s' specifies windows", agentPoolProfile.Name)
+			if e := validate.Var(a.WindowsProfile.AdminPassword, "required"); e != nil {
+				return fmt.Errorf("WindowsProfile.AdminPassword is required, when agent pool specifies windows")
 			}
 			if e := validateKeyVaultSecrets(a.WindowsProfile.Secrets, true); e != nil {
 				return e
@@ -509,19 +487,6 @@ func validateUniqueProfileNames(profiles []*AgentPoolProfile) error {
 			return fmt.Errorf("profile name '%s' already exists, profile names must be unique across pools", profile.Name)
 		}
 		profileNames[profile.Name] = true
-	}
-	return nil
-}
-
-func validateStorageProfile(storageProfile string) error {
-	switch storageProfile {
-	case StorageAccount:
-	case ManagedDisks:
-	case "":
-	default:
-		{
-			return fmt.Errorf("Unknown storageProfile '%s'. Specify either %s or %s", storageProfile, StorageAccount, ManagedDisks)
-		}
 	}
 	return nil
 }

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -242,7 +242,7 @@ func getK8sDefaultProperties() *Properties {
 		LinuxProfile: &LinuxProfile{
 			AdminUsername: "azureuser",
 			SSH: struct {
-				PublicKeys []PublicKey `json:"publicKeys"`
+				PublicKeys []PublicKey `json:"publicKeys" validate:"required,len=1"`
 			}{
 				PublicKeys: []PublicKey{{
 					KeyData: "publickeydata",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Update vlab api to adopt validate tag. For #921, i will add OrchestratorVersionHint, don't want to have different validate functions for the new field. So I just convert it to use the tag approach as well.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: relates #921

**Special notes for your reviewer**:
Ready to review
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
