### PR TITLE
fix for cloud-init not properly formatting ephemeral disk

### DIFF
--- a/parts/dcoscustomdata190.t
+++ b/parts/dcoscustomdata190.t
@@ -84,6 +84,7 @@ runcmd:
   - unscd.service
 - sed -i "s/^Port 22$/Port 22\nPort 2222/1" /etc/ssh/sshd_config
 - service ssh restart 
+- /opt/azure/containers/setup_ephemeral_disk.sh
 - /opt/azure/containers/provision.sh
 - - cp
   - -p
@@ -308,5 +309,44 @@ write_files:
     #!/bin/bash
     adduser {{{adminUsername}}} docker
   path: "/opt/azure/containers/add_admin_to_docker_group.sh"
+  permissions: "0744"
+  owner: "root"
+- content: |
+    #!/bin/bash
+    # Check the partitions on /dev/sdb created by cloudinit and force a detach and
+    # reformat of the parition.  After which, all will be remounted.
+    EPHEMERAL_DISK="/dev/sdb"
+    PARTITIONS=`fdisk -l $EPHEMERAL_DISK | grep "^$EPHEMERAL_DISK" | cut -d" " -f1 | sed "s~$EPHEMERAL_DISK~~"`
+    if [ -n "$PARTITIONS" ]; then
+        for f in $PARTITIONS; do
+            df -k | grep "/dev/sdb$f"
+            if [ $? -eq 0 ]; then
+                umount -f /dev/sdb$f
+            fi
+            mkfs.ext4 /dev/sdb$f
+        done
+        mount -a
+    fi
+    # If there is a /var/tmp partition on the ephemeral disk, create a symlink such
+    # that the /var/log/mesos and /var/log/journal placed on the ephemeral disk.
+    VAR_TMP_PARTITION=`df -P /var/tmp | tail -1 | cut -d" " -f 1`
+    echo $VAR_TMP_PARTITION | grep "^$EPHEMERAL_DISK"
+    if [ $? -eq 0 ]; then
+        # Handle the /var/log/mesos directory
+        mkdir -p /var/tmp/log/mesos
+        if [ -d "/var/log/mesos" ]; then
+            cp -rp /var/log/mesos/* /var/tmp/log/mesos/
+            rm -rf /var/log/mesos
+        fi
+        ln -s /var/tmp/log/mesos /var/log/mesos
+        # Handle the /var/log/journal direcotry
+        mkdir -p /var/tmp/log/journal
+        if [ -d "/var/log/journal" ]; then
+            cp -rp /var/log/journal/* /var/tmp/log/journal/
+            rm -rf /var/log/journal
+        fi
+        ln -s /var/tmp/log/journal /var/log/journal
+    fi
+  path: "/opt/azure/containers/setup_ephemeral_disk.sh"
   permissions: "0744"
   owner: "root"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Fix for Issue #1099.  cloud-init not properly provisioning ephemeral disk.

Fixes #1099 

**Special notes for your reviewer**:  An additional script is added which corrects the disk format/mounting behavior.  Has been tested with current acs-engine/master.

**Release note**: 
```
A script that fixes ephemeral disk partitioning issues due to a bug in cloud-init on Azure ubuntu vms.
```

@anhowe @seanknox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1100)
<!-- Reviewable:end -->
