### PR TITLE
Added retries for apt-get install and systemctl enable commands for kubernetes custom script.

### DIFF
--- a/parts/kubernetesmastercustomdata.yml
+++ b/parts/kubernetesmastercustomdata.yml
@@ -304,14 +304,15 @@ runcmd:
 - sudo -u etcd rm -rf /var/lib/etcd/default
 - systemctl restart etcd
 - for i in $(seq 1 20); do curl --max-time 60 http://127.0.0.1:2379/v2/machines; [ $? -eq 0 ] && break || sleep 5; done
-- apt-get update
-- apt-get install -y apt-transport-https ca-certificates
-- for i in 1 2 3 4 5; do curl --max-time 60 -fsSL https://aptdocker.azureedge.net/gpg | apt-key add -; [ $? -eq 0 ] && break || sleep 5; done
+- retrycmd_if_failure() { for i in 1 2 3 4 5; do $@; [ $? -eq 0  ] && break || sleep 5; done ; }
+- retrycmd_if_failure apt-get update
+- retrycmd_if_failure apt-get install -y apt-transport-https ca-certificates
+- retrycmd_if_failure curl --max-time 60 -fsSL https://aptdocker.azureedge.net/gpg | apt-key add - 
 - echo "deb {{WrapAsVariable "dockerEngineDownloadRepo"}} ubuntu-xenial main" | sudo tee /etc/apt/sources.list.d/docker.list
 - "echo \"Package: docker-engine\nPin: version {{WrapAsVariable "dockerEngineVersion"}}\nPin-Priority: 550\n\" > /etc/apt/preferences.d/docker.pref"
-- apt-get update
-- apt-get install -y ebtables
-- apt-get install -y docker-engine
+- retrycmd_if_failure apt-get update
+- retrycmd_if_failure apt-get install -y ebtables
+- retrycmd_if_failure apt-get install -y docker-engine
 - systemctl restart docker
 - mkdir -p /etc/kubernetes/manifests
 - usermod -aG docker {{WrapAsVariable "username"}}

--- a/parts/kubernetesmastercustomscript.sh
+++ b/parts/kubernetesmastercustomscript.sh
@@ -241,7 +241,7 @@ function systemctlEnableAndCheck() {
     if [ $enabled -ne 0 ]
     then
         echo "$1 could not be enabled by systemctl"
-        exit 2
+        exit 5
     fi
     systemctl enable $1
 }


### PR DESCRIPTION
What this PR does / why we need it:

Added retries for apt-get install commands as well as systemctl commands for enabling services such as docker and the kubelet. Fixes #853

This is just a rebased version of #901

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1104)
<!-- Reviewable:end -->
