### PR TITLE
Add admin user to docker group on DC/OS

### DIFF
--- a/parts/dcoscustomdata190.t
+++ b/parts/dcoscustomdata190.t
@@ -118,6 +118,7 @@ runcmd:
   - --no-block
   - start
   - dcos-setup.service
+- /opt/azure/containers/add_admin_to_docker_group.sh
 write_files:
 - content: 'https://dcosio.azureedge.net/dcos/stable
 
@@ -302,4 +303,10 @@ write_files:
 - path: /var/lib/dcos/mesos-slave-common
   content: 'ATTRIBUTES_STR'
   permissions: "0644"
+  owner: "root"
+- content: |
+    #!/bin/bash
+    adduser {{{adminUsername}}} docker
+  path: "/opt/azure/containers/add_admin_to_docker_group.sh"
+  permissions: "0744"
   owner: "root"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:  Adds the admin user to the docker group on DC/OS.  Some packages in universe may require access to spinning up docker containers.

**Which issue this PR fixes** Fixes #1112 
**Special notes for your reviewer**:  This is done as a script due to issue number #1109 

**Release note**:

```
Adds admin user to the docker group, avoids the need for sudo.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1113)
<!-- Reviewable:end -->
