### PR TITLE
remove StorageProfile defaults in v20170701

### DIFF
--- a/pkg/api/v20170701/types.go
+++ b/pkg/api/v20170701/types.go
@@ -149,10 +149,9 @@ func (m *MasterProfile) UnmarshalJSON(b []byte) error {
 		m.FirstConsecutiveStaticIP = "10.240.255.5"
 	}
 
-	if m.StorageProfile == "" {
-		// if StorageProfile is missing, set to default StorageAccount
-		m.StorageProfile = StorageAccount
-	}
+	// StorageProfile
+	// DockerCE is default to ManagedDisks
+	// Other Orchestrator is default to StorageAccount
 
 	// OSDiskSizeGB is an override value. vm sizes have default OS disk sizes.
 	// If it is not set. The user should get the default for the vm size
@@ -197,10 +196,9 @@ func (a *AgentPoolProfile) UnmarshalJSON(b []byte) error {
 		a.Count = 1
 	}
 
-	if a.StorageProfile == "" {
-		// if StorageProfile is missing, set to default StorageAccount
-		a.StorageProfile = StorageAccount
-	}
+	// StorageProfile
+	// DockerCE is default to ManagedDisks
+	// Other Orchestrator is default to StorageAccount
 
 	if string(a.OSType) == "" {
 		// OSType is the operating system type for agents

--- a/pkg/api/v20170701/types.go
+++ b/pkg/api/v20170701/types.go
@@ -149,10 +149,6 @@ func (m *MasterProfile) UnmarshalJSON(b []byte) error {
 		m.FirstConsecutiveStaticIP = "10.240.255.5"
 	}
 
-	// StorageProfile
-	// DockerCE is default to ManagedDisks
-	// Other Orchestrator is default to StorageAccount
-
 	// OSDiskSizeGB is an override value. vm sizes have default OS disk sizes.
 	// If it is not set. The user should get the default for the vm size
 	return nil
@@ -195,10 +191,6 @@ func (a *AgentPoolProfile) UnmarshalJSON(b []byte) error {
 		// if AgentPoolProfile.Count is missing or 0, set it to default 1
 		a.Count = 1
 	}
-
-	// StorageProfile
-	// DockerCE is default to ManagedDisks
-	// Other Orchestrator is default to StorageAccount
 
 	if string(a.OSType) == "" {
 		// OSType is the operating system type for agents

--- a/pkg/api/v20170701/types_test.go
+++ b/pkg/api/v20170701/types_test.go
@@ -16,10 +16,6 @@ func TestMasterProfile(t *testing.T) {
 		t.Fatalf("unexpectedly detected MasterProfile.Count != 1 after unmarshal")
 	}
 
-	if !mp.IsStorageAccount() {
-		t.Fatalf("unexpectedly detected MasterProfile.StorageProfile != StorageAccount after unmarshal")
-	}
-
 	if mp.FirstConsecutiveStaticIP != "10.240.255.5" {
 		t.Fatalf("unexpectedly detected MasterProfile.FirstConsecutiveStaticIP != 10.240.255.5 after unmarshal")
 	}
@@ -39,9 +35,5 @@ func TestAgentPoolProfile(t *testing.T) {
 
 	if ap.OSType != Linux {
 		t.Fatalf("unexpectedly detected AgentPoolProfile.OSType != Linux after unmarshal")
-	}
-
-	if !ap.IsStorageAccount() {
-		t.Fatalf("unexpectedly detected AgentPoolProfile.StorageProfile != StorageAccount after unmarshal")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
DockerCE has different default setup. So remove it, so the setDefaultValue function in generateTemplate would populate the default

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1117 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1119)
<!-- Reviewable:end -->
