### PR TITLE
fix(deploy): Change SP creation logging to debug

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -196,7 +196,7 @@ func autofillApimodel(dc *deployCmd) {
 			for {
 				err = dc.client.CreateRoleAssignmentSimple(dc.resourceGroup, servicePrincipalObjectID)
 				if err != nil {
-					log.Warnf("Failed to create role assignment (will retry): %q", err)
+					log.Debugf("Failed to create role assignment (will retry): %q", err)
 					time.Sleep(3 * time.Second)
 					continue
 				}

--- a/pkg/armhelpers/graph.go
+++ b/pkg/armhelpers/graph.go
@@ -105,7 +105,7 @@ func (az *AzureClient) CreateRoleAssignmentSimple(resourceGroup, servicePrincipa
 			roleAssignmentParameters,
 		)
 		if err != nil {
-			log.Warnf("Failed to create role assignment (will retry): %q", err)
+			log.Debugf("Failed to create role assignment (will retry): %q", err)
 			time.Sleep(3 * time.Second)
 			continue
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Changes SP/AAD logging to debug, so not to scare users using `acs-engine deploy`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1120 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1121)
<!-- Reviewable:end -->
