### PR TITLE
acs-engine test housekeeping

### DIFF
--- a/test/acs-engine-test/main.go
+++ b/test/acs-engine-test/main.go
@@ -55,7 +55,7 @@ const usage = `Usage:
 
 var logDir string
 var orchestratorRe *regexp.Regexp
-var skipMetrics bool
+var enableMetrics bool
 
 func init() {
 	orchestratorRe = regexp.MustCompile(`"orchestratorType": "(\S+)"`)
@@ -337,7 +337,7 @@ func wrileLog(fname string, format string, args ...interface{}) {
 }
 
 func sendErrorMetrics(resMap map[string]*ErrorStat) {
-	if skipMetrics {
+	if !enableMetrics {
 		return
 	}
 	for _, errorStat := range resMap {
@@ -368,7 +368,7 @@ func sendErrorMetrics(resMap map[string]*ErrorStat) {
 }
 
 func sendDurationMetrics(step, location string, duration time.Duration, errorName string) {
-	if skipMetrics {
+	if !enableMetrics {
 		return
 	}
 	var metricName string
@@ -425,10 +425,9 @@ func mainInternal() error {
 		fmt.Println("Warning: BUILD_NUMBER is not set or invalid. Assuming 0")
 		buildNum = 0
 	}
-	// set environment variable SKIP_METRICS=y to disable sending the metrics.
-	// sending the metrics is enabled by default.
-	if os.Getenv("SKIP_METRICS") == "y" {
-		skipMetrics = true
+	// set environment variable ENABLE_METRICS=y to enable sending the metrics (disabled by default)
+	if os.Getenv("ENABLE_METRICS") == "y" {
+		enableMetrics = true
 	}
 	// initialize report manager
 	testManager.reportMgr = report.New(os.Getenv("JOB_BASE_NAME"), buildNum, len(testManager.config.Deployments))

--- a/test/acs-engine-test/report/report.go
+++ b/test/acs-engine-test/report/report.go
@@ -184,7 +184,6 @@ func (h *ReportMgr) CreateCombinedReport(filepath, testReportFname string) error
 	// "COMBINED_PAST_REPORTS" is the number of recent reports in the combined report
 	reports, err := strconv.Atoi(os.Getenv("COMBINED_PAST_REPORTS"))
 	if err != nil || reports <= 0 {
-		fmt.Println("Warning: COMBINED_PAST_REPORTS is not set or invalid. Ignoring")
 		return nil
 	}
 	combinedReport := h.Copy()

--- a/test/common.sh
+++ b/test/common.sh
@@ -104,7 +104,7 @@ function create_resource_group() {
 	# Create resource group if doesn't exist
 	rg=$(az group show --name="${RESOURCE_GROUP}")
 	if [ -z "$rg" ]; then
-		az group create --name="${RESOURCE_GROUP}" --location="${LOCATION}"
+		az group create --name="${RESOURCE_GROUP}" --location="${LOCATION}" --tags "type=${RESOURCE_GROUP_TAG_TYPE:-}" "now=$(date +%s)" "job=${JOB_BASE_NAME:-}" "buildno=${BUILD_NUMBER:-}"
 		sleep 3 # TODO: investigate why this is needed (eventual consistency in ARM)
 	fi
 }


### PR DESCRIPTION
 - added label to resource group, to enable auto-removal in case
   of unexpected job termination (performed by another scheduled job)
 - set the default for metrics sending to false

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1125)
<!-- Reviewable:end -->
