### PR TITLE
Obvious Makefile typo and documentation update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ GOFILES=`go list ./... | grep -v "github.com/Azure/acs-engine/vendor" | sed 's|g
 
 all: build
 
-.PHONE: generate
+.PHONY: generate
 generate:
 	go generate -v $(GOFILES)
 

--- a/docs/acsengine.md
+++ b/docs/acsengine.md
@@ -32,7 +32,7 @@ When the build process completes, verify that `acs-engine` is available, invokin
 You should see something like this:
 
 ```
-# ./acs-engine
+# ./bin/acs-engine
 ACS-Engine deploys and manages Kubernetes, Swarm Mode, and DC/OS clusters in Azure
 
 Usage:
@@ -148,7 +148,7 @@ Here is an example of how to generate a new deployment.  This example assumes yo
 
 1. Before starting ensure you have generated a valid [SSH Public/Private key pair](ssh.md#ssh-key-generation).
 2. edit [examples/kubernetes.json](../examples/kubernetes.json) and fill in the blanks.
-3. run `./acs-engine generate examples/kubernetes.json` to generate the templates in the _output/Kubernetes-UNIQUEID directory.  The UNIQUEID is a hash of your master's FQDN prefix.
+3. run `./bin/acs-engine generate examples/kubernetes.json` to generate the templates in the _output/Kubernetes-UNIQUEID directory.  The UNIQUEID is a hash of your master's FQDN prefix.
 4. now you can use the `azuredeploy.json` and `azuredeploy.parameters.json` for deployment as described in [deployment usage](../README.md#deployment-usage).
 
 # Deploying templates

--- a/docs/acsengine.zh-CN.md
+++ b/docs/acsengine.zh-CN.md
@@ -11,6 +11,10 @@
 
 上面的这段脚本在Docker容器中挂载了`acs-engine`源目录。你可以在任何熟悉的编辑器上修改这些源代码，所做的修改可以直接在Docker容器中编译和测试（本项目的持续集成系统中也采用了同样的方式）。
 
+```
+make bootstrap
+```
+
 当`devenv.{ps1,sh}`执行完毕的时候，你可以在容器中查看对应的日志，最后执行下面的脚本就可以生成`acs-engine`工具了：
 
 ```
@@ -20,7 +24,7 @@ make build
 当项目编译通过后，可以使用如下的命令来验证`acs-engine`是否正常运行：
 
 ```
-# ./acs-engine 
+# ./bin/acs-engine 
 ACS-Engine deploys and manages Kubernetes, Swarm Mode, and DC/OS clusters in Azure
 
 Usage:
@@ -134,7 +138,7 @@ ACS引擎使用json格式的[集群定义文件](clusterdefinition.md)作为输�
 
 1. 首先需要准备一个[SSH 公钥私钥对](ssh.md#ssh-key-generation).
 2. 编辑[examples/kubernetes.json](../examples/kubernetes.json)将其需要的参数配置好.
-3. 运行`./acs-engine generate examples/kubernetes.json`命令在_output/Kubernetes-UNIQUEID目录中生成对应的模板。（UNIQUEID是master节点的FQDN前缀的hash值）
+3. 运行`./bin/acs-engine generate examples/kubernetes.json`命令在_output/Kubernetes-UNIQUEID目录中生成对应的模板。（UNIQUEID是master节点的FQDN前缀的hash值）
 4. 按照README中指定的方式使用`azuredeploy.json`和`azuredeploy.parameters.json`部署容器集群 [deployment usage](../README.md#deployment-usage).
 
 # 部署方法


### PR DESCRIPTION
**What this PR does / why we need it**:
This is fix for one character typo in Makefile introduced with latest Makefile refactoring. Also since artifact ./acs-engine is now output to ./bin/acs-engine I've updated doc correspondingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1126)
<!-- Reviewable:end -->
