### PR TITLE
add addon-manager label in order to not reconcile heapster deployment

### DIFF
--- a/parts/kubernetesmasteraddons-heapster-deployment.yaml
+++ b/parts/kubernetesmasteraddons-heapster-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
   namespace: kube-system
   name: heapster
 spec:


### PR DESCRIPTION
heapster-nanny container is modifying the deployment and addon-manager is reconciling the change....

This label makes addon-manager ensure a resource of that name exists. https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/addon-manager

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1133)
<!-- Reviewable:end -->
