### PR TITLE
added fault domain and update domain labels to agent nodes

### DIFF
--- a/parts/dcosprovision.sh
+++ b/parts/dcosprovision.sh
@@ -42,3 +42,8 @@ for i in {1..300}; do
 done
 
 ROLESFILECONTENTS
+
+# add Azure update domain and fault domain attributes
+ud=$( curl -H Metadata:true "http://169.254.169.254/metadata/instance/compute/platformUpdateDomain?api-version=2017-04-02&format=text" )
+fd=$( curl -H Metadata:true "http://169.254.169.254/metadata/instance/compute/platformFaultDomain?api-version=2017-04-02&format=text" )
+echo ";azure.faultdomain:$fd;azure.updatedomain:$ud" >> /var/lib/dcos/mesos-slave-common

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -1090,6 +1090,9 @@ func getDCOSAgentCustomNodeLabels(profile *api.AgentPoolProfile) string {
 	var buf bytes.Buffer
 	var attrstring string
 	buf.WriteString("")
+	// always write MESOS_ATTRIBUTES because
+	// the provision script will add FD/UD attributes
+	// at node provisioning time
 	if len(profile.OSType) > 0 {
 		attrstring = fmt.Sprintf("MESOS_ATTRIBUTES=\"os:%s", profile.OSType)
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
adds fault domain and update domain labels to agent nodes in the same way acs already does it for k8s clusters.

fault domain labels are necessary for HA deployments of container


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes Issue [1135](https://github.com/Azure/acs-engine/issues/1135)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1139)
<!-- Reviewable:end -->
