### PR TITLE
fix(e2e): remove keyvault tests from feature validation (for now)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,8 @@ jobs:
       - run:
           name: e2e tests
           command: make bootstrap build test-e2e
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_logs
   master:
     working_directory: /go/src/github.com/Azure/acs-engine
     docker:
@@ -61,6 +63,8 @@ jobs:
       - run:
           name: Feature validation tests
           command: make bootstrap build test-e2e
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_logs
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,11 @@ jobs:
           echo 'export STAGE_TIMEOUT_MIN=30' >> $BASH_ENV
           echo 'export NUM_OF_RETRIES=2' >> $BASH_ENV
           echo 'export TEST_CONFIG=test/acse-conf/acse-feature-validation.json' >> $BASH_ENV
+          echo 'export SUBSCRIPTION_ID=${SUBSCRIPTION_ID_FEATURE_VALIDATION}' >> $BASH_ENV
+          echo 'export SERVICE_PRINCIPAL_CLIENT_ID=${SERVICE_PRINCIPAL_CLIENT_ID_FEATURE_VALIDATION}' >> $BASH_ENV
+          echo 'export SERVICE_PRINCIPAL_CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET_FEATURE_VALIDATION}' >> $BASH_ENV
+          echo 'export CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID_FEATURE_VALIDATION}' >> $BASH_ENV
+          echo 'export CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET_FEATURE_VALIDATION}' >> $BASH_ENV
       - run:
           name: Feature validation tests
           command: make bootstrap build test-e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,9 @@ workflows:
       - e2e:
           requires:
             - e2e-hold
+          filters:
+            branches:
+              ignore: /master/
       - master:
           filters:
             branches:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Microsoft Azure Container Service Engine - Builds Docker Enabled Clusters
 [![Coverage Status](https://coveralls.io/repos/github/Azure/acs-engine/badge.svg?branch=master)](https://coveralls.io/github/Azure/acs-engine?branch=master)
+[![CircleCI](https://circleci.com/gh/Azure/acs-engine/tree/master.svg?style=svg)](https://circleci.com/gh/Azure/acs-engine/tree/master)
 
 ## Overview
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,4 @@
 # Microsoft Azure Container Service Engine - Builds Docker Enabled Clusters
-[![CircleCI](https://circleci.com/gh/Azure/acs-engine/tree/master.svg?style=svg)](https://circleci.com/gh/Azure/acs-engine/tree/master)
 
 ## Overview
 

--- a/test/acse-conf/acse-feature-validation.json
+++ b/test/acse-conf/acse-feature-validation.json
@@ -57,14 +57,6 @@
       "location": "centralus"
     },
     {
-      "cluster_definition": "keyvaultcerts/swarm-windows.json",
-      "location": "westus"
-    },
-    {
-      "cluster_definition": "keyvaultcerts/swarmmode.json",
-      "location": "westus"
-    },
-    {
       "cluster_definition": "kubernetesversions/kubernetes1.5.7.json",
       "location": "centralus"
     },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: 
- we're removing keyvault tests while we refactor our e2e test runners and create necessary infra.
- don't run e2e tests (four tests) when running on master branch as we run a full 24-set feature validation suite.
- store e2e logs as test artifacts
- use a different subscription for feature validation tests
- fix CI status badge. had accidentally applied to the wrong README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1155)
<!-- Reviewable:end -->
