### PR TITLE
chore(circleci): BUILD_NUMBER should be BUILD_NUM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - checkout
       - run: |
           echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
-          echo 'export BUILD_NUMBER=${CIRCLE_BUILD_NUM}' >> $BASH_ENV
+          echo 'export BUILD_NUM=${CIRCLE_BUILD_NUM}' >> $BASH_ENV
           echo 'export RESOURCE_GROUP_PREFIX=y' >> $BASH_ENV
           echo 'export SKIP_METRICS=y' >> $BASH_ENV
           echo 'export STAGE_TIMEOUT_MIN=30' >> $BASH_ENV
@@ -49,7 +49,7 @@ jobs:
       - checkout
       - run: |
           echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
-          echo 'export BUILD_NUMBER=${CIRCLE_BUILD_NUM}' >> $BASH_ENV
+          echo 'export BUILD_NUM=${CIRCLE_BUILD_NUM}' >> $BASH_ENV
           echo 'export RESOURCE_GROUP_PREFIX=y' >> $BASH_ENV
           echo 'export SKIP_METRICS=y' >> $BASH_ENV
           echo 'export STAGE_TIMEOUT_MIN=30' >> $BASH_ENV


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: injects build number into CI run logs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1169)
<!-- Reviewable:end -->
