### PR TITLE
feat(k8s): make v1.7.2 the default version

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -68,7 +68,7 @@ const (
 	// Kubernetes172 is the string constant for Kubernetes 1.7.2
 	Kubernetes172 string = "1.7.2"
 	// KubernetesDefaultVersion is the string constant for current Kubernetes version
-	KubernetesDefaultVersion string = Kubernetes166
+	KubernetesDefaultVersion string = Kubernetes172
 )
 
 const (

--- a/pkg/api/vlabs/const.go
+++ b/pkg/api/vlabs/const.go
@@ -101,5 +101,5 @@ const (
 	// KubernetesLatest is the string constant for latest Kubernetes version
 	KubernetesLatest string = Kubernetes166
 	// KubernetesDefaultVersion is the string constant for current Kubernetes version
-	KubernetesDefaultVersion string = Kubernetes166
+	KubernetesDefaultVersion string = Kubernetes172
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This is an ask from @sauryadas and the ACS RP team.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1170 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Kubernetes v1.7.2 is now the default Kubernetes version (if version unspecified) 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1171)
<!-- Reviewable:end -->
