### PR TITLE
workaday improvements

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -276,24 +276,36 @@ func setDefaultCerts(a *api.Properties) (bool, error) {
 }
 
 func certGenerationRequired(a *api.Properties) bool {
-	if a.CertificateProfile != nil &&
-		(len(a.CertificateProfile.APIServerCertificate) > 0 || len(a.CertificateProfile.APIServerPrivateKey) > 0 ||
-			len(a.CertificateProfile.ClientCertificate) > 0 || len(a.CertificateProfile.ClientPrivateKey) > 0) {
+	if certAlreadyPresent(a.CertificateProfile) {
 		return false
 	}
 
 	switch a.OrchestratorProfile.OrchestratorType {
-	case api.DCOS:
-		return false
-	case api.Swarm:
-		return false
-	case api.SwarmMode:
-		return false
 	case api.Kubernetes:
 		return true
 	default:
 		return false
 	}
+}
+
+// certAlreadyPresent determines if the passed in CertificateProfile includes certificate data
+// TODO actually verify valid/useable certificate data
+func certAlreadyPresent(c *api.CertificateProfile) bool {
+	if c != nil {
+		switch {
+		case len(c.APIServerCertificate) > 0:
+			return true
+		case len(c.APIServerPrivateKey) > 0:
+			return true
+		case len(c.ClientCertificate) > 0:
+			return true
+		case len(c.ClientPrivateKey) > 0:
+			return true
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 // getFirstConsecutiveStaticIPAddress returns the first static IP address of the given subnet.

--- a/pkg/acsengine/defaults_test.go
+++ b/pkg/acsengine/defaults_test.go
@@ -1,0 +1,40 @@
+// +build ignore
+
+package acsengine
+
+import (
+	"testing"
+
+	"github.com/Azure/acs-engine/pkg/api"
+	. "github.com/onsi/gomega"
+)
+
+func TestCertAlreadyPresent(t *testing.T) {
+	RegisterTestingT(t)
+	var cert *api.CertificateProfile
+
+	Expect(certAlreadyPresent(nil)).To(BeFalse())
+
+	cert = &api.CertificateProfile{}
+	Expect(certAlreadyPresent(cert)).To(BeFalse())
+
+	cert = &api.CertificateProfile{
+		APIServerCertificate: "a",
+	}
+	Expect(certAlreadyPresent(cert)).To(BeTrue())
+
+	cert = &api.CertificateProfile{
+		APIServerPrivateKey: "b",
+	}
+	Expect(certAlreadyPresent(cert)).To(BeTrue())
+
+	cert = &api.CertificateProfile{
+		ClientCertificate: "c",
+	}
+	Expect(certAlreadyPresent(cert)).To(BeTrue())
+
+	cert = &api.CertificateProfile{
+		ClientPrivateKey: "d",
+	}
+	Expect(certAlreadyPresent(cert)).To(BeTrue())
+}


### PR DESCRIPTION
- favoring a new, typed `paramsMap` over a `map[string]interface{}` for clarity/thin abstraction
- favoring a `template.FuncMap` type over a `map[string]interface{}`
- favoring a switch/case block over if / else if blocks
- broke out simple “do we already have a certificate?” logic into a convenience function for clarity, and as a reminder to make it more useful in the future
- added unit test for novel `acsengine.certAlreadyPresent()` function

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Eat your spinach.

**Special notes for your reviewer**: This does not introduce any new functionality. If successful, this PR should introduce some minor clarifying improvements in `pkg/acsengine/engine.go` and `pkg/acsengine/defaults.go`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1192)
<!-- Reviewable:end -->
