### PR TITLE
Add new fields to agentpoolonly API model

### DIFF
--- a/pkg/agentPoolOnlyApi/v20170831/types.go
+++ b/pkg/agentPoolOnlyApi/v20170831/types.go
@@ -101,8 +101,11 @@ const (
 
 // NetworkProfile represents the definition of network profile for the cluster
 type NetworkProfile struct {
-	PodCidr          string `json:"podCidr,omitempty"`
-	ServiceCidr      string `json:"serviceCidr,omitempty"`
+	PodCidr string `json:"podCidr,omitempty"`
+	// ServiceCidr is used to define the range of addresses within a Subnet
+	ServiceCidr string `json:"serviceCidr,omitempty"`
+	// Address range for Kubernetes service
+	AgentCidr        string `json:"agentCidr,omitempty"`
 	KubeDNSServiceIP string `json:"kubeDNSServiceIP,omitempty"`
 }
 
@@ -110,6 +113,7 @@ type NetworkProfile struct {
 type JumpboxProfile struct {
 	PublicIPAddressID string `json:"publicIPAddressID,omitempty"`
 	PublicIPAddress   string `json:"publicIPAddress,omitempty"`
+	InternalIPAddress string `json:"internalIPAddress,omitempty"`
 }
 
 // AgentPoolProfile represents configuration of VMs running agent

--- a/pkg/agentPoolOnlyApi/v20170831/types.go
+++ b/pkg/agentPoolOnlyApi/v20170831/types.go
@@ -101,10 +101,12 @@ const (
 
 // NetworkProfile represents the definition of network profile for the cluster
 type NetworkProfile struct {
+	// PodCidr defines the range of addresses that will be used for Pods.
+	// Allocation of subnets to agents will be handed by kube-controller-manager
 	PodCidr string `json:"podCidr,omitempty"`
-	// ServiceCidr is used to define the range of addresses within a Subnet
+	// ServiceCidr defines the range for Kubernetes services
 	ServiceCidr string `json:"serviceCidr,omitempty"`
-	// Address range for Kubernetes service
+	// AgentCidr defines the range for Agent VMs in the subnet
 	AgentCidr        string `json:"agentCidr,omitempty"`
 	KubeDNSServiceIP string `json:"kubeDNSServiceIP,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds new fields to NetworkProfile and JumpboxProfile. This is needed to support agent pools only scenario.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1211)
<!-- Reviewable:end -->
