### PR TITLE
fix(version): don't include timestamp in version

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,9 +8,6 @@ import (
 var (
 	// BuildSHA holds the git commit SHA at `make build` time.
 	BuildSHA = "unset"
-
-	// BuildTime holds the `date` at `make build` time.
-	BuildTime = "unset"
 )
 
 func newVersionCmd() *cobra.Command {
@@ -20,7 +17,7 @@ func newVersionCmd() *cobra.Command {
 		Long:  "Print the version of ACS-Engine",
 
 		Run: func(cmd *cobra.Command, args []string) {
-			log.Infof("ACS-Engine Version: %s (%s)", BuildSHA, BuildTime)
+			log.Infof("ACS-Engine Version: %s", BuildSHA)
 		},
 	}
 	return versionCmd

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -13,7 +13,7 @@ var _ = Describe("the version command", func() {
 		command := newVersionCmd()
 		hook := logtest.NewGlobal()
 		command.Run(command, nil)
-		Expect(hook.LastEntry().Message).To(Equal(fmt.Sprintf("ACS-Engine Version: %s (%s)", BuildSHA, BuildTime)))
+		Expect(hook.LastEntry().Message).To(Equal(fmt.Sprintf("ACS-Engine Version: %s", BuildSHA)))
 
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: 
- don't include timestamp in `acs-engine version`
- fix so computed binary SHAs are consistent for release


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1227 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1228)
<!-- Reviewable:end -->
