### PR TITLE
Automate Kubernetes on Windows builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ DIST_DIRS         = find * -type d -exec
 ifdef DEBUG
 GOFLAGS   := -gcflags="-N -l"
 else
-GOFLAGS   := 
+GOFLAGS   :=
 endif
 
 # go option
 GO        ?= go
 TAGS      :=
-LDFLAGS   := 
+LDFLAGS   :=
 BINDIR    := $(CURDIR)/bin
 BINARIES  := acs-engine
 VERSION   ?= $(shell git rev-parse HEAD)
@@ -48,6 +48,10 @@ build-binary: generate
 build-cross: LDFLAGS += -extldflags "-static"
 build-cross:
 	CGO_ENABLED=0 gox -output="_dist/acs-engine-${VERSION}-{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)'
+
+.PHONY: build-windows-k8s
+build-windows-k8s:
+	./scripts/build-windows-k8s.sh -v ${K8S_VERSION} -p ${PATCH_VERSION}
 
 .PHONY: dist
 dist:

--- a/docs/kubernetes-build-win-binaries.md
+++ b/docs/kubernetes-build-win-binaries.md
@@ -31,15 +31,6 @@ AZURE_STORAGE_CONTAINER_NAME=MyStorageContainerName
 
 ### Run `make build-windows-k8s`
 
-The `make build-windows-k8s` will do the following:
-- Clone the fork of Azure/kubernetes which include Windows fixes not yet in upstream Kubernetes
-- Build kubelet.exe, kube-proxy.exe
-- Download kubectl.exe for desired release
-- Download [NSSM](https://nssm.cc) which is used to start kubelet and kube-proxy on Windows
-- Download [Windows NAT](https://blogs.technet.microsoft.com/virtualization/2016/05/25/windows-nat-winnat-capabilities-and-limitations/)
-- Create an .zip archive of these Windows components
-- Upload archive to Azure Blob Storage
-
 Usage: `make build-windows-k8s K8S_VERSION=1.7.4 PATCH_VERSION=1`
 
-This will build Kubernetes binaries for Windows agents based on Kubernetes release version 1.7.4.
+This will build Kubernetes binaries for Windows agents based on Kubernetes release version 1.7.4 and place the zip artifact in Azure Blob Storage.

--- a/docs/kubernetes-build-win-binaries.md
+++ b/docs/kubernetes-build-win-binaries.md
@@ -1,87 +1,45 @@
-# Microsoft Azure Container Service Engine - Build Windows Kubernetes Binaries
-
-## Building Windows Kubernetes Binaries and deploy to an Azure storage account
+# Building Windows Kubernetes Binaries and deploy to an Azure storage account
 
 The following instructions show how to deploy the Windows Kubernetes Binaries and deploy them to an Azure Storage Account.
 
-1. Deploy a linux VM
+### Prerequisites
+* Azure Storage Account and Azure Storage Container to store Windows binaries
+* Access to [winnat.sys](https://blogs.technet.microsoft.com/virtualization/2016/05/25/windows-nat-winnat-capabilities-and-limitations/) stored in a storage container. (WinNAT) is used to provide required NAT networking functionality for Windows containers that will be included in a future Windows image update.
+* Docker installed and running. MacOS users using Docker for Mac must have at [least 3GB of memory allocated to Docker](https://github.com/kubernetes/kubernetes/tree/master/build/#requirements) or building will likely fail.
 
-2. Install docker
-   ```
-   sudo wget --tries 4 --retry-connrefused --waitretry=15 -qO- https://get.docker.com | sh
-   sudo usermod -aG docker $USER
-   newgrp docker
-   ```
+## Background
+Microsoft maintains a fork of the Kubernetes project at https://github.com/Azure/kubernetes which includes patches not yet included in upstream Kubernetes; these are needed for Windows containers to function.
 
-3. Update linux
-   ```
-   sudo apt-get update
-   sudo apt-get install -y linux-image-extra-$(uname -r) linux-image-extra-virtual apt-transport-https ca-certificates make gcc gcc-aarch64-linux-gnu zip
-   ```
+[build-windows-k8s.sh](scripts/build-windows-k8s.sh) does the following:
+- Checks out the fork of Azure/kubernetes (includes Windows fixes not yet in upstream Kubernetes, needed for Windows containers to function)
+- Builds kubelet.exe and kube-proxy.exe from source in a Docker container
+- Downloads kubectl.exe for desired release
+- Downloads [NSSM](https://nssm.cc) which is used to start kubelet and kube-proxy on Windows
+- Downloads [Windows NAT](https://blogs.technet.microsoft.com/virtualization/2016/05/25/windows-nat-winnat-capabilities-and-limitations/)
+- Creates an .zip archive of these Windows components
+- Uploads archive to Azure Blob Storage
 
-4. Install Go - this must be installed in local user account since kubernetes cross compile install binaries. For kubernetes 1.6.* and below, use Go version 1.7.3. For Kubernetes 1.7.* and up, use Go version 1.8.3.
-   ```
-   wget -qO- https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz | tar zx -C $HOME
-   echo "export GOPATH=$HOME/gopath" >> $HOME/.profile
-   echo 'export PATH=$PATH:$HOME/go/bin:$GOPATH/bin' >> $HOME/.profile
-   echo 'export GOROOT=$HOME/go' >> $HOME/.profile
-   source $HOME/.profile
-   ```
+More information about building Kubernetes binaries from source here: https://github.com/kubernetes/kubernetes/tree/master/build/
 
-5. Install Go Dependencies
-   ```
-   go get -u github.com/jteeuwen/go-bindata/go-bindata
-   ```
+### Set Azure Storage credentials and Container name
 
-6. Build windows kubelet.exe
-   ```
-   cd $HOME
-   git clone https://github.com/kubernetes/kubernetes $GOPATH/src/k8s.io/kubernetes
-   cd $GOPATH/src/k8s.io/kubernetes
-   make WHAT=cmd/kubelet
-   make WHAT=cmd/kubelet KUBE_BUILD_PLATFORMS=windows/amd64
-   ```
-7. Build windows kube-proxy.exe
-   ```
-   cd $GOPATH/src/k8s.io/kubernetes
-   make WHAT=cmd/kube-proxy
-   make WHAT=cmd/kube-proxy KUBE_BUILD_PLATFORMS=windows/amd64
-   ```
+A storage container is used to download winnat.sys during the build phase and to upload the resulting archive artifact.
+```
+$ export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=MyStorageAccountName;AccountKey=..." \
+AZURE_STORAGE_CONTAINER_NAME=MyStorageContainerName
+```
 
-8. Build the zip file
-   ```
-   cd $HOME
-   rm -rf uploadk
-   mkdir uploadk
-   cd uploadk
-   mkdir k
-   cp $HOME/kubelet/kubernetes/_output/local/bin/windows/amd64/kubelet.exe k
-   cp $HOME/kube-proxy/kubernetes/_output/local/bin/windows/amd64/kube-proxy.exe k
-   wget https://storage.googleapis.com/kubernetes-release/release/v1.4.6/bin/windows/amd64/kubectl.exe -P k
-   chmod 775 k/kubectl.exe
-   cat <<EOT >> k/Dockerfile
-   FROM microsoft/windowsservercore
-   
-   ADD pause.ps1 /pause/pause.ps1
-   	
-   CMD powershell /pause/pause.ps1
-   EOT
-   cat <<EOT >> k/pause.ps1
-   while(\$true)
-   {
-       Start-Sleep -Seconds 60
-   }
-   EOT
-   wget https://nssm.cc/release/nssm-2.24.zip
-   unzip nssm-2.24.zip
-   cp nssm-2.24/win64/nssm.exe k
-   rm -rf nssm-2.24*
-   chmod 775 k/nssm.exe
-   zip -r k.zip *
-   ```
+### Run `make build-windows-k8s`
 
-9. Upload to storage.  This assumes you have az cli installed and you have a storage account
-   ```
-   export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=enter_your_account;AccountKey=enter_your_key"
-   azure storage blob upload k.zip k8scontainer k.zip -q
-   ```
+The `make build-windows-k8s` will do the following:
+- Clone the fork of Azure/kubernetes which include Windows fixes not yet in upstream Kubernetes
+- Build kubelet.exe, kube-proxy.exe
+- Download kubectl.exe for desired release
+- Download [NSSM](https://nssm.cc) which is used to start kubelet and kube-proxy on Windows
+- Download [Windows NAT](https://blogs.technet.microsoft.com/virtualization/2016/05/25/windows-nat-winnat-capabilities-and-limitations/)
+- Create an .zip archive of these Windows components
+- Upload archive to Azure Blob Storage
+
+Usage: `make build-windows-k8s K8S_VERSION=1.7.4 PATCH_VERSION=1`
+
+This will build Kubernetes binaries for Windows agents based on Kubernetes release version 1.7.4.

--- a/scripts/build-windows-k8s.sh
+++ b/scripts/build-windows-k8s.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+set -eo pipefail
+
+ACS_ENGINE_HOME=${GOPATH}/src/github.com/Azure/acs-engine
+
+usage() {
+	echo "$0 [-v version] [-p acs_patch_version]"
+	echo " -v <version>: version"
+	echo " -p <patched version>: acs_patch_version"
+	exit 0
+}
+
+while getopts ":v:p:" opt; do
+  case ${opt} in
+    v)
+      version=${OPTARG}
+      ;;
+    p)
+      acs_patch_version=${OPTARG}
+      ;;
+    *)
+			usage
+      ;;
+  esac
+done
+
+if [ -z "${version}" ] || [ -z "${acs_patch_version}" ]; then
+    usage
+fi
+
+if [ -z "${AZURE_STORAGE_CONNECTION_STRING}" ] || [ -z "${AZURE_STORAGE_CONTAINER_NAME}" ]; then
+    echo '$AZURE_STORAGE_CONNECTION_STRING and $AZURE_STORAGE_CONTAINER_NAME need to be set for upload to Azure Blob Storage.'
+		exit 1
+fi
+
+KUBERNETES_RELEASE=$(echo $version | cut -d'.' -f1,2)
+KUBERNETES_TAG_BRANCH=v${version}
+ACS_VERSION=${version}-${acs_patch_version}
+ACS_BRANCH_NAME=acs-v${ACS_VERSION}
+DIST_DIR=${ACS_ENGINE_HOME}/_dist/k8s-windows-v${ACS_VERSION}/k
+
+fetch_k8s() {
+	git clone https://github.com/Azure/kubernetes ${GOPATH}/src/k8s.io/kubernetes || true
+	cd ${GOPATH}/src/k8s.io/kubernetes
+	git remote add upstream https://github.com/kubernetes/kubernetes || true
+	git fetch upstream
+}
+
+set_git_config() {
+	git config user.name "ACS CI"
+	git config user.email "containers@microsoft.com"
+}
+
+create_version_branch() {
+	git checkout -b ${ACS_BRANCH_NAME} ${KUBERNETES_TAG_BRANCH} || true
+}
+
+k8s_16_cherry_pick() {
+	# 232fa6e5bc (HEAD -> release-1.6, origin/release-1.6) Fix the delay caused by network setup in POD Infra container
+	# 02b1c2b9e2 Use dns policy to determine setting DNS servers on the correct NIC in Windows container
+	# 4c2a2d79aa Fix getting host DNS for Windows node when dnsPolicy is Default
+	# caa314ccdc Update docker version parsing to allow nonsemantic versions as they have changed how they do their versions
+	# f18be40948 Fix the issue in unqualified name where DNS client such as ping or iwr validate name in response and original question. Switch to use miekg's DNS library
+	# c862b583c9 Remove DNS server from NAT network adapter inside container
+	# f6c27f9375 Merged libCNI-on-Windows changes from CNI release 0.5.0, PRs 359 and 361
+	# 4f196c6cac Fix the issue that ping uses the incorrect NIC to resolve name sometimes
+	# 2c9fd27449 Workaround for Outbound Internet traffic in Azure Kubernetes
+	# 5fa0725025 Use adapter vEthernet (HNSTransparent) on Windows host network to find node IP
+
+	git cherry-pick 5fa0725025..232fa6e5bc
+}
+
+k8s_17_cherry_pick() {
+	# 45ba7bb0fb Implement metrics for Windows Containers
+	# 76b94898ec Use dns policy to determine setting DNS servers on the correct NIC in Windows container
+	# 74a2f37447 Fix network config due to the split of start POD sandbox and start container from 1.7.0
+	# 5fc0a5e4a2 Workaround for Outbound Internet traffic in Azure Kubernetes (*) Connect a Nat Network to the container (Second adapter) (*) Modify the route so that internet traffic goes via Nat network, and POD traffic goes over the CONTAINER_NETWORK (*) Modify getContainerIP to return the IP corresponding to POD network, and ignore Nat Network (*) DNS Fix for ACS Kubernetes in Windows
+	# adeb88d774 Use adapter vEthernet (HNSTransparent) on Windows host network to find node IP
+
+	git cherry-pick adeb88d774..45ba7bb0fb
+}
+
+apply_acs_cherry_picks() {
+	if [ "${KUBERNETES_RELEASE}" == "1.6" ]; then
+		k8s_16_cherry_pick
+	elif [ "${KUBERNETES_RELEASE}" == "1.7" ]; then
+		k8s_17_cherry_pick
+	else
+		echo "Unable to apply cherry picks for ${KUBERNETES_RELEASE}."
+		exit 1
+	fi
+}
+
+create_dist_dir() {
+	mkdir -p ${DIST_DIR}
+}
+
+build_kubelet() {
+	echo "building kubelet.exe..."
+	build/run.sh make WHAT=cmd/kubelet KUBE_BUILD_PLATFORMS=windows/amd64
+	cp ${GOPATH}/src/k8s.io/kubernetes/_output/dockerized/bin/windows/amd64/kubelet.exe ${DIST_DIR}
+}
+
+build_kubeproxy() {
+	echo "building kube-proxy.exe..."
+	build/run.sh make WHAT=cmd/kube-proxy KUBE_BUILD_PLATFORMS=windows/amd64
+	cp ${GOPATH}/src/k8s.io/kubernetes/_output/dockerized/bin/windows/amd64/kube-proxy.exe ${DIST_DIR}
+}
+
+download_kubectl() {
+	kubectl="https://storage.googleapis.com/kubernetes-release/release/v${version}/bin/windows/amd64/kubectl.exe"
+	echo "dowloading ${kubectl} ..."
+	wget ${kubectl} -P k
+	curl ${kubectl} -o ${DIST_DIR}/kubectl.exe
+	chmod 775 ${DIST_DIR}/kubectl.exe
+}
+
+download_nssm() {
+	NSSM_VERSION=2.24
+	NSSM_URL=https://nssm.cc/release/nssm-${NSSM_VERSION}.zip
+	echo "downloading nssm ..."
+	curl ${NSSM_URL} -o /tmp/nssm-${NSSM_VERSION}.zip
+	unzip -q -d /tmp /tmp/nssm-${NSSM_VERSION}.zip
+	cp /tmp/nssm-${NSSM_VERSION}/win64/nssm.exe ${DIST_DIR}
+	chmod 775 ${DIST_DIR}/nssm.exe
+	rm -rf /tmp/nssm-${NSSM_VERSION}*
+}
+
+download_winnat() {
+	az storage blob download -f ${DIST_DIR}/winnat.sys -c ${AZURE_STORAGE_CONTAINER_NAME} -n winnat.sys
+}
+
+copy_dockerfile_and_pause_ps1() {
+  cp ${ACS_ENGINE_HOME}/windows/* ${DIST_DIR}
+}
+
+create_zip() {
+	cd ${DIST_DIR}/..
+	zip -r ../v${ACS_VERSION}intwinnat.zip k/*
+	cd -
+}
+
+upload_zip_to_blob_storage() {
+	az storage blob upload -f ${DIST_DIR}/../../v${ACS_VERSION}intwinnat.zip -c ${AZURE_STORAGE_CONTAINER_NAME} -n v${ACS_VERSION}intwinnat.zip
+}
+
+create_dist_dir
+fetch_k8s
+set_git_config
+create_version_branch
+apply_acs_cherry_picks
+
+# Due to what appears to be a bug in the Kubernetes Windows build system, one
+# has to first build a linux binary to generate _output/bin/deepcopy-gen.
+# Building to Windows w/o doing this will generate an empty deepcopy-gen.
+build/run.sh make WHAT=cmd/kubelet KUBE_BUILD_PLATFORMS=linux/amd64
+
+build_kubelet
+build_kubeproxy
+download_kubectl
+download_nssm
+download_winnat
+copy_dockerfile_and_pause_ps1
+create_zip
+upload_zip_to_blob_storage

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -1,0 +1,5 @@
+FROM microsoft/windowsservercore
+
+ADD pause.ps1 /pause/pause.ps1
+
+CMD powershell /pause/pause.ps1

--- a/windows/pause.ps1
+++ b/windows/pause.ps1
@@ -1,4 +1,4 @@
-while(\$true)
+while($true)
 {
     Start-Sleep -Seconds 60
 }

--- a/windows/pause.ps1
+++ b/windows/pause.ps1
@@ -1,0 +1,4 @@
+while(\$true)
+{
+    Start-Sleep -Seconds 60
+}


### PR DESCRIPTION
This will provide tooling to allow CI to build Kubernetes binaries for Windows.
Todo:
- [x] Script to build Windows binaries for v1.6.x or v1.7.x, based on https://github.com/Azure/acs-engine/blob/master/docs/kubernetes-build-win-binaries.md
- [x] Fork kubernetes to Azure/kubernetes
- [x] Script can upload to ACS Azure blob storage
- [x] Update https://github.com/Azure/acs-engine/blob/master/docs/kubernetes-build-win-binaries.md

~- [ ] Runs in CI~ (for another PR)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1168 

**Special notes for your reviewer**: fyi @JiangtianLi 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1236)
<!-- Reviewable:end -->
