### PR TITLE
Changes k8s templates to generate better resource names

### DIFF
--- a/parts/kubernetesagentresourcesvmas.t
+++ b/parts/kubernetesagentresourcesvmas.t
@@ -12,7 +12,7 @@
 {{end}}
       ],
       "location": "[variables('location')]",
-      "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
+      "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')), '-nic')]",
       "properties": {
 {{if .IsCustomVNET}}
         "networkSecurityGroup": {
@@ -118,18 +118,18 @@
         "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
   {{end}}
 {{end}}
-        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')), '-nic')]",
         "[concat('Microsoft.Compute/availabilitySets/', variables('{{.Name}}AvailabilitySet'))]"
       ],
       "tags":
       {
-        "creationSource" : "[concat('acsengine-', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
+        "creationSource" : "[concat('acsengine-', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')))]",
         "resourceNameSuffix" : "[variables('nameSuffix')]",
         "orchestrator" : "[variables('orchestratorNameVersionTag')]",
         "poolName" : "{{.Name}}"
       },
       "location": "[variables('location')]",
-      "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
+      "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')))]",
       {{if UseManagedIdentity}}
       "identity": {
         "type": "systemAssigned"
@@ -145,13 +145,13 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset'))))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')), '-nic'))]"
             }
           ]
         },
         "osProfile": {
           "adminUsername": "[variables('username')]",
-          "computername": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
+          "computername": "[concat(variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')))]",
           {{GetKubernetesAgentCustomData .}}
           "linuxConfiguration": {
               "disablePasswordAuthentication": "true",
@@ -180,10 +180,10 @@
           "osDisk": {
             "createOption": "FromImage"
             ,"caching": "ReadWrite"
+            ,"name": "[concat(variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')),'-osdisk')]"
           {{if .IsStorageAccount}}
-            ,"name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')),'-osdisk')]"
             ,"vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-osdisk.vhd')]"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')), '-osdisk.vhd')]"
             }
           {{end}}
           {{if ne .OSDiskSizeGB 0}}
@@ -201,16 +201,16 @@
          "count": "[variables('{{.Name}}Count')]",
          "name": "vmLoopNode"
        },
-      "name": "[guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(), 'vmidentity'))]",
+      "name": "[guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(), 'vmidentity'))]",
       "type": "Microsoft.Authorization/roleAssignments",
       "properties": {
         "roleDefinitionId": "[variables('readerRoleDefinitionId')]",
-        "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex()), '2017-03-30', 'Full').identity.principalId]"
+        "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex()), '2017-03-30', 'Full').identity.principalId]"
       }
     },
      {
        "type": "Microsoft.Compute/virtualMachines/extensions",
-       "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(), '/ManagedIdentityExtension')]",
+       "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(), '/ManagedIdentityExtension')]",
        "copy": {
          "count": "[variables('{{.Name}}Count')]",
          "name": "vmLoopNode"
@@ -218,8 +218,8 @@
        "apiVersion": "2015-05-01-preview",
        "location": "[resourceGroup().location]",
        "dependsOn": [
-         "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex())]",
-         "[concat('Microsoft.Authorization/roleAssignments/', guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(), 'vmidentity')))]"
+         "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex())]",
+         "[concat('Microsoft.Authorization/roleAssignments/', guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(), 'vmidentity')))]"
        ],
        "properties": {
          "publisher": "Microsoft.ManagedIdentity",
@@ -241,14 +241,14 @@
       },
       "dependsOn": [
         {{if UseManagedIdentity}}
-        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(), '/extensions/ManagedIdentityExtension')]"
+        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(), '/extensions/ManagedIdentityExtension')]"
         {{else}}
-        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]"
+        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')))]"
         {{end}}
       ],
       "location": "[variables('location')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')),'/cse', copyIndex(variables('{{.Name}}Offset')))]",
+      "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')),'/cse', copyIndex(variables('{{.Name}}Offset')))]",
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
         "type": "CustomScript",

--- a/parts/kubernetesagentvars.t
+++ b/parts/kubernetesagentvars.t
@@ -4,12 +4,12 @@
 {{end}}
     "{{.Name}}Count": "[parameters('{{.Name}}Count')]",
     "{{.Name}}Offset": "[parameters('{{.Name}}Offset')]",
-    "{{.Name}}AvailabilitySet": "[concat('{{.Name}}-availabilitySet-', variables('nameSuffix'))]",
+    "{{.Name}}AvailabilitySet": "[concat(variables('orchestratorName'), '-', variables('nameSuffix'), '-{{.Name}}-avs')]",
 {{if .IsWindows}}
     "winResourceNamePrefix" : "[substring(variables('nameSuffix'), 0, 5)]",
     "{{.Name}}VMNamePrefix": "[concat(variables('winResourceNamePrefix'), 'acs', add(900,variables('{{.Name}}Index')))]",
 {{else}}
-    "{{.Name}}VMNamePrefix": "[concat(variables('orchestratorName'), '-{{.Name}}-', variables('nameSuffix'), '-')]", 
+    "{{.Name}}VMNamePrefix": "[concat(variables('orchestratorName'), '-', variables('nameSuffix'), '-{{.Name}}-')]", 
 {{end}}
     "{{.Name}}VMSize": "[parameters('{{.Name}}VMSize')]",
 {{if .IsCustomVNET}}

--- a/parts/kubernetesmasterresources.t
+++ b/parts/kubernetesmasterresources.t
@@ -277,7 +277,7 @@
         "[variables('masterLbID')]"
       ],
       "location": "[variables('location')]",
-      "name": "[concat(variables('masterLbName'), '/', 'SSH-', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')))]",
+      "name": "[concat(variables('masterLbName'), '/', 'SSH-', variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')))]",
       "properties": {
         "backendPort": 22,
         "enableFloatingIP": false,
@@ -301,13 +301,13 @@
 {{else}}
         "[variables('vnetID')]",
 {{end}}
-        "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')))]"
+        "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')))]"
 {{if gt .MasterProfile.Count 1}}
         ,"[variables('masterInternalLbName')]"
 {{end}}
       ],
       "location": "[variables('location')]",
-      "name": "[concat(variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]",
+      "name": "[concat(variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')), '-nic')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -326,7 +326,7 @@
               ],
               "loadBalancerInboundNatRules": [
                 {
-                  "id": "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')))]"
+                  "id": "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')))]"
                 }
               ],
               "privateIPAddress": "[variables('masterPrivateIpAddrs')[copyIndex(variables('masterOffset'))]]",
@@ -376,7 +376,7 @@
         "name": "vmLoopNode"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]"
+        "[concat('Microsoft.Network/networkInterfaces/', variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')), '-nic')]"
         ,"[concat('Microsoft.Compute/availabilitySets/',variables('masterAvailabilitySet'))]"
 {{if .MasterProfile.IsStorageAccount}}
         ,"[variables('masterStorageAccountName')]"
@@ -384,12 +384,12 @@
       ],
       "tags":
       {
-        "creationSource" : "[concat('acsengine-', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')))]",
+        "creationSource" : "[concat('acsengine-', variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')))]",
         "resourceNameSuffix" : "[variables('nameSuffix')]",
         "orchestrator" : "[variables('orchestratorNameVersionTag')]"
       },
       "location": "[variables('location')]",
-      "name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')))]",
+      "name": "[concat(variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')))]",
       {{if UseManagedIdentity}}
       "identity": {
         "type": "systemAssigned"
@@ -405,13 +405,13 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('masterVMNamePrefix'),'nic-', copyIndex(variables('masterOffset'))))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')), '-nic'))]"
             }
           ]
         },
         "osProfile": {
           "adminUsername": "[variables('username')]",
-          "computername": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')))]",
+          "computername": "[concat(variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')))]",
           {{GetKubernetesMasterCustomData .}}
           "linuxConfiguration": {
             "disablePasswordAuthentication": "true",
@@ -435,10 +435,10 @@
               "createOption": "Empty"
               ,"diskSizeGB": "128"
               ,"lun": 0
-              ,"name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-etcddisk')]"
+              ,"name": "[concat(variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')),'-etcddisk')]"
           {{if .MasterProfile.IsStorageAccount}}
               ,"vhd": {
-                "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/', variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')),'-etcddisk.vhd')]"
+                "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/', variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')),'-etcddisk.vhd')]"
               }
           {{end}}
             }
@@ -452,10 +452,10 @@
           "osDisk": {
             "caching": "ReadWrite"
             ,"createOption": "FromImage"
+            ,"name": "[concat(variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')),'-osdisk')]"
 {{if .MasterProfile.IsStorageAccount}}
-            ,"name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-osdisk')]"
             ,"vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')),'-osdisk.vhd')]"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/',variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')),'-osdisk.vhd')]"
             }
 {{end}}
 {{if ne .MasterProfile.OSDiskSizeGB 0}}
@@ -474,16 +474,16 @@
          "count": "[variables('masterCount')]",
          "name": "vmLoopNode"
        },
-      "name": "[guid(concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), copyIndex(),'vmidentity'))]",
+      "name": "[guid(concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), 'vm', copyIndex(),'vmidentity'))]",
       "type": "Microsoft.Authorization/roleAssignments",
       "properties": {
         "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
-        "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), copyIndex()), '2017-03-30', 'Full').identity.principalId]"
+        "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), 'vm', copyIndex()), '2017-03-30', 'Full').identity.principalId]"
       }
     },
      {
        "type": "Microsoft.Compute/virtualMachines/extensions",
-       "name": "[concat(variables('masterVMNamePrefix'), copyIndex(), '/ManagedIdentityExtension')]",
+       "name": "[concat(variables('masterVMNamePrefix'), 'vm', copyIndex(), '/ManagedIdentityExtension')]",
        "copy": {
          "count": "[variables('masterCount')]",
          "name": "vmLoopNode"
@@ -491,8 +491,8 @@
        "apiVersion": "2015-05-01-preview",
        "location": "[resourceGroup().location]",
        "dependsOn": [
-         "[concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), copyIndex())]",
-         "[concat('Microsoft.Authorization/roleAssignments/', guid(concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), copyIndex(), 'vmidentity')))]"
+         "[concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), 'vm', copyIndex())]",
+         "[concat('Microsoft.Authorization/roleAssignments/', guid(concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), 'vm', copyIndex(), 'vmidentity')))]"
        ],
        "properties": {
          "publisher": "Microsoft.ManagedIdentity",
@@ -514,14 +514,14 @@
       },
       "dependsOn": [
         {{if UseManagedIdentity}}
-        "[concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '/extensions/ManagedIdentityExtension')]"
+        "[concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')), '/extensions/ManagedIdentityExtension')]"
         {{else}}
-        "[concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')))]"
+        "[concat('Microsoft.Compute/virtualMachines/', variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')))]"
         {{end}}
       ],
       "location": "[variables('location')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'/cse', copyIndex(variables('masterOffset')))]",
+      "name": "[concat(variables('masterVMNamePrefix'), 'vm', copyIndex(variables('masterOffset')),'/cse', copyIndex(variables('masterOffset')))]",
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
         "type": "CustomScript",

--- a/parts/kubernetesmastervars.t
+++ b/parts/kubernetesmastervars.t
@@ -56,7 +56,7 @@
          "[parameters('location')]"
     ],
     "location": "[variables('locations')[mod(add(2,length(parameters('location'))),add(1,length(parameters('location'))))]]",
-    "masterAvailabilitySet": "[concat('master-availabilityset-', variables('nameSuffix'))]",
+    "masterAvailabilitySet": "[concat(variables('orchestratorName'), '-', variables('nameSuffix'), '-master-avs')]",
     "nameSuffix": "[parameters('nameSuffix')]",
     "orchestratorName": "k8s",
     "osImageOffer": "UbuntuServer",
@@ -107,7 +107,7 @@
     "subnetName": "[concat(variables('orchestratorName'), '-subnet')]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "vnetSubnetID": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "[concat(variables('orchestratorName'), '-vnet-', variables('nameSuffix'))]",
+    "virtualNetworkName": "[concat(variables('orchestratorName'), '-', variables('nameSuffix'), '-vnet')]",
     "vnetCidr": "10.0.0.0/8",
 {{end}}
     "kubeDnsServiceIp": "10.0.0.10",
@@ -121,16 +121,16 @@
 {{end}}
     "nsgName": "[concat(variables('masterVMNamePrefix'), 'nsg')]",
     "nsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName'))]",
-    "primaryAvailablitySetName": "[concat('{{ (index .AgentPoolProfiles 0).Name }}-availabilitySet-',variables('nameSuffix'))]",
-    "masterPublicIPAddressName": "[concat(variables('orchestratorName'), '-master-ip-', variables('masterFqdnPrefix'), '-', variables('nameSuffix'))]",
+    "primaryAvailablitySetName": "[concat(variables('orchestratorName'), '-', variables('nameSuffix'), '-{{ (index .AgentPoolProfiles 0).Name }}-avs')]",
+    "masterPublicIPAddressName": "[concat(variables('orchestratorName'), '-', variables('nameSuffix'), '-master-ip-', variables('masterFqdnPrefix'))]",
     "masterLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('masterLbName'))]",
     "masterLbIPConfigID": "[concat(variables('masterLbID'),'/frontendIPConfigurations/', variables('masterLbIPConfigName'))]",
-    "masterLbIPConfigName": "[concat(variables('orchestratorName'), '-master-lbFrontEnd-', variables('nameSuffix'))]",
-    "masterLbName": "[concat(variables('orchestratorName'), '-master-lb-', variables('nameSuffix'))]",
+    "masterLbIPConfigName": "[concat(variables('masterLbName'), '-frontend')]",
+    "masterLbName": "[concat(variables('orchestratorName'), '-', variables('nameSuffix'), '-master-lb')]",
 {{if gt .MasterProfile.Count 1}}
-    "masterInternalLbName": "[concat(variables('orchestratorName'), '-master-internal-lb-', variables('nameSuffix'))]",
+    "masterInternalLbName": "[concat(variables('orchestratorName'), '-', variables('nameSuffix'), '-master-internal-lb')]",
     "masterInternalLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('masterInternalLbName'))]",
-    "masterInternalLbIPConfigName": "[concat(variables('orchestratorName'), '-master-internal-lbFrontEnd-', variables('nameSuffix'))]",
+    "masterInternalLbIPConfigName": "[concat(variables('masterInternalLbName'), '-frontend')]",
     "masterInternalLbIPConfigID": "[concat(variables('masterInternalLbID'),'/frontendIPConfigurations/', variables('masterInternalLbIPConfigName'))]",
     "masterInternalLbIPOffset": {{GetDefaultInternalLbStaticIPOffset}},
     "kubernetesAPIServerIP": "[concat(variables('masterFirstAddrPrefix'), add(variables('masterInternalLbIPOffset'), int(variables('masterFirstAddrOctet4'))))]",
@@ -142,13 +142,13 @@
     "masterFirstAddrOctets": "[split(parameters('firstConsecutiveStaticIP'),'.')]",
     "masterFirstAddrOctet4": "[variables('masterFirstAddrOctets')[3]]",
     "masterFirstAddrPrefix": "[concat(variables('masterFirstAddrOctets')[0],'.',variables('masterFirstAddrOctets')[1],'.',variables('masterFirstAddrOctets')[2],'.')]",
-    "masterVMNamePrefix": "[concat(variables('orchestratorName'), '-master-', variables('nameSuffix'), '-')]",
+    "masterVMNamePrefix": "[concat(variables('orchestratorName'), '-', variables('nameSuffix'), '-master-')]",
     "masterVMNames": [
-      "[concat(variables('masterVMNamePrefix'), '0')]",
-      "[concat(variables('masterVMNamePrefix'), '1')]",
-      "[concat(variables('masterVMNamePrefix'), '2')]",
-      "[concat(variables('masterVMNamePrefix'), '3')]",
-      "[concat(variables('masterVMNamePrefix'), '4')]"
+      "[concat(variables('masterVMNamePrefix'), 'vm0')]",
+      "[concat(variables('masterVMNamePrefix'), 'vm1')]",
+      "[concat(variables('masterVMNamePrefix'), 'vm2')]",
+      "[concat(variables('masterVMNamePrefix'), 'vm3')]",
+      "[concat(variables('masterVMNamePrefix'), 'vm4')]"
     ],
     "masterPrivateIpAddrs": [
       "[concat(variables('masterFirstAddrPrefix'), add(0, int(variables('masterFirstAddrOctet4'))))]",

--- a/parts/kuberneteswinagentresourcesvmas.t
+++ b/parts/kuberneteswinagentresourcesvmas.t
@@ -12,7 +12,7 @@
 {{end}}
       ],
       "location": "[variables('location')]",
-      "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
+      "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')), '-nic')]",
       "properties": {
 {{if .IsCustomVNET}}
 	    "networkSecurityGroup": {
@@ -117,18 +117,18 @@
         "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
   {{end}}
 {{end}}
-        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')), '-nic')]",
         "[concat('Microsoft.Compute/availabilitySets/', variables('{{.Name}}AvailabilitySet'))]"
       ],
       "tags":
       {
-        "creationSource" : "[concat('acsengine-', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
+        "creationSource" : "[concat('acsengine-', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')))]",
         "resourceNameSuffix" : "[variables('winResourceNamePrefix')]",
         "orchestrator" : "[variables('orchestratorNameVersionTag')]",
         "poolName" : "{{.Name}}"
       },
       "location": "[variables('location')]",
-      "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
+      "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')))]",
       {{if UseManagedIdentity}}
       "identity": {
         "type": "systemAssigned"
@@ -144,12 +144,12 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset'))))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')), '-nic'))]"
             }
           ]
         },
         "osProfile": {
-          "computername": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
+          "computername": "[concat(variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')))]",
           {{GetKubernetesWindowsAgentCustomData .}}
           "adminUsername": "[variables('windowsAdminUsername')]",
           "adminPassword": "[variables('windowsAdminPassword')]"
@@ -165,10 +165,10 @@
           "osDisk": {
             "createOption": "FromImage"
             ,"caching": "ReadWrite"
+            ,"name": "[concat(variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')),'-osdisk')]"
 {{if .IsStorageAccount}}
-            ,"name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')),'-osdisk')]"
             ,"vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-osdisk.vhd')]"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')), '-osdisk.vhd')]"
             }
 {{end}}
 {{if ne .OSDiskSizeGB 0}}
@@ -186,16 +186,16 @@
          "count": "[variables('{{.Name}}Count')]",
          "name": "vmLoopNode"
        },
-      "name": "[guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(),'vmidentity'))]",
+      "name": "[guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(),'vmidentity'))]",
       "type": "Microsoft.Authorization/roleAssignments",
       "properties": {
         "roleDefinitionId": "[variables('readerRoleDefinitionId')]",
-        "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex()), '2017-03-30', 'Full').identity.principalId]"
+        "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex()), '2017-03-30', 'Full').identity.principalId]"
       }
     },
       {
         "type": "Microsoft.Compute/virtualMachines/extensions",
-        "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(), '/ManagedIdentityExtension')]",
+        "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(), '/ManagedIdentityExtension')]",
         "copy": {
           "count": "[variables('{{.Name}}Count')]",
           "name": "vmLoopNode"
@@ -203,8 +203,8 @@
         "apiVersion": "2015-05-01-preview",
         "location": "[resourceGroup().location]",
         "dependsOn": [
-          "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex())]",
-          "[concat('Microsoft.Authorization/roleAssignments/', guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(), 'vmidentity')))]"
+          "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex())]",
+          "[concat('Microsoft.Authorization/roleAssignments/', guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(), 'vmidentity')))]"
         ],
         "properties": {
           "publisher": "Microsoft.ManagedIdentity",
@@ -226,14 +226,14 @@
       },
       "dependsOn": [
         {{if UseManagedIdentity}}
-        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(), '/extensions/ManagedIdentityExtension')]"
+        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(), '/extensions/ManagedIdentityExtension')]"
         {{else}}
-        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]"
+        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')))]"
         {{end}}
       ],
       "location": "[variables('location')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '/cse')]",
+      "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')), '/cse')]",
       "properties": {
         "publisher": "Microsoft.Compute",
         "type": "CustomScriptExtension",
@@ -241,7 +241,7 @@
         "autoUpgradeMinorVersion": true,
         "settings": {},
         "protectedSettings": {
-          "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -command \"', '$arguments = ', variables('singleQuote'),'-MasterIP ',variables('kubernetesAPIServerIP'),' -KubeDnsServiceIp ',variables('kubeDnsServiceIp'),' -MasterFQDNPrefix ',variables('masterFqdnPrefix'),' -Location ',variables('location'),' -AgentKey ',variables('clientPrivateKey'),' -AzureHostname ',variables('{{.Name}}VMNamePrefix'),copyIndex(variables('{{.Name}}Offset')),' -AADClientId ',variables('servicePrincipalClientId'),' -AADClientSecret ',variables('servicePrincipalClientSecret'),variables('singleQuote'), ' ; ', variables('windowsCustomScriptSuffix'), '\" > %SYSTEMDRIVE%\\AzureData\\CustomDataSetupScript.log 2>&1')]"
+          "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -command \"', '$arguments = ', variables('singleQuote'),'-MasterIP ',variables('kubernetesAPIServerIP'),' -KubeDnsServiceIp ',variables('kubeDnsServiceIp'),' -MasterFQDNPrefix ',variables('masterFqdnPrefix'),' -Location ',variables('location'),' -AgentKey ',variables('clientPrivateKey'),' -AzureHostname ',variables('{{.Name}}VMNamePrefix'), 'vm', copyIndex(variables('{{.Name}}Offset')),' -AADClientId ',variables('servicePrincipalClientId'),' -AADClientSecret ',variables('servicePrincipalClientSecret'),variables('singleQuote'), ' ; ', variables('windowsCustomScriptSuffix'), '\" > %SYSTEMDRIVE%\\AzureData\\CustomDataSetupScript.log 2>&1')]"
         }
       }
     }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**Generate better azure resource names**:
Current implementation generates less consistent names and for large clusters it is difficult to distinguish resources from each other. The following table shows how the PR improves naming consistency.

azuredeploy.parameters.json:
``` json
...
"masterEndpointDNSNamePrefix": {
  "value": "kubetest"
},
"nameSuffix": {
  "value": "kubetest"
},
```

| Generated by PR | Generated by original templates |
| ------------------  | ----------------------------------- |
| k8s-kubetest-agentpool1-avs | agentpool1-availabilitySet-kubetest |
| k8s-kubetest-agentpool1-vm0 |   k8s-agentpool1-kubetest-0  |
| k8s-kubetest-agentpool1-vm0-nic |  k8s-agentpool1-kubetest-nic-0   |
| k8s-kubetest-agentpool1-vm0-osdisk | k8s-agentpool1-kubetest-0_OsDisk_1_7a47d9bb...    |
| k8s-kubetest-agentpool1-vm1 |  k8s-agentpool1-kubetest-1   |
| k8s-kubetest-agentpool1-vm1-nic |  k8s-agentpool1-kubetest-nic-1   |
| k8s-kubetest-agentpool1-vm1-osdisk | k8s-agentpool1-kubetest-1_OsDisk_1_29843f9... |
| k8s-kubetest-agentpool2-avs |  agentpool2-availabilitySet-kubetest	   |
| k8s-kubetest-agentpool2-vm0 |  k8s-agentpool2-kubetest-0   |
| k8s-kubetest-agentpool2-vm0-nic |  k8s-agentpool2-kubetest-nic-0   |
| k8s-kubetest-agentpool2-vm0-osdisk |  k8s-agentpool2-kubetest-0_OsDisk_1_40f33537...   |
| k8s-kubetest-agentpool2-vm1 |  k8s-agentpool2-kubetest-1   |
| k8s-kubetest-agentpool2-vm1-nic | k8s-agentpool2-kubetest-nic-1    |
| k8s-kubetest-agentpool2-vm1-osdisk | k8s-agentpool2-kubetest-1_OsDisk_1_50b0d47...    |
| k8s-kubetest-agentpool3-avs | agentpool3-availabilitySet-kubetest    |
| k8s-kubetest-agentpool3-vm0 |  k8s-agentpool3-kubetest-0   |
| k8s-kubetest-agentpool3-vm0-nic |  k8s-agentpool3-kubetest-nic-0   |
| k8s-kubetest-agentpool3-vm0-osdisk |  k8s-agentpool3-kubetest-0_OsDisk_1_a2e1bdd...    |
| k8s-kubetest-agentpool3-vm1 | k8s-agentpool3-kubetest-1    |
| k8s-kubetest-agentpool3-vm1-nic |  k8s-agentpool3-kubetest-nic-1   |
| k8s-kubetest-agentpool3-vm1-osdisk | k8s-agentpool3-kubetest-1_OsDisk_1_f4664963...  |
| k8s-kubetest-master-avs |   master-availabilityset-kubetest  |
| k8s-kubetest-master-internal-lb |  k8s-master-lb-kubetest   |
| k8s-kubetest-master-ip-kubetest |  k8s-master-ip-kubetest-kubetest   |
| k8s-kubetest-master-lb |  k8s-master-internal-lb-kubetest   |
| k8s-kubetest-master-nsg |   k8s-master-kubetest-nsg  |
| k8s-kubetest-master-routetable |  k8s-master-kubetest-routetable   |
| k8s-kubetest-master-vm0 |   k8s-master-kubetest-0  |
| k8s-kubetest-master-vm0-etcddisk |   k8s-master-kubetest-0-etcddisk  |
| k8s-kubetest-master-vm0-nic |  k8s-master-kubetest-nic-0   |
| k8s-kubetest-master-vm0-osdisk |    k8s-master-kubetest-0_OsDisk_1_abca9cf1 |
| k8s-kubetest-master-vm1 |   k8s-master-kubetest-1    |
| k8s-kubetest-master-vm1-etcddisk |    k8s-master-kubetest-1-etcddisk  |
| k8s-kubetest-master-vm1-nic |   k8s-master-kubetest-nic-1  |
| k8s-kubetest-master-vm1-osdisk | k8s-master-kubetest-1_OsDisk_1_f372b4...    |
| k8s-kubetest-master-vm2 |  k8s-master-kubetest-2 |
| k8s-kubetest-master-vm2-etcddisk |   k8s-master-kubetest-2-etcddisk  |
| k8s-kubetest-master-vm2-nic | k8s-master-kubetest-nic-2    |
| k8s-kubetest-master-vm2-osdisk |  k8s-master-kubetest-2_OsDisk_1_2189f6   |
| k8s-kubetest-vnet |  k8s-vnet-kubetest   |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1237)
<!-- Reviewable:end -->
