### PR TITLE
add repo url to sirupsen dependency to fix glide installs

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -60,6 +60,7 @@ imports:
   version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - name: github.com/Sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+  repo:    https://github.com/sirupsen/logrus
 - name: github.com/spf13/cobra
   version: 4cdb38c072b86bf795d2c81de50784d9fdd6eb77
 - name: github.com/spf13/pflag

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,6 +20,7 @@ import:
   - autorest/date
 - package: github.com/Sirupsen/logrus
   version: v0.11.5
+  repo:    https://github.com/sirupsen/logrus
 - package: github.com/ghodss/yaml
   version: v1.0.0
 - package: github.com/mitchellh/go-homedir


### PR DESCRIPTION
- fixes #803
- does not update logrus dependency or any code or imports,
  just glide.yaml and lock file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1242)
<!-- Reviewable:end -->
