### PR TITLE
Add TillerImageBase for AzureChinaCloudSpec

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -38,6 +38,7 @@ var (
 		//KubernetesSpecConfig - Due to Chinese firewall issue, the default containers from google is blocked, use the Chinese local mirror instead
 		KubernetesSpecConfig: KubernetesSpecConfig{
 			KubernetesImageBase:    "mirror.azure.cn:5000/google_containers/",
+			TillerImageBase:        "mirror.azure.cn:5000/kubernetes-helm/",
 			KubeBinariesSASURLBase: "https://acs-mirror.azureedge.net/wink8s/",
 		},
 		DCOSSpecConfig: DCOSSpecConfig{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Currently when generating for China Cloud, tillerSpec doesn't have a repository basename : 
```
"kubernetesTillerSpec": {
      "value": "tiller:v2.5.1"
    },
```
This fix it by setting a missing default for AuchanChinaCloud

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1246)
<!-- Reviewable:end -->
