### PR TITLE
Enable the StorageAccount Encryption and Enforce HTTPS

### DIFF
--- a/parts/kubernetesagentresourcesvmas.t
+++ b/parts/kubernetesagentresourcesvmas.t
@@ -52,7 +52,7 @@
         {
             "platformFaultDomainCount": "2",
             "platformUpdateDomainCount": "3",
-		"managed" : "true"
+            "managed" : "true"
         },
   
       "type": "Microsoft.Compute/availabilitySets"
@@ -77,14 +77,14 @@
           "keySource": "Microsoft.Storage",
           "services": {
             "blob": {
-              "enabled": "true"
+              "enabled": true
             },
             "file": {
-              "enabled": "true"
+              "enabled": true
             }
           }
         },
-        "supportsHttpsTrafficOnly": "true"
+        "supportsHttpsTrafficOnly": true
       },
       "sku": {
         "name": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
@@ -111,14 +111,14 @@
           "keySource": "Microsoft.Storage",
           "services": {
             "blob": {
-              "enabled": "true"
+              "enabled": true
             },
             "file": {
-              "enabled": "true"
+              "enabled": true
             }
           }
         },
-        "supportsHttpsTrafficOnly": "true"
+        "supportsHttpsTrafficOnly": true
       },
       "sku": {
         "name": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"

--- a/parts/kubernetesagentresourcesvmas.t
+++ b/parts/kubernetesagentresourcesvmas.t
@@ -69,10 +69,25 @@
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
       ],
       {{end}}
+      "kind": "Storage",
       "location": "[variables('location')]",
       "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
       "properties": {
-        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": "true"
+            },
+            "file": {
+              "enabled": "true"
+            }
+          }
+        },
+        "supportsHttpsTrafficOnly": "true"
+      },
+      "sku": {
+        "name": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
       },
       "type": "Microsoft.Storage/storageAccounts"
     },
@@ -88,10 +103,25 @@
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
       ],
       {{end}}
+      "kind": "Storage",
       "location": "[variables('location')]",
       "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
       "properties": {
-        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": "true"
+            },
+            "file": {
+              "enabled": "true"
+            }
+          }
+        },
+        "supportsHttpsTrafficOnly": "true"
+      },
+      "sku": {
+        "name": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
       },
       "type": "Microsoft.Storage/storageAccounts"
     },

--- a/parts/kubernetesmasterresources.t
+++ b/parts/kubernetesmasterresources.t
@@ -24,10 +24,25 @@
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
       ],
+      "kind": "Storage",
       "location": "[variables('location')]",
       "name": "[variables('masterStorageAccountName')]",
       "properties": {
-        "accountType": "[variables('vmSizesMap')[variables('masterVMSize')].storageAccountType]"
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": "true"
+            },
+            "file": {
+              "enabled": "true"
+            }
+          }
+        },
+        "supportsHttpsTrafficOnly": "true"
+      },
+      "sku": {
+        "name": "[variables('vmSizesMap')[variables('masterVMSize')].storageAccountType]"
       },
       "type": "Microsoft.Storage/storageAccounts"
     },

--- a/parts/kubernetesmasterresources.t
+++ b/parts/kubernetesmasterresources.t
@@ -32,14 +32,14 @@
           "keySource": "Microsoft.Storage",
           "services": {
             "blob": {
-              "enabled": "true"
+              "enabled": true
             },
             "file": {
-              "enabled": "true"
+              "enabled": true
             }
           }
         },
-        "supportsHttpsTrafficOnly": "true"
+        "supportsHttpsTrafficOnly": true
       },
       "sku": {
         "name": "[variables('vmSizesMap')[variables('masterVMSize')].storageAccountType]"

--- a/parts/kubernetesmastervars.t
+++ b/parts/kubernetesmastervars.t
@@ -91,7 +91,7 @@
     "sshKeyPath": "[concat('/home/',variables('username'),'/.ssh/authorized_keys')]",
 
 {{if .HasStorageAccountDisks}}
-    "apiVersionStorage": "2015-06-15",
+    "apiVersionStorage": "2016-12-01",
     "maxVMsPerStorageAccount": 20,
     "maxStorageAccountsPerAgent": "[div(variables('maxVMsPerPool'),variables('maxVMsPerStorageAccount'))]",
     "dataStorageAccountPrefixSeed": 97,

--- a/parts/kuberneteswinagentresourcesvmas.t
+++ b/parts/kuberneteswinagentresourcesvmas.t
@@ -69,10 +69,25 @@
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
       ],
       {{end}}
+      "kind": "Storage",
       "location": "[variables('location')]",
       "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
       "properties": {
-        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": "true"
+            },
+            "file": {
+              "enabled": "true"
+            }
+          }
+        },
+        "supportsHttpsTrafficOnly": "true"
+      },
+      "sku": {
+        "name": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
       },
       "type": "Microsoft.Storage/storageAccounts"
     },
@@ -88,10 +103,25 @@
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
       ],
       {{end}}
+      "kind": "Storage",
       "location": "[variables('location')]",
       "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
       "properties": {
-        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": "true"
+            },
+            "file": {
+              "enabled": "true"
+            }
+          }
+        },
+        "supportsHttpsTrafficOnly": "true"
+      },
+      "sku": {
+        "name": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
       },
       "type": "Microsoft.Storage/storageAccounts"
     },

--- a/parts/kuberneteswinagentresourcesvmas.t
+++ b/parts/kuberneteswinagentresourcesvmas.t
@@ -77,14 +77,14 @@
           "keySource": "Microsoft.Storage",
           "services": {
             "blob": {
-              "enabled": "true"
+              "enabled": true
             },
             "file": {
-              "enabled": "true"
+              "enabled": true
             }
           }
         },
-        "supportsHttpsTrafficOnly": "true"
+        "supportsHttpsTrafficOnly": true
       },
       "sku": {
         "name": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
@@ -111,14 +111,14 @@
           "keySource": "Microsoft.Storage",
           "services": {
             "blob": {
-              "enabled": "true"
+              "enabled": true
             },
             "file": {
-              "enabled": "true"
+              "enabled": true
             }
           }
         },
-        "supportsHttpsTrafficOnly": "true"
+        "supportsHttpsTrafficOnly": true
       },
       "sku": {
         "name": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
The PR enables the [encryption at rest](https://docs.microsoft.com/en-us/azure/storage/storage-security-guide#encryption-at-rest) and enforces [encryption in transit](https://docs.microsoft.com/en-us/azure/storage/storage-security-guide#encryption-in-transit) for the StorageAccount provisioned by acs-engine for Kubernetes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
It's a requirement from the internal security review of CloudShell.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1258)
<!-- Reviewable:end -->
