### PR TITLE
fix(Makefile): run generate before test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ ifneq ($(GIT_BASEDIR),)
 	LDFLAGS += -X github.com/Azure/acs-engine/pkg/test.JUnitOutDir=${GIT_BASEDIR}/test/junit
 endif
 
-test:
+test: generate
 	ginkgo -skipPackage test/e2e -r .
 
 .PHONY: test-style


### PR DESCRIPTION
closes #1251

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1264)
<!-- Reviewable:end -->
