### PR TITLE
Fix message format

### DIFF
--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -322,7 +322,7 @@ func (az *AzureClient) ensureProvidersRegistered(subscriptionID string) error {
 		if registered {
 			log.Debugf("Already registered for %q", provider)
 		} else {
-			log.Info("Registering subscription to resource provider. provider=%q subscription=%q", provider, subscriptionID)
+			log.Infof("Registering subscription to resource provider. provider=%q subscription=%q", provider, subscriptionID)
 			if _, err := az.providersClient.Register(provider); err != nil {
 				return err
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
 Fixes error in format of message creating a deploy
```console 
INFO[0004] Registering subscription to resource provider. provider=%q subscription=%qMicrosoft.ComputeXXXXXX-XXXX-XXXX-XXXXXXXXXXXX
```

**Release note**:
`NONE`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1265)
<!-- Reviewable:end -->
