### PR TITLE
chore(dcos-e2e): run dcos pr-e2e in southcentralus

### DIFF
--- a/test/e2e/dcos-deployments.json
+++ b/test/e2e/dcos-deployments.json
@@ -14,7 +14,7 @@
 		},
 		{
 			"cluster_definition": "disks-storageaccount/dcos.json",
-			"location": "westcentralus"
+			"location": "southcentralus"
 		},
 		{
 			"cluster_definition": "vnet/dcosvnet.json",


### PR DESCRIPTION
This moves one of the DCOS pr-e2e tests into `southcentralus`, where we were just granted a core quota increase—`westcentralus` is experiencing capacity issues apparently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1267)
<!-- Reviewable:end -->
