### PR TITLE
Fix Docker dev environment build failure on Windows and Mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN git clone https://github.com/akesterson/shunit.git /tmp/shunit \
 WORKDIR /gopath/src/github.com/Azure/acs-engine
 
 # Cache vendor layer
-ADD Makefile versioning.mk glide.yaml glide.lock /gopath/src/github.com/Azure/acs-engine/
+ADD Makefile test.mk versioning.mk glide.yaml glide.lock /gopath/src/github.com/Azure/acs-engine/
 RUN make bootstrap
 
 ADD . /gopath/src/github.com/Azure/acs-engine


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: The `./scripts/devenv.ps1` scripts fails on Windows and Mac with the error 'test.mk: no such file or directory`. This breaks the Docker dev/build environment.

**Which issue this PR fixes**: fixes #1271

**Special notes for your reviewer**: I have tested this only on Windows; I don't have a Mac to test on but I think it should work!

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1275)
<!-- Reviewable:end -->
