### PR TITLE
fix(Makefile): Call bootstrap before we run generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ DIST_DIRS         = find * -type d -exec
 
 # go option
 GO        ?= go
-PKG       := $(shell glide novendor)
 TAGS      :=
 LDFLAGS   :=
 GOFLAGS   :=

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,6 @@ BINDIR    := $(CURDIR)/bin
 BINARIES  := acs-engine
 VERSION   ?= $(shell git rev-parse HEAD)
 
-GOFILES=`glide novendor | xargs go list`
-
 REPO_PATH := github.com/Azure/acs-engine
 DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.2.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
@@ -31,7 +29,7 @@ all: build
 
 .PHONY: generate
 generate: bootstrap
-	go generate -v $(GOFILES)
+	go generate -v `glide novendor | xargs go list`
 
 .PHONY: build
 build: generate

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ BINARY_DEST_DIR ?= bin
 all: build
 
 .PHONY: generate
-generate:
+generate: bootstrap
 	go generate -v $(GOFILES)
 
 .PHONY: build


### PR DESCRIPTION
closes #1274
We call out to glide to get a list of directories when we run generate. This fails if the person doesnt have glide. So lets just go ahead and call bootstrap as part of that process

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1276)
<!-- Reviewable:end -->
