### PR TITLE
change master count to 1 for k8s 1.6/1.7 example files

### DIFF
--- a/examples/kubernetes-releases/kubernetes1.6.json
+++ b/examples/kubernetes-releases/kubernetes1.6.json
@@ -6,7 +6,7 @@
       "orchestratorRelease": "1.6"
     },
     "masterProfile": {
-      "count": 3,
+      "count": 1,
       "dnsPrefix": "",
       "vmSize": "Standard_D2_v2"
     },

--- a/examples/kubernetes-releases/kubernetes1.7.json
+++ b/examples/kubernetes-releases/kubernetes1.7.json
@@ -6,7 +6,7 @@
       "orchestratorRelease": "1.7"
     },
     "masterProfile": {
-      "count": 3,
+      "count": 1,
       "dnsPrefix": "",
       "vmSize": "Standard_D2_v2"
     },


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

The kubernetes 1.6 & 1.7 example files have a master count of 3. All other kubernetes examples have a master count of 1 (which is what I would expect as a user). I believe this was likely just a fat-finger in the past that got carried over. Reverting back to 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1287)
<!-- Reviewable:end -->
