### PR TITLE
fix(kubernetes_test): Wait for dashboard to be ready before performing test

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -127,6 +127,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 	})
 
 	It("should be able to access the dashboard from each node", func() {
+		pod.WaitOnReady("kubernetes-dashboard", "kube-system", 5*time.Second, 3*time.Minute)
 		kubeConfig, err := GetConfig()
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Its possible that the access dashboard test will run before the pods are in a ready state. This adds a wait to help with taht condition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1292)
<!-- Reviewable:end -->
