### PR TITLE
we don’t want to run the hold job on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,9 @@ workflows:
       - test
       - pr-e2e-hold:
           type: approval
+          filters:
+            branches:
+              ignore: master
       - non-k8s-pr-e2e:
           requires:
             - pr-e2e-hold


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: circleci config

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1302)
<!-- Reviewable:end -->
