### PR TITLE
Unit test standalone agent pool scenario and misc agent pool only fixes

### DIFF
--- a/parts/kubernetesmastervars.t
+++ b/parts/kubernetesmastervars.t
@@ -123,7 +123,7 @@
     "virtualNetworkName": "[concat(variables('orchestratorName'), '-vnet-', variables('nameSuffix'))]",
   {{end}}
 {{else}}
-    "subnet": "10.0.0/16",
+    "subnet": "10.0.0.0/16",
     "subnetName": "[concat(variables('orchestratorName'), '-subnet')]",
     "virtualNetworkName": "[concat(variables('orchestratorName'), '-vnet-', variables('nameSuffix'))]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",

--- a/pkg/acsengine/testdata/agentPoolOnly/v20170831/agents.json
+++ b/pkg/acsengine/testdata/agentPoolOnly/v20170831/agents.json
@@ -1,0 +1,29 @@
+{
+  "apiVersion": "2017-08-31",
+  "properties": {
+    "dnsPrefix": "agents006",
+    "fqdn": "agents006.azmk8s.io",
+    "kubernetesRelease": "1.7",
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 2,
+        "vmSize": "Standard_D2_v2"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+             "keyData": "ssh-rsa PUBLICKEY azureuser@linuxvm"
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientID": "ServicePrincipalClientID",
+      "secret": "myServicePrincipalClientSecret"
+    }
+  }
+}

--- a/pkg/api/agentPoolOnlyApi/v20170831/types.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/types.go
@@ -38,7 +38,7 @@ type Properties struct {
 	LinuxProfile            *LinuxProfile            `json:"linuxProfile,omitempty" validate:"required"`
 	WindowsProfile          *WindowsProfile          `json:"windowsProfile,omitempty"`
 	ServicePrincipalProfile *ServicePrincipalProfile `json:"servicePrincipalProfile,omitempty"`
-	AccessProfiles          []*AccessProfile         `json:"accessProfiles,omitempty"`
+	AccessProfiles          map[string]AccessProfile `json:"accessProfiles,omitempty"`
 }
 
 // ServicePrincipalProfile contains the client and secret used by the cluster for Azure Resource CRUD
@@ -118,7 +118,6 @@ type AgentPoolProfile struct {
 
 // AccessProfile represents role name and kubeconfig
 type AccessProfile struct {
-	RoleName   string `json:"roleName"`
 	KubeConfig string `json:"kubeConfig"`
 }
 

--- a/pkg/api/agentPoolOnlyApi/v20170831/types.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/types.go
@@ -38,7 +38,7 @@ type Properties struct {
 	LinuxProfile            *LinuxProfile            `json:"linuxProfile,omitempty" validate:"required"`
 	WindowsProfile          *WindowsProfile          `json:"windowsProfile,omitempty"`
 	ServicePrincipalProfile *ServicePrincipalProfile `json:"servicePrincipalProfile,omitempty"`
-	AccessProfiles          []*AccessProfile         `json:"accessProfiles,omitempty"` //@todo(jahanse): not used
+	AccessProfiles          []*AccessProfile         `json:"accessProfiles,omitempty"`
 }
 
 // ServicePrincipalProfile contains the client and secret used by the cluster for Azure Resource CRUD

--- a/pkg/api/agentPoolOnlyApi/vlabs/types.go
+++ b/pkg/api/agentPoolOnlyApi/vlabs/types.go
@@ -38,7 +38,7 @@ type Properties struct {
 	LinuxProfile            *LinuxProfile            `json:"linuxProfile,omitempty" validate:"required"`
 	WindowsProfile          *WindowsProfile          `json:"windowsProfile,omitempty"`
 	ServicePrincipalProfile *ServicePrincipalProfile `json:"servicePrincipalProfile,omitempty"`
-	AccessProfiles          []*AccessProfile         `json:"accessProfiles,omitempty"`
+	AccessProfiles          map[string]AccessProfile `json:"accessProfiles,omitempty"`
 	CertificateProfile      *CertificateProfile      `json:"certificateProfile,omitempty" validate:"required"`
 }
 

--- a/pkg/api/agentPoolOnlyApi/vlabs/types.go
+++ b/pkg/api/agentPoolOnlyApi/vlabs/types.go
@@ -38,7 +38,7 @@ type Properties struct {
 	LinuxProfile            *LinuxProfile            `json:"linuxProfile,omitempty" validate:"required"`
 	WindowsProfile          *WindowsProfile          `json:"windowsProfile,omitempty"`
 	ServicePrincipalProfile *ServicePrincipalProfile `json:"servicePrincipalProfile,omitempty"`
-	AccessProfiles          []*AccessProfile         `json:"accessProfiles,omitempty"` //@todo(jahanse): not used
+	AccessProfiles          []*AccessProfile         `json:"accessProfiles,omitempty"`
 	CertificateProfile      *CertificateProfile      `json:"certificateProfile,omitempty" validate:"required"`
 }
 

--- a/pkg/api/apiloader.go
+++ b/pkg/api/apiloader.go
@@ -151,6 +151,7 @@ func (a *Apiloader) LoadContainerServiceForAgentPoolOnlyCluster(contents []byte,
 		if e := json.Unmarshal(contents, &hostedMaster); e != nil {
 			return nil, e
 		}
+		setHostedMasterDefaultsv20170701(hostedMaster)
 		if e := hostedMaster.Properties.Validate(); validate && e != nil {
 			return nil, e
 		}
@@ -160,6 +161,7 @@ func (a *Apiloader) LoadContainerServiceForAgentPoolOnlyCluster(contents []byte,
 		if e := json.Unmarshal(contents, &hostedMaster); e != nil {
 			return nil, e
 		}
+		setHostedMasterDefaultsvlabs(hostedMaster)
 		if e := hostedMaster.Properties.Validate(); validate && e != nil {
 			return nil, e
 		}
@@ -295,4 +297,14 @@ func setContainerServiceDefaultsvlabs(c *vlabs.ContainerService) {
 	if c.Properties.OrchestratorProfile != nil {
 		c.Properties.OrchestratorProfile.OrchestratorVersion = ""
 	}
+}
+
+// Sets default HostedMaster property values for any appropriate zero values
+func setHostedMasterDefaultsv20170701(hm *v20170831.HostedMaster) {
+	hm.Properties.KubernetesVersion = ""
+}
+
+// Sets default HostedMaster property values for any appropriate zero values
+func setHostedMasterDefaultsvlabs(hm *apvlabs.HostedMaster) {
+	hm.Properties.KubernetesVersion = ""
 }

--- a/pkg/api/apiloader.go
+++ b/pkg/api/apiloader.go
@@ -151,7 +151,7 @@ func (a *Apiloader) LoadContainerServiceForAgentPoolOnlyCluster(contents []byte,
 		if e := json.Unmarshal(contents, &hostedMaster); e != nil {
 			return nil, e
 		}
-		setHostedMasterDefaultsv20170701(hostedMaster)
+		setHostedMasterDefaultsv20170831(hostedMaster)
 		if e := hostedMaster.Properties.Validate(); validate && e != nil {
 			return nil, e
 		}
@@ -300,7 +300,7 @@ func setContainerServiceDefaultsvlabs(c *vlabs.ContainerService) {
 }
 
 // Sets default HostedMaster property values for any appropriate zero values
-func setHostedMasterDefaultsv20170701(hm *v20170831.HostedMaster) {
+func setHostedMasterDefaultsv20170831(hm *v20170831.HostedMaster) {
 	hm.Properties.KubernetesVersion = ""
 }
 

--- a/pkg/api/converterfromagentpoolonlyapi.go
+++ b/pkg/api/converterfromagentpoolonlyapi.go
@@ -41,8 +41,13 @@ func convertResourcePurchasePlanToV20170831AgentPoolOnly(api *ResourcePurchasePl
 func convertPropertiesToV20170831AgentPoolOnly(api *Properties, p *v20170831.Properties) {
 	p.ProvisioningState = v20170831.ProvisioningState(api.ProvisioningState)
 	if api.OrchestratorProfile != nil {
-		p.KubernetesVersion = api.OrchestratorProfile.OrchestratorVersion
-		p.KubernetesRelease = api.OrchestratorProfile.OrchestratorRelease
+		if api.OrchestratorProfile.OrchestratorRelease != "" {
+			p.KubernetesVersion = api.OrchestratorProfile.OrchestratorVersion
+		}
+
+		if api.OrchestratorProfile.OrchestratorVersion != "" {
+			p.KubernetesRelease = api.OrchestratorProfile.OrchestratorRelease
+		}
 	}
 	if api.HostedMasterProfile != nil {
 		p.DNSPrefix = api.HostedMasterProfile.DNSPrefix


### PR DESCRIPTION
**What this PR does / why we need it**:
1) ACS Engine enabled creation of standalone agent pools: https://github.com/Azure/acs-engine/pull/1290. The template generation code path is shared by both full cluster creation scenario and agent pool only scenario. The unit test in this PR validates that agent pool only scenario template is a syntactically correct JSON.
2) Fix typo in subnet mask
3) Convert AccessProfiles to be a map instead of an array
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1305)
<!-- Reviewable:end -->
