### PR TITLE
Updating the information that must be provided

### DIFF
--- a/docs/acsengine.md
+++ b/docs/acsengine.md
@@ -24,7 +24,7 @@ If would prefer to build `acs-engine` from source or are you are interested in c
 Here is an example of how to generate a new deployment. This example assumes you are using [examples/kubernetes.json](../examples/kubernetes.json).
 
 1. Before starting ensure you have generated a valid [SSH Public/Private key pair](ssh.md#ssh-key-generation).
-2. edit [examples/kubernetes.json](../examples/kubernetes.json) and fill in the blanks. The necessary [deployment values](../kubernetes/deploy.md#gather-information) (outside of the SSH public key that you created in step 1, above) include a DNS prefix, and a [service principal](./serviceprincipal.md). (If you don't already have one to enter here, that will be detected at deploy and one is generated for you.)
+2. edit [examples/kubernetes.json](../examples/kubernetes.json) and fill in the blanks. The necessary [deployment values](kubernetes/deploy.md#gather-information) (outside of the SSH public key that you created in step 1, above) include a DNS prefix, and a [service principal](./serviceprincipal.md). (If you don't already have one to enter here, that will be detected at deploy and one is generated for you.)
 3. run `./bin/acs-engine generate examples/kubernetes.json` to generate the templates in the _output/Kubernetes-UNIQUEID directory.  The UNIQUEID is a hash of your master's FQDN prefix.
 4. now you can use the `azuredeploy.json` and `azuredeploy.parameters.json` for deployment as described in [Deploy Templates](#deploy-templates).
 

--- a/docs/acsengine.md
+++ b/docs/acsengine.md
@@ -24,7 +24,7 @@ If would prefer to build `acs-engine` from source or are you are interested in c
 Here is an example of how to generate a new deployment. This example assumes you are using [examples/kubernetes.json](../examples/kubernetes.json).
 
 1. Before starting ensure you have generated a valid [SSH Public/Private key pair](ssh.md#ssh-key-generation).
-2. edit [examples/kubernetes.json](../examples/kubernetes.json) and fill in the blanks.
+2. edit [examples/kubernetes.json](../examples/kubernetes.json) and fill in the blanks. The necessary [deployment values](../kubernetes/deploy.md#gather-information) (outside of the SSH public key that you created in step 1, above) include a DNS prefix, and a [service principal](./serviceprincipal.md). (If you don't already have one to enter here, that will be detected at deploy and one is generated for you.)
 3. run `./bin/acs-engine generate examples/kubernetes.json` to generate the templates in the _output/Kubernetes-UNIQUEID directory.  The UNIQUEID is a hash of your master's FQDN prefix.
 4. now you can use the `azuredeploy.json` and `azuredeploy.parameters.json` for deployment as described in [Deploy Templates](#deploy-templates).
 


### PR DESCRIPTION
Added links to deploy and serviceprincipal, and included information that if you don't have one yet the SP is created automatically on deploy.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
https://github.com/Azure/acs-engine/issues/1293
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/Azure/acs-engine/issues/1293
**Special notes for your reviewer**:
Decide.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added links to deploy and serviceprincipal, and included information that if you don't have one yet the SP is created automatically on deploy.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1309)
<!-- Reviewable:end -->
