### PR TITLE
adding regional distribution to k8s e2e config

### DIFF
--- a/test/e2e/kubernetes-deployments.json
+++ b/test/e2e/kubernetes-deployments.json
@@ -6,11 +6,11 @@
 		},
 		{
 			"cluster_definition": "windows/kubernetes.json",
-			"location": "southcentralus"
+			"location": "eastus"
 		},
 		{
 			"cluster_definition": "disks-managed/kubernetes-preAttachedDisks-vmas.json",
-			"location": "southcentralus"
+			"location": "westus2"
 		},
 		{
 			"cluster_definition": "disks-managed/kubernetes-vmas.json",
@@ -18,11 +18,11 @@
 		},
 		{
 			"cluster_definition": "disks-storageaccount/kubernetes.json",
-			"location": "westcentralus"
+			"location": "westus2"
 		},
 		{
 			"cluster_definition": "kubernetes-releases/kubernetes1.5.json",
-			"location": "southcentralus"
+			"location": "eastus"
 		},
 		{
 			"cluster_definition": "networkpolicy/kubernetes-calico.json",
@@ -30,11 +30,11 @@
 		},
 		{
 			"cluster_definition": "kubernetes-config/kubernetes-clustersubnet.json",
-			"location": "southcentralus"
+			"location": "eastus"
 		},
 		{
 			"cluster_definition": "vnet/kubernetesvnet.json",
-			"location": "southcentralus"
+			"location": "westus2"
 		}
 	]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: spreads out regional effects of k8s e2e tests

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1322)
<!-- Reviewable:end -->
