### PR TITLE
fix(test/e2e/kubernetes): Bring k8s e2e tests to parity with bash tests

### DIFF
--- a/test/e2e/engine/cli.go
+++ b/test/e2e/engine/cli.go
@@ -7,15 +7,10 @@ import (
 
 // Generate will run acs-engine generate on a given cluster definition
 func (e *Engine) Generate() error {
-	cmd := exec.Command("acs-engine", "generate", e.ClusterDefinitionTemplate, "--output-directory", e.GeneratedDefinitionPath)
-	err := cmd.Start()
+	out, err := exec.Command("acs-engine", "generate", e.ClusterDefinitionTemplate, "--output-directory", e.GeneratedDefinitionPath).CombinedOutput()
 	if err != nil {
-		log.Printf("Error while trying to start generate:%s\n", err)
-		return err
-	}
-	err = cmd.Wait()
-	if err != nil {
-		log.Printf("Error while trying to generate acs-engine template with cluster definition - %s: %s", e.GeneratedDefinitionPath, err)
+		log.Printf("Error while trying to generate acs-engine template with cluster definition - %s: %s\n", e.ClusterDefinitionTemplate, err)
+		log.Printf("Output:%s\n", out)
 		return err
 	}
 	return nil

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -24,13 +24,14 @@ type Config struct {
 // Engine holds necessary information to interact with acs-engine cli
 type Engine struct {
 	Config                    *Config
-	ClusterDefinitionPath     string // The original template we want to use to build the cluster from.
-	ClusterDefinitionTemplate string // This is the template after we splice in the environment variables
-	GeneratedDefinitionPath   string // Holds the contents of running acs-engine generate
-	OutputPath                string // This is the root output path
-	DefinitionName            string // Unique cluster name
-	GeneratedTemplatePath     string // azuredeploy.json path
-	GeneratedParametersPath   string // azuredeploy.parameters.json path
+	ClusterDefinitionPath     string                       // The original template we want to use to build the cluster from.
+	ClusterDefinitionTemplate string                       // This is the template after we splice in the environment variables
+	GeneratedDefinitionPath   string                       // Holds the contents of running acs-engine generate
+	OutputPath                string                       // This is the root output path
+	DefinitionName            string                       // Unique cluster name
+	GeneratedTemplatePath     string                       // azuredeploy.json path
+	GeneratedParametersPath   string                       // azuredeploy.parameters.json path
+	ClusterDefinition         api.VlabsARMContainerService // Holds the parsed ClusterDefinition
 }
 
 // ParseConfig will return a new engine config struct taking values from env vars
@@ -94,7 +95,29 @@ func Build(templatePath, outputPath, definitionName string) (*Engine, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	engine.ClusterDefinition = *cs
 	return &engine, nil
+}
+
+// HasLinuxAgents will return true if there is at least 1 linux agent pool
+func (e *Engine) HasLinuxAgents() bool {
+	for _, ap := range e.ClusterDefinition.Properties.AgentPoolProfiles {
+		if ap.OSType == "" || ap.OSType == "Linux" {
+			return true
+		}
+	}
+	return false
+}
+
+// HasWindowsAgents will return true is there is at least 1 windows agent pool
+func (e *Engine) HasWindowsAgents() bool {
+	for _, ap := range e.ClusterDefinition.Properties.AgentPoolProfiles {
+		if ap.OSType == "Windows" {
+			return true
+		}
+	}
+	return false
 }
 
 // Parse takes a template path and will parse that into a api.VlabsARMContainerService

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"net/http"
 	"os"
 	"os/exec"
@@ -22,8 +23,9 @@ import (
 
 var (
 	cfg  config.Config
-	err  error
 	acct azure.Account
+	eng  engine.Engine
+	err  error
 )
 
 var _ = BeforeSuite(func() {
@@ -44,8 +46,9 @@ var _ = BeforeSuite(func() {
 		// Lets modify our template and call acs-engine generate on it
 		e, err := engine.Build(cfg.ClusterDefinition, "_output", cfg.Name)
 		Expect(err).NotTo(HaveOccurred())
+		eng = *e
 
-		err = e.Generate()
+		err = eng.Generate()
 		Expect(err).NotTo(HaveOccurred())
 
 		err = acct.CreateGroup(cfg.Name, cfg.Location)
@@ -53,8 +56,12 @@ var _ = BeforeSuite(func() {
 
 		// Lets start by just using the normal az group deployment cli for creating a cluster
 		log.Println("Creating deployment this make take a few minutes...")
-		err = acct.CreateDeployment(cfg.Name, e)
+		err = acct.CreateDeployment(cfg.Name, &eng)
 		Expect(err).NotTo(HaveOccurred())
+	} else {
+		e, err := engine.Build(cfg.ClusterDefinition, "_output", cfg.Name)
+		Expect(err).NotTo(HaveOccurred())
+		eng = *e
 	}
 
 	err = os.Setenv("KUBECONFIG", cfg.GetKubeConfig())
@@ -70,108 +77,183 @@ var _ = AfterSuite(func() {
 		log.Printf("Deleting Group:%s\n", cfg.Name)
 		acct.DeleteGroup()
 	}
-
-	if _, err := os.Stat(cfg.GetKubeConfig()); os.IsExist(err) {
-		if svc, _ := service.Get(cfg.Name, "default"); svc != nil {
-			svc.Delete()
-		}
-
-		if d, _ := deployment.Get(cfg.Name, "default"); d != nil {
-			d.Delete()
-		}
-	}
 })
 
 var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", func() {
+	Context("regardless of agent pool type", func() {
+		It("should be logged into the correct account", func() {
+			current, err := azure.GetCurrentAccount()
 
-	It("should be logged into the correct account", func() {
-		current, err := azure.GetCurrentAccount()
-
-		Expect(err).NotTo(HaveOccurred())
-		Expect(current.User.ID).To(Equal(acct.User.ID))
-		Expect(current.TenantID).To(Equal(acct.TenantID))
-		Expect(current.SubscriptionID).To(Equal(acct.SubscriptionID))
-	})
-
-	It("should have have the appropriate node count", func() {
-		nodeList, err := node.Get()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(len(nodeList.Nodes)).To(Equal(4))
-	})
-
-	It("should be running the expected default version", func() {
-		version, err := node.Version()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(version).To(Equal("v1.6.6"))
-	})
-
-	It("should have kube-dns running", func() {
-		running, err := pod.WaitOnReady("kube-dns", "kube-system", 5*time.Second, 10*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(running).To(Equal(true))
-	})
-
-	It("should have kube-dashboard running", func() {
-		running, err := pod.WaitOnReady("kubernetes-dashboard", "kube-system", 5*time.Second, 10*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(running).To(Equal(true))
-	})
-
-	It("should have kube-proxy running", func() {
-		running, err := pod.WaitOnReady("kube-proxy", "kube-system", 5*time.Second, 10*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(running).To(Equal(true))
-	})
-
-	It("should be able to access the dashboard from each node", func() {
-		running, err := pod.WaitOnReady("kube-proxy", "kube-system", 5*time.Second, 10*time.Minute)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(running).To(Equal(true))
-
-		kubeConfig, err := GetConfig()
-		Expect(err).NotTo(HaveOccurred())
-
-		sshKeyPath, err := cfg.GetSSHKeyPath()
-		Expect(err).NotTo(HaveOccurred())
-
-		s, err := service.Get("kubernetes-dashboard", "kube-system")
-		Expect(err).NotTo(HaveOccurred())
-		port := s.GetNodePort(80)
-
-		master := fmt.Sprintf("azureuser@%s", kubeConfig.GetServerName())
-		nodeList, err := node.Get()
-		Expect(err).NotTo(HaveOccurred())
-
-		for _, node := range nodeList.Nodes {
-			dashboardURL := fmt.Sprintf("http://%s:%v", node.Status.GetAddressByType("InternalIP").Address, port)
-			curlCMD := fmt.Sprintf("curl --max-time 60 %s", dashboardURL)
-			output, err := exec.Command("ssh", "-i", sshKeyPath, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, curlCMD).CombinedOutput()
-			if err != nil {
-				log.Printf("\n\nOutput:%s\n\n", string(output))
-			}
 			Expect(err).NotTo(HaveOccurred())
-		}
+			Expect(current.User.ID).To(Equal(acct.User.ID))
+			Expect(current.TenantID).To(Equal(acct.TenantID))
+			Expect(current.SubscriptionID).To(Equal(acct.SubscriptionID))
+		})
+
+		It("should have have the appropriate node count", func() {
+			expectedCount := eng.ClusterDefinition.Properties.MasterProfile.Count
+			for _, pool := range eng.ClusterDefinition.Properties.AgentPoolProfiles {
+				expectedCount = expectedCount + pool.Count
+			}
+			nodeList, err := node.Get()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(nodeList.Nodes)).To(Equal(expectedCount))
+		})
+
+		It("should be running the expected default version", func() {
+			version, err := node.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal("v1.6.6"))
+		})
+
+		It("should have kube-dns running", func() {
+			running, err := pod.WaitOnReady("kube-dns", "kube-system", 5*time.Second, 10*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(running).To(Equal(true))
+		})
+
+		It("should have kube-dashboard running", func() {
+			running, err := pod.WaitOnReady("kubernetes-dashboard", "kube-system", 5*time.Second, 10*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(running).To(Equal(true))
+		})
+
+		It("should have kube-proxy running", func() {
+			running, err := pod.WaitOnReady("kube-proxy", "kube-system", 5*time.Second, 10*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(running).To(Equal(true))
+		})
+
+		It("should have heapster running", func() {
+			running, err := pod.WaitOnReady("heapster", "kube-system", 5*time.Second, 10*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(running).To(Equal(true))
+		})
+
+		It("should have kube-addon-manager running", func() {
+			running, err := pod.WaitOnReady("kube-addon-manager", "kube-system", 5*time.Second, 10*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(running).To(Equal(true))
+		})
+
+		It("should have kube-apiserver running", func() {
+			running, err := pod.WaitOnReady("kube-apiserver", "kube-system", 5*time.Second, 10*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(running).To(Equal(true))
+		})
+
+		It("should have kube-controller-manager running", func() {
+			running, err := pod.WaitOnReady("kube-controller-manager", "kube-system", 5*time.Second, 10*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(running).To(Equal(true))
+		})
+
+		It("should have kube-scheduler running", func() {
+			running, err := pod.WaitOnReady("kube-scheduler", "kube-system", 5*time.Second, 10*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(running).To(Equal(true))
+		})
+
+		It("should have tiller running", func() {
+			running, err := pod.WaitOnReady("tiller", "kube-system", 5*time.Second, 10*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(running).To(Equal(true))
+		})
+
+		It("should be able to access the dashboard from each node", func() {
+			running, err := pod.WaitOnReady("kube-proxy", "kube-system", 5*time.Second, 10*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(running).To(Equal(true))
+
+			kubeConfig, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			sshKeyPath, err := cfg.GetSSHKeyPath()
+			Expect(err).NotTo(HaveOccurred())
+
+			s, err := service.Get("kubernetes-dashboard", "kube-system")
+			Expect(err).NotTo(HaveOccurred())
+			port := s.GetNodePort(80)
+
+			master := fmt.Sprintf("azureuser@%s", kubeConfig.GetServerName())
+			nodeList, err := node.Get()
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, node := range nodeList.Nodes {
+				dashboardURL := fmt.Sprintf("http://%s:%v", node.Status.GetAddressByType("InternalIP").Address, port)
+				curlCMD := fmt.Sprintf("curl --max-time 60 %s", dashboardURL)
+				output, err := exec.Command("ssh", "-i", sshKeyPath, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, curlCMD).CombinedOutput()
+				if err != nil {
+					log.Printf("\n\nOutput:%s\n\n", string(output))
+				}
+			}
+		})
 	})
 
-	It("should be able to deploy an nginx service", func() {
-		d, err := deployment.Create("library/nginx:latest", cfg.Name, "default")
-		Expect(err).NotTo(HaveOccurred())
-		err = d.Expose(80)
-		Expect(err).NotTo(HaveOccurred())
+	Context("with a linux agent pool", func() {
+		It("should be able to deploy an nginx service", func() {
+			if eng.HasLinuxAgents() {
+				r := rand.New(rand.NewSource(time.Now().UnixNano()))
+				deploymentName := fmt.Sprintf("%s-%v", cfg.Name, r.Intn(99999))
+				d, err := deployment.CreateLinuxDeploy("library/nginx:latest", deploymentName, "default")
+				Expect(err).NotTo(HaveOccurred())
 
-		s, err := service.Get(cfg.Name, "default")
-		Expect(err).NotTo(HaveOccurred())
-		s, err = s.WaitForExternalIP(360, 5)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(s.Status.LoadBalancer.Ingress).NotTo(BeEmpty())
+				running, err := pod.WaitOnReady(deploymentName, "default", 5*time.Second, 10*time.Minute)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(running).To(Equal(true))
 
-		url := fmt.Sprintf("http://%s", s.Status.LoadBalancer.Ingress[0]["ip"])
-		resp, err := http.Get(url)
-		Expect(err).NotTo(HaveOccurred())
-		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(body)).To(MatchRegexp("(Welcome to nginx)"))
+				err = d.Expose(80, 80)
+				Expect(err).NotTo(HaveOccurred())
+
+				s, err := service.Get(deploymentName, "default")
+				Expect(err).NotTo(HaveOccurred())
+				s, err = s.WaitForExternalIP(10*time.Minute, 5*time.Second)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(s.Status.LoadBalancer.Ingress).NotTo(BeEmpty())
+
+				url := fmt.Sprintf("http://%s", s.Status.LoadBalancer.Ingress[0]["ip"])
+				resp, err := http.Get(url)
+				Expect(err).NotTo(HaveOccurred())
+				defer resp.Body.Close()
+				body, err := ioutil.ReadAll(resp.Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(body)).To(MatchRegexp("(Welcome to nginx)"))
+			} else {
+				Skip("No linux agent was provisioned for this Cluster Definition")
+			}
+		})
 	})
 
+	Context("with a windows agent pool", func() {
+		It("should be able to deploy an iis webserver", func() {
+			if eng.HasWindowsAgents() {
+				r := rand.New(rand.NewSource(time.Now().UnixNano()))
+				deploymentName := fmt.Sprintf("%s-%v", cfg.Name, r.Intn(99999))
+				d, err := deployment.CreateWindowsDeploy("microsoft/iis", deploymentName, "default", 80)
+				Expect(err).NotTo(HaveOccurred())
+
+				running, err := pod.WaitOnReady(deploymentName, "default", 5*time.Second, 15*time.Minute)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(running).To(Equal(true))
+
+				err = d.Expose(80, 80)
+				Expect(err).NotTo(HaveOccurred())
+
+				s, err := service.Get(deploymentName, "default")
+				Expect(err).NotTo(HaveOccurred())
+				s, err = s.WaitForExternalIP(10*time.Minute, 5*time.Second)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(s.Status.LoadBalancer.Ingress).NotTo(BeEmpty())
+
+				url := fmt.Sprintf("http://%s", s.Status.LoadBalancer.Ingress[0]["ip"])
+				resp, err := http.Get(url)
+				Expect(err).NotTo(HaveOccurred())
+				defer resp.Body.Close()
+				body, err := ioutil.ReadAll(resp.Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(body)).To(MatchRegexp("(IIS Windows Server)"))
+			} else {
+				Skip("No windows agent was provisioned for this Cluster Definition")
+			}
+		})
+	})
 })

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -2,10 +2,8 @@ package kubernetes
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
-	"net/http"
 	"os"
 	"os/exec"
 	"time"
@@ -210,13 +208,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 				Expect(s.Status.LoadBalancer.Ingress).NotTo(BeEmpty())
 
-				url := fmt.Sprintf("http://%s", s.Status.LoadBalancer.Ingress[0]["ip"])
-				resp, err := http.Get(url)
-				Expect(err).NotTo(HaveOccurred())
-				defer resp.Body.Close()
-				body, err := ioutil.ReadAll(resp.Body)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(string(body)).To(MatchRegexp("(Welcome to nginx)"))
+				valid := s.Validate("(Welcome to nginx)", 5, 5*time.Second)
+				Expect(valid).To(BeTrue())
 			} else {
 				Skip("No linux agent was provisioned for this Cluster Definition")
 			}
@@ -244,13 +237,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 				Expect(s.Status.LoadBalancer.Ingress).NotTo(BeEmpty())
 
-				url := fmt.Sprintf("http://%s", s.Status.LoadBalancer.Ingress[0]["ip"])
-				resp, err := http.Get(url)
-				Expect(err).NotTo(HaveOccurred())
-				defer resp.Body.Close()
-				body, err := ioutil.ReadAll(resp.Body)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(string(body)).To(MatchRegexp("(IIS Windows Server)"))
+				valid := s.Validate("(IIS Windows Server)", 5, 5*time.Second)
+				Expect(valid).To(BeTrue())
 			} else {
 				Skip("No windows agent was provisioned for this Cluster Definition")
 			}

--- a/test/e2e/kubernetes/service/service.go
+++ b/test/e2e/kubernetes/service/service.go
@@ -86,27 +86,22 @@ func (s *Service) GetNodePort(port int) int {
 }
 
 // WaitForExternalIP waits for an external ip to be provisioned
-func (s *Service) WaitForExternalIP(wait, sleep int) (*Service, error) {
+func (s *Service) WaitForExternalIP(wait, sleep time.Duration) (*Service, error) {
 	svcCh := make(chan *Service)
 	errCh := make(chan error)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(wait))
+	ctx, cancel := context.WithTimeout(context.Background(), wait)
 	defer cancel()
 	go func() {
-		var svc *Service
-		var err error
 		for {
 			select {
 			case <-ctx.Done():
 				errCh <- fmt.Errorf("Timeout exceeded while waiting for External IP to be provisioned")
 			default:
-				svc, err = Get(s.Metadata.Name, s.Metadata.Namespace)
-				if err != nil {
-					errCh <- err
-				}
+				svc, _ := Get(s.Metadata.Name, s.Metadata.Namespace)
 				if svc.Status.LoadBalancer.Ingress != nil {
 					svcCh <- svc
 				}
-				time.Sleep(time.Second * time.Duration(sleep))
+				time.Sleep(sleep)
 			}
 		}
 	}()

--- a/test/e2e/runner
+++ b/test/e2e/runner
@@ -39,6 +39,4 @@ export DNS_PREFIX=test-$(echo $RANDOM)
 
 ginkgo -slowSpecThreshold 60 -r test/e2e/${TEST}
 
-if [ -z "${CLEANUP_ON_EXIT}" ] || [ "${CLEANUP_ON_EXIT}" != false ]; then
-  ssh-add -d _output/${SSH_KEY_NAME}
-fi
+ssh-add -d _output/${SSH_KEY_NAME}

--- a/test/e2e/runner
+++ b/test/e2e/runner
@@ -38,5 +38,7 @@ export PUBLIC_SSH_KEY="$(cat _output/${SSH_KEY_NAME}.pub)"
 export DNS_PREFIX=test-$(echo $RANDOM)
 
 ginkgo -slowSpecThreshold 60 -r test/e2e/${TEST}
+exit_code=$?
 
-ssh-add -d _output/${SSH_KEY_NAME}
+ssh-add -d _output/${SSH_KEY_NAME} || true
+exit $exit_code


### PR DESCRIPTION
* closes #1278
* add tests for heapster, kube-addon-manager, kube-apiserver, kube-controller-manager, kube-scheduler, tiller
* adds logic for dynmamically running the linux and windows agent tests
* assertions made about node count use the cluster definition to determine the expected count

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1323)
<!-- Reviewable:end -->
