### PR TITLE
add version output options

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,17 +1,70 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
+
 	log "github.com/sirupsen/logrus"
+
 	"github.com/spf13/cobra"
 )
 
 var (
+	// BuildTag holds the `git tag` if this is a tagged build/release
+	BuildTag = "canary"
+
 	// BuildSHA holds the git commit SHA at `make build` time.
 	BuildSHA = "unset"
 
-	// BuildTag holds the `git tag` if this is a tagged build/release
-	BuildTag = "unset"
+	// GitTreeState is the state of the git tree, either clean or dirty
+	GitTreeState = "unset"
+
+	outputFormatOptions = []string{"human", "json"}
+	outputFormat        string
+	version             versionInfo
 )
+
+type versionInfo struct {
+	GitTag       string
+	GitCommit    string
+	GitTreeState string
+}
+
+func init() {
+	version = versionInfo{
+		GitTag:       BuildTag,
+		GitCommit:    BuildSHA,
+		GitTreeState: GitTreeState,
+	}
+}
+
+func getHumanVersion() string {
+	r := fmt.Sprintf("Version: %s\nGitCommit: %s\nGitTreeState: %s",
+		version.GitTag,
+		version.GitCommit,
+		version.GitTreeState)
+
+	return r
+}
+
+func getJSONVersion() string {
+	jsonVersion, _ := json.MarshalIndent(version, "", "  ")
+	return string(jsonVersion)
+}
+
+func getVersion(outputType string) string {
+	var output string
+
+	if outputType == "human" {
+		output = getHumanVersion()
+	} else if outputType == "json" {
+		output = getJSONVersion()
+	} else {
+		log.Fatalf("unsupported output format: %s\n", outputFormat)
+	}
+
+	return output
+}
 
 func newVersionCmd() *cobra.Command {
 	versionCmd := &cobra.Command{
@@ -20,8 +73,13 @@ func newVersionCmd() *cobra.Command {
 		Long:  "Print the version of ACS-Engine",
 
 		Run: func(cmd *cobra.Command, args []string) {
-			log.Infof("ACS-Engine Version: %s (%s)", BuildTag, BuildSHA)
+			fmt.Println(getVersion(outputFormat))
 		},
 	}
+
+	versionCmdDescription := fmt.Sprintf("Output format to use: %s", outputFormatOptions)
+
+	versionCmd.Flags().StringVarP(&outputFormat, "output", "o", "human", versionCmdDescription)
+
 	return versionCmd
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,18 +1,30 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	logtest "github.com/sirupsen/logrus/hooks/test"
 )
 
 var _ = Describe("the version command", func() {
-	It("should print the version of ACS-Engine", func() {
-		command := newVersionCmd()
-		hook := logtest.NewGlobal()
-		command.Run(command, nil)
-		Expect(hook.LastEntry().Message).To(Equal(fmt.Sprintf("ACS-Engine Version: %s (%s)", BuildTag, BuildSHA)))
+	It("should print a humanized version of ACS-Engine", func() {
+		output := getVersion("human")
+
+		expectedOutput := fmt.Sprintf("Version: %s\nGitCommit: %s\nGitTreeState: %s",
+			BuildTag,
+			BuildSHA,
+			GitTreeState)
+
+		Expect(output).Should(Equal(expectedOutput))
+	})
+
+	It("should print a json version of ACS-Engine", func() {
+		output := getVersion("json")
+
+		expectedOutput, _ := json.MarshalIndent(version, "", "  ")
+
+		Expect(output).Should(Equal(string(expectedOutput)))
 	})
 })

--- a/versioning.mk
+++ b/versioning.mk
@@ -3,7 +3,8 @@ GIT_SHA    = $(shell git rev-parse --short HEAD)
 GIT_TAG    = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null || echo "canary")
 GIT_DIRTY  = $(shell test -n "`git status --porcelain`" && echo "dirty" || echo "clean")
 
-LDFLAGS += -X github.com/Azure/acs-engine/cmd.BuildSHA=${GIT_SHA}-${GIT_DIRTY}
+LDFLAGS += -X github.com/Azure/acs-engine/cmd.BuildSHA=${GIT_SHA}
+LDFLAGS += -X github.com/Azure/acs-engine/cmd.GitTreeState=${GIT_DIRTY}
 DOCKER_VERSION ?= git-${GIT_SHA}
 
 ifneq ($(GIT_TAG),)


### PR DESCRIPTION
**What this PR does / why we need it**: Adds better formatting for acs engine output. Also provides output configurability (human, json)

**Special notes for your reviewer**: Willing to chat about golang code/design. First draft attempt. Open for refactoring!

**Release note**:
```release-note
version command now has 2 output formats (--output=[human, json])
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1325)
<!-- Reviewable:end -->
