### PR TITLE
Add timeout in Windows outbound connection test and more logging

### DIFF
--- a/test/cluster-tests/kubernetes/k8s-utils.sh
+++ b/test/cluster-tests/kubernetes/k8s-utils.sh
@@ -132,7 +132,7 @@ function test_windows_deployment() {
   success="n"
   while (( $count > 0 )); do
     log "  ... counting down $count"
-    statuscode=$(kubectl exec $winpodname -- powershell iwr -UseBasicParsing www.bing.com | grep StatusCode)
+    statuscode=$(kubectl exec $winpodname -- powershell iwr -UseBasicParsing -TimeoutSec 60 www.bing.com | grep StatusCode)
     if [[ $(echo ${statuscode} | grep 200 | awk '{print $3}' | tr -d '\r') -eq "200" ]]; then 
       success="y"
       break 
@@ -140,6 +140,15 @@ function test_windows_deployment() {
     sleep 10; count=$((count-1))
   done
   if [[ "${success}" != "y" ]]; then
+    nslookup=$(kubectl exec $winpodname -- powershell nslookup www.bing.com)
+    log "$nslookup"
+    ipconfig=$(kubectl exec $winpodname -- powershell ipconfig /all)
+    log "$ipconfig"
+    log "getting the last 50 events to check timeout failure"
+    hdr=$(kubectl get events | head -n 1)
+    log "$hdr"
+    evt=$(kubectl get events | tail -n 50)
+    log "$evt"
     log "K8S-Windows: failed to get outbound internet connection inside simpleweb container"
     exit 1
   fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->
**What this PR does / why we need it**:
Improve test. Add timeout in Windows outbound connection test and more logging.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1326)
<!-- Reviewable:end -->
