### PR TITLE
bump k8s dashboard version

### DIFF
--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -93,7 +93,7 @@ const (
 var KubeConfigs = map[string]map[string]string{
 	api.KubernetesRelease1Dot7: {
 		"hyperkube":       "hyperkube-amd64:v1.7.4",
-		"dashboard":       "kubernetes-dashboard-amd64:v1.6.1",
+		"dashboard":       "kubernetes-dashboard-amd64:v1.6.3",
 		"exechealthz":     "exechealthz-amd64:1.2",
 		"addonresizer":    "addon-resizer:1.7",
 		"heapster":        "heapster-amd64:v1.4.1",
@@ -116,7 +116,7 @@ var KubeConfigs = map[string]map[string]string{
 	},
 	api.KubernetesRelease1Dot6: {
 		"hyperkube":       "hyperkube-amd64:v1.6.6",
-		"dashboard":       "kubernetes-dashboard-amd64:v1.6.1",
+		"dashboard":       "kubernetes-dashboard-amd64:v1.6.3",
 		"exechealthz":     "exechealthz-amd64:1.2",
 		"addonresizer":    "addon-resizer:1.7",
 		"heapster":        "heapster-amd64:v1.3.0",


### PR DESCRIPTION
Bumping to latest release -- https://github.com/kubernetes/dashboard/releases/tag/v1.6.3

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1328)
<!-- Reviewable:end -->
