### PR TITLE
1334 - Kubernetes agents don't always attach to master - missing 1 minute grace period

### DIFF
--- a/parts/kubernetesmastercustomscript.sh
+++ b/parts/kubernetesmastercustomscript.sh
@@ -437,12 +437,7 @@ sed -i "13i\echo 2dd1ce17-079e-403c-b352-a1921ee207ee > /sys/bus/vmbus/drivers/h
 echo "Install complete successfully"
 
 if $REBOOTREQUIRED; then
-  if [[ ! -z "${APISERVER_PRIVATE_KEY}" ]]; then
-    # wait 1 minute to restart master
-    echo 'reboot required, rebooting master in 1 minute'
-    /bin/bash -c "shutdown -r 1 &"
-  else
-    echo 'reboot required, rebooting agent in 1 minute'
-    shutdown -r now
-  fi
+  # wait 1 minute to restart node, so that the custom script extension can complete
+  echo 'reboot required, rebooting node in 1 minute'
+  /bin/bash -c "shutdown -r 1 &"
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Adds a 1 minute timeout to fix the case where Kubernetes agents need to wait 1 minute to reboot, so that the CSE can properly signal completion. Otherwise, deployments will fail, or agents will fail to attach.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1344

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1335)
<!-- Reviewable:end -->
