### PR TITLE
WIP - bump k8s 1.6 release channel to version 1.6.9

### DIFF
--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -133,7 +133,7 @@ var KubeConfigs = map[string]map[string]string{
 		"dnsmasq":         "k8s-dns-dnsmasq-amd64:1.13.0",
 		"pause":           "pause-amd64:3.0",
 		"tiller":          DefaultTillerImage,
-		"windowszip":      "v1.6.9intwinnat.zip",
+		"windowszip":      "v1.6.9-1intwinnat.zip",
 		"nodestatusfreq":  DefaultKubernetesNodeStatusUpdateFrequency,
 		"nodegraceperiod": DefaultKubernetesCtrlMgrNodeMonitorGracePeriod,
 		"podeviction":     DefaultKubernetesCtrlMgrPodEvictionTimeout,

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -123,7 +123,7 @@ var KubeConfigs = map[string]map[string]string{
 		"ratelimitbucket": strconv.Itoa(DefaultKubernetesCloudProviderRateLimitBucket),
 	},
 	api.KubernetesRelease1Dot6: {
-		"hyperkube":       "hyperkube-amd64:v1.6.8",
+		"hyperkube":       "hyperkube-amd64:v1.6.9",
 		"dashboard":       "kubernetes-dashboard-amd64:v1.6.3",
 		"exechealthz":     "exechealthz-amd64:1.2",
 		"addonresizer":    "addon-resizer:1.7",
@@ -133,7 +133,7 @@ var KubeConfigs = map[string]map[string]string{
 		"dnsmasq":         "k8s-dns-dnsmasq-amd64:1.13.0",
 		"pause":           "pause-amd64:3.0",
 		"tiller":          DefaultTillerImage,
-		"windowszip":      "v1.6.8intwinnat.zip",
+		"windowszip":      "v1.6.9intwinnat.zip",
 		"nodestatusfreq":  DefaultKubernetesNodeStatusUpdateFrequency,
 		"nodegraceperiod": DefaultKubernetesCtrlMgrNodeMonitorGracePeriod,
 		"podeviction":     DefaultKubernetesCtrlMgrPodEvictionTimeout,

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -110,7 +110,7 @@ var KubeConfigs = map[string]map[string]string{
 		"dnsmasq":         "k8s-dns-dnsmasq-amd64:1.14.4",
 		"pause":           "pause-amd64:3.0",
 		"tiller":          DefaultTillerImage,
-		"windowszip":      "v1.7.5-1intwinnat.zip",
+		"windowszip":      "v1.7.5-2intwinnat.zip",
 		"nodestatusfreq":  DefaultKubernetesNodeStatusUpdateFrequency,
 		"nodegraceperiod": DefaultKubernetesCtrlMgrNodeMonitorGracePeriod,
 		"podeviction":     DefaultKubernetesCtrlMgrPodEvictionTimeout,

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -133,7 +133,7 @@ var KubeConfigs = map[string]map[string]string{
 		"dnsmasq":         "k8s-dns-dnsmasq-amd64:1.13.0",
 		"pause":           "pause-amd64:3.0",
 		"tiller":          DefaultTillerImage,
-		"windowszip":      "v1.6.9-1intwinnat.zip",
+		"windowszip":      "v1.6.9-2intwinnat.zip",
 		"nodestatusfreq":  DefaultKubernetesNodeStatusUpdateFrequency,
 		"nodegraceperiod": DefaultKubernetesCtrlMgrNodeMonitorGracePeriod,
 		"podeviction":     DefaultKubernetesCtrlMgrPodEvictionTimeout,

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -133,7 +133,7 @@ var KubeConfigs = map[string]map[string]string{
 		"dnsmasq":         "k8s-dns-dnsmasq-amd64:1.13.0",
 		"pause":           "pause-amd64:3.0",
 		"tiller":          DefaultTillerImage,
-		"windowszip":      "v1.6.9-2intwinnat.zip",
+		"windowszip":      "v1.6.9-3intwinnat.zip",
 		"nodestatusfreq":  DefaultKubernetesNodeStatusUpdateFrequency,
 		"nodegraceperiod": DefaultKubernetesCtrlMgrNodeMonitorGracePeriod,
 		"podeviction":     DefaultKubernetesCtrlMgrPodEvictionTimeout,

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -123,7 +123,7 @@ var KubeConfigs = map[string]map[string]string{
 		"ratelimitbucket": strconv.Itoa(DefaultKubernetesCloudProviderRateLimitBucket),
 	},
 	api.KubernetesRelease1Dot6: {
-		"hyperkube":       "hyperkube-amd64:v1.6.6",
+		"hyperkube":       "hyperkube-amd64:v1.6.8",
 		"dashboard":       "kubernetes-dashboard-amd64:v1.6.3",
 		"exechealthz":     "exechealthz-amd64:1.2",
 		"addonresizer":    "addon-resizer:1.7",
@@ -133,7 +133,7 @@ var KubeConfigs = map[string]map[string]string{
 		"dnsmasq":         "k8s-dns-dnsmasq-amd64:1.13.0",
 		"pause":           "pause-amd64:3.0",
 		"tiller":          DefaultTillerImage,
-		"windowszip":      "v1.6.6intwinnat.zip",
+		"windowszip":      "v1.6.8intwinnat.zip",
 		"nodestatusfreq":  DefaultKubernetesNodeStatusUpdateFrequency,
 		"nodegraceperiod": DefaultKubernetesCtrlMgrNodeMonitorGracePeriod,
 		"podeviction":     DefaultKubernetesCtrlMgrPodEvictionTimeout,

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -52,7 +52,7 @@ const (
 // KubeReleaseToVersion maps a major.minor release to an full major.minor.patch version
 var KubeReleaseToVersion = map[string]string{
 	KubernetesRelease1Dot7: "1.7.5",
-	KubernetesRelease1Dot6: "1.6.8",
+	KubernetesRelease1Dot6: "1.6.9",
 	KubernetesRelease1Dot5: "1.5.7",
 }
 

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -52,7 +52,7 @@ const (
 // KubeReleaseToVersion maps a major.minor release to an full major.minor.patch version
 var KubeReleaseToVersion = map[string]string{
 	KubernetesRelease1Dot7: "1.7.5",
-	KubernetesRelease1Dot6: "1.6.6",
+	KubernetesRelease1Dot6: "1.6.8",
 	KubernetesRelease1Dot5: "1.5.7",
 }
 

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -82,7 +82,7 @@ var DCOSReleaseToVersion = map[string]string{
 // KubernetesReleaseToVersion maps a major.minor release to an full major.minor.patch version
 var KubernetesReleaseToVersion = map[string]string{
 	KubernetesRelease1Dot7: "1.7.5",
-	KubernetesRelease1Dot6: "1.6.6",
+	KubernetesRelease1Dot6: "1.6.8",
 	KubernetesRelease1Dot5: "1.5.7",
 }
 

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -82,7 +82,7 @@ var DCOSReleaseToVersion = map[string]string{
 // KubernetesReleaseToVersion maps a major.minor release to an full major.minor.patch version
 var KubernetesReleaseToVersion = map[string]string{
 	KubernetesRelease1Dot7: "1.7.5",
-	KubernetesRelease1Dot6: "1.6.8",
+	KubernetesRelease1Dot6: "1.6.9",
 	KubernetesRelease1Dot5: "1.5.7",
 }
 

--- a/scripts/build-windows-k8s.sh
+++ b/scripts/build-windows-k8s.sh
@@ -145,6 +145,11 @@ upload_zip_to_blob_storage() {
 	az storage blob upload -f ${DIST_DIR}/../../v${ACS_VERSION}intwinnat.zip -c ${AZURE_STORAGE_CONTAINER_NAME} -n v${ACS_VERSION}intwinnat.zip
 }
 
+push_acs_branch() {
+  cd ${GOPATH}/src/k8s.io/kubernetes
+  git push origin ${ACS_BRANCH_NAME}
+}
+
 create_dist_dir
 fetch_k8s
 set_git_config
@@ -164,3 +169,4 @@ download_winnat
 copy_dockerfile_and_pause_ps1
 create_zip
 upload_zip_to_blob_storage
+push_acs_branch

--- a/scripts/build-windows-k8s.sh
+++ b/scripts/build-windows-k8s.sh
@@ -78,8 +78,9 @@ k8s_17_cherry_pick() {
 	# 74a2f37447 Fix network config due to the split of start POD sandbox and start container from 1.7.0
 	# 5fc0a5e4a2 Workaround for Outbound Internet traffic in Azure Kubernetes (*) Connect a Nat Network to the container (Second adapter) (*) Modify the route so that internet traffic goes via Nat network, and POD traffic goes over the CONTAINER_NETWORK (*) Modify getContainerIP to return the IP corresponding to POD network, and ignore Nat Network (*) DNS Fix for ACS Kubernetes in Windows
 	# adeb88d774 Use adapter vEthernet (HNSTransparent) on Windows host network to find node IP
+	# 02549d6647 Merge pull request #50914 from shyamjvs/add-logging-to-logdump
 
-	git cherry-pick adeb88d774..45ba7bb0fb
+	git cherry-pick 02549d6647..45ba7bb0fb
 }
 
 apply_acs_cherry_picks() {

--- a/scripts/build-windows-k8s.sh
+++ b/scripts/build-windows-k8s.sh
@@ -7,7 +7,6 @@ usage() {
 	echo "$0 [-v version] [-p acs_patch_version]"
 	echo " -v <version>: version"
 	echo " -p <patched version>: acs_patch_version"
-	exit 0
 }
 
 while getopts ":v:p:" opt; do
@@ -20,12 +19,14 @@ while getopts ":v:p:" opt; do
       ;;
     *)
 			usage
+			exit
       ;;
   esac
 done
 
 if [ -z "${version}" ] || [ -z "${acs_patch_version}" ]; then
     usage
+		exit 1
 fi
 
 if [ -z "${AZURE_STORAGE_CONNECTION_STRING}" ] || [ -z "${AZURE_STORAGE_CONTAINER_NAME}" ]; then

--- a/scripts/build-windows-k8s.sh
+++ b/scripts/build-windows-k8s.sh
@@ -66,8 +66,9 @@ k8s_16_cherry_pick() {
 	# 4f196c6cac Fix the issue that ping uses the incorrect NIC to resolve name sometimes
 	# 2c9fd27449 Workaround for Outbound Internet traffic in Azure Kubernetes
 	# 5fa0725025 Use adapter vEthernet (HNSTransparent) on Windows host network to find node IP
+	# 79cf9963f7 Merge pull request #51126 from chen-anders/anders/port-47991-to-release-1.6
 
-	git cherry-pick 5fa0725025..232fa6e5bc
+	git cherry-pick 79cf9963f7..232fa6e5bc
 }
 
 k8s_17_cherry_pick() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Upgrades default 1.6 version of kubernetes to `v1.6.9`.

See: https://github.com/kubernetes/kubernetes/releases/tag/v1.6.9

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1200 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Kubernetes v1.6.9 is the default 1.6 version for new clusters
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1343)
<!-- Reviewable:end -->
