### PR TITLE
fix: adding log-errors config file to acs-engine-test

### DIFF
--- a/test/acs-engine-test/main.go
+++ b/test/acs-engine-test/main.go
@@ -46,12 +46,13 @@ const (
 )
 
 const usage = `Usage:
-  acs-engine-test -c <configuration.json> -d <acs-engine root directory>
+  acs-engine-test <options>
 
   Options:
     -c <configuration.json> : JSON file containing a list of deployment configurations.
 		Refer to acs-engine/test/acs-engine-test/acs-engine-test.json for examples
 	-d <acs-engine root directory>
+	-e <log-errors configuration file>
 `
 
 var logDir string
@@ -408,11 +409,11 @@ func sendDurationMetrics(step, location string, duration time.Duration, errorNam
 func mainInternal() error {
 	var configFile string
 	var rootDir string
-	var errorFile string
+	var logErrorFile string
 	var err error
 	flag.StringVar(&configFile, "c", "", "deployment configurations")
 	flag.StringVar(&rootDir, "d", "", "acs-engine root directory")
-	flag.StringVar(&errorFile, "e", "", "acs-engine root directory")
+	flag.StringVar(&logErrorFile, "e", "", "logError config file")
 	flag.Usage = func() {
 		fmt.Println(usage)
 	}
@@ -443,7 +444,7 @@ func mainInternal() error {
 		enableMetrics = true
 	}
 	// initialize report manager
-	testManager.Manager = report.New(os.Getenv("JOB_BASE_NAME"), buildNum, len(testManager.config.Deployments), errorFile)
+	testManager.Manager = report.New(os.Getenv("JOB_BASE_NAME"), buildNum, len(testManager.config.Deployments), logErrorFile)
 	// check root directory
 	if rootDir == "" {
 		return fmt.Errorf("acs-engine root directory is not provided")

--- a/test/acs-engine-test/report/report.go
+++ b/test/acs-engine-test/report/report.go
@@ -66,7 +66,7 @@ const (
 )
 
 // New creates a new error report
-func New(jobName string, buildNum int, nDeploys int, fileName string) *Manager {
+func New(jobName string, buildNum int, nDeploys int, logErrorsFileName string) *Manager {
 	h := &Manager{}
 	h.JobName = jobName
 	h.BuildNum = buildNum
@@ -74,7 +74,7 @@ func New(jobName string, buildNum int, nDeploys int, fileName string) *Manager {
 	h.Errors = 0
 	h.StartTime = time.Now().UTC()
 	h.Failures = make(map[string]*ErrorStat)
-	h.LogErrors = makeErrorList(fileName)
+	h.LogErrors = makeErrorList(logErrorsFileName)
 	return h
 }
 
@@ -84,8 +84,8 @@ func makeErrorList(fileName string) logErrors {
 	if fileName != "" {
 		file, e := ioutil.ReadFile(fileName)
 		if e != nil {
-			fmt.Printf("File error: %v\n", e)
-			os.Exit(1)
+			// do not exit the tests
+			fmt.Printf("ERROR: %v\n", e)
 		}
 		json.Unmarshal(file, &dummy)
 	}

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -24,7 +24,8 @@ ROOT="${DIR}/.."
 [[ ! -z "${CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID:-}" ]]     || (echo "Must specify CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID" && exit -1)
 [[ ! -z "${CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET:-}" ]] || (echo "Must specify CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET" && exit -1)
 [[ ! -z "${STAGE_TIMEOUT_MIN:-}" ]]                       || (echo "Must specify STAGE_TIMEOUT_MIN" && exit -1)
+[[ ! -z "${TEST_CONFIG:-}" ]]                             || (echo "Must specify TEST_CONFIG" && exit -1)
 
 make bootstrap build
 
-${ROOT}/test/acs-engine-test/acs-engine-test -c ${TEST_CONFIG:-${ROOT}/test/acs-engine-test/acs-engine-test.json} -d ${ROOT}
+${ROOT}/test/acs-engine-test/acs-engine-test -c ${TEST_CONFIG} -d ${ROOT} -e ${LOGERROR_CONFIG:-${ROOT}/test/acs-engine-test/acs-engine-errors.json}


### PR DESCRIPTION
fix: adding log-errors config file to acs-engine-test