### PR TITLE
e2e(k8s): keep only hybrid windows scenario in e2e

### DIFF
--- a/test/acse-conf/acse-feature-validation.json
+++ b/test/acse-conf/acse-feature-validation.json
@@ -5,10 +5,6 @@
       "location": "eastus"
     },
     {
-      "cluster_definition": "windows/kubernetes.json",
-      "location": "eastus"
-    },
-    {
       "cluster_definition": "dcos-releases/dcos1.8.json",
       "location": "eastus"
     },

--- a/test/acse-conf/acse-regression.json
+++ b/test/acse-conf/acse-regression.json
@@ -5,10 +5,6 @@
       "category": "windows"
     },
     {
-      "cluster_definition": "windows/kubernetes.json",
-      "category": "windows"
-    },
-    {
       "cluster_definition": "dcos-releases/dcos1.8.json",
       "category": "version"
     },


### PR DESCRIPTION
Hybrid clusters (Windows + Linux) e2e tests capture if Windows nodes are functional which frees us to remove Windows-only e2e tests. This removes `windows/kubernetes.json` from 

- `test/acse-conf/acse-feature-validation.json`
- `test/acse-conf/acse-regression.json`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1352)
<!-- Reviewable:end -->
