### PR TITLE
Update resource name for agentPoolOnly API model

### DIFF
--- a/pkg/api/agentPoolOnlyApi/v20170831/types.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/types.go
@@ -14,9 +14,9 @@ type ResourcePurchasePlan struct {
 	Publisher     string `json:"publisher,omitempty"`
 }
 
-// HostedMaster complies with the ARM model of
+// ManagedCluster complies with the ARM model of
 // resource definition in a JSON template.
-type HostedMaster struct {
+type ManagedCluster struct {
 	ID       string                `json:"id,omitempty"`
 	Location string                `json:"location,omitempty" validate:"required"`
 	Name     string                `json:"name,omitempty"`

--- a/pkg/api/agentPoolOnlyApi/vlabs/types.go
+++ b/pkg/api/agentPoolOnlyApi/vlabs/types.go
@@ -14,9 +14,9 @@ type ResourcePurchasePlan struct {
 	Publisher     string `json:"publisher,omitempty"`
 }
 
-// HostedMaster complies with the ARM model of
+// ManagedCluster complies with the ARM model of
 // resource definition in a JSON template.
-type HostedMaster struct {
+type ManagedCluster struct {
 	ID       string                `json:"id,omitempty"`
 	Location string                `json:"location,omitempty" validate:"required"`
 	Name     string                `json:"name,omitempty"`

--- a/pkg/api/apiloader.go
+++ b/pkg/api/apiloader.go
@@ -147,25 +147,25 @@ func (a *Apiloader) LoadContainerService(
 func (a *Apiloader) LoadContainerServiceForAgentPoolOnlyCluster(contents []byte, version string, validate bool) (*ContainerService, error) {
 	switch version {
 	case v20170831.APIVersion:
-		hostedMaster := &v20170831.HostedMaster{}
-		if e := json.Unmarshal(contents, &hostedMaster); e != nil {
+		managedCluster := &v20170831.ManagedCluster{}
+		if e := json.Unmarshal(contents, &managedCluster); e != nil {
 			return nil, e
 		}
-		setHostedMasterDefaultsv20170831(hostedMaster)
-		if e := hostedMaster.Properties.Validate(); validate && e != nil {
+		setManagedClusterDefaultsv20170831(managedCluster)
+		if e := managedCluster.Properties.Validate(); validate && e != nil {
 			return nil, e
 		}
-		return ConvertV20170831AgentPoolOnly(hostedMaster), nil
+		return ConvertV20170831AgentPoolOnly(managedCluster), nil
 	case apvlabs.APIVersion:
-		hostedMaster := &apvlabs.HostedMaster{}
-		if e := json.Unmarshal(contents, &hostedMaster); e != nil {
+		managedCluster := &apvlabs.ManagedCluster{}
+		if e := json.Unmarshal(contents, &managedCluster); e != nil {
 			return nil, e
 		}
-		setHostedMasterDefaultsvlabs(hostedMaster)
-		if e := hostedMaster.Properties.Validate(); validate && e != nil {
+		setManagedClusterDefaultsvlabs(managedCluster)
+		if e := managedCluster.Properties.Validate(); validate && e != nil {
 			return nil, e
 		}
-		return ConvertVLabsAgentPoolOnly(hostedMaster), nil
+		return ConvertVLabsAgentPoolOnly(managedCluster), nil
 	default:
 		return nil, a.Translator.Errorf("unrecognized APIVersion in LoadContainerServiceForAgentPoolOnlyCluster '%s'", version)
 	}
@@ -246,7 +246,7 @@ func (a *Apiloader) serializeHostedContainerService(containerService *ContainerS
 	case v20170831.APIVersion:
 		v20170831ContainerService := ConvertContainerServiceToV20170831AgentPoolOnly(containerService)
 		armContainerService := &V20170831ARMManagedContainerService{}
-		armContainerService.HostedMaster = v20170831ContainerService
+		armContainerService.ManagedCluster = v20170831ContainerService
 		armContainerService.APIVersion = version
 		b, err := json.MarshalIndent(armContainerService, "", "  ")
 		if err != nil {
@@ -300,11 +300,11 @@ func setContainerServiceDefaultsvlabs(c *vlabs.ContainerService) {
 }
 
 // Sets default HostedMaster property values for any appropriate zero values
-func setHostedMasterDefaultsv20170831(hm *v20170831.HostedMaster) {
+func setManagedClusterDefaultsv20170831(hm *v20170831.ManagedCluster) {
 	hm.Properties.KubernetesVersion = ""
 }
 
 // Sets default HostedMaster property values for any appropriate zero values
-func setHostedMasterDefaultsvlabs(hm *apvlabs.HostedMaster) {
+func setManagedClusterDefaultsvlabs(hm *apvlabs.ManagedCluster) {
 	hm.Properties.KubernetesVersion = ""
 }

--- a/pkg/api/converterfromagentpoolonlyapi.go
+++ b/pkg/api/converterfromagentpoolonlyapi.go
@@ -11,8 +11,8 @@ import "github.com/Azure/acs-engine/pkg/api/agentPoolOnlyApi/v20170831"
 ///////////////////////////////////////////////////////////
 
 // ConvertContainerServiceToV20170831 converts an unversioned ContainerService to a v20170831 ContainerService
-func ConvertContainerServiceToV20170831AgentPoolOnly(api *ContainerService) *v20170831.HostedMaster {
-	v20170831HCP := &v20170831.HostedMaster{}
+func ConvertContainerServiceToV20170831AgentPoolOnly(api *ContainerService) *v20170831.ManagedCluster {
+	v20170831HCP := &v20170831.ManagedCluster{}
 	v20170831HCP.ID = api.ID
 	v20170831HCP.Location = api.Location
 	v20170831HCP.Name = api.Name

--- a/pkg/api/convertertoagentpoolonlyapi.go
+++ b/pkg/api/convertertoagentpoolonlyapi.go
@@ -14,7 +14,7 @@ import (
 ///////////////////////////////////////////////////////////
 
 // ConvertV20170831AgentPoolOnly converts an AgentPoolOnly object into an in-memory container service
-func ConvertV20170831AgentPoolOnly(v20170831 *v20170831.HostedMaster) *ContainerService {
+func ConvertV20170831AgentPoolOnly(v20170831 *v20170831.ManagedCluster) *ContainerService {
 	c := &ContainerService{}
 	c.ID = v20170831.ID
 	c.Location = v20170831.Location
@@ -71,7 +71,7 @@ func convertV20170831AgentPoolOnlyProperties(obj *v20170831.Properties) *Propert
 }
 
 // ConvertVLabsContainerService converts a vlabs ContainerService to an unversioned ContainerService
-func ConvertVLabsAgentPoolOnly(vlabs *vlabs.HostedMaster) *ContainerService {
+func ConvertVLabsAgentPoolOnly(vlabs *vlabs.ManagedCluster) *ContainerService {
 	c := &ContainerService{}
 	c.ID = vlabs.ID
 	c.Location = vlabs.Location

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -330,7 +330,7 @@ type VlabsUpgradeContainerService struct {
 // is different from the json that the ACS RP Api gets from ARM
 type V20170831ARMManagedContainerService struct {
 	TypeMeta
-	*v20170831.HostedMaster
+	*v20170831.ManagedCluster
 }
 
 // UpgradeContainerService API model


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates resource name for agentPoolOnly API from "hostedMaster" to "managedCluster" as decided by the team.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1353)
<!-- Reviewable:end -->
