### PR TITLE
added e2e test cleanup script

### DIFF
--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+####################################################
+
+if [ -z "$SERVICE_PRINCIPAL_CLIENT_ID" ]; then
+    exit 1;
+fi
+
+if [ -z "$SERVICE_PRINCIPAL_CLIENT_SECRET" ]; then
+    exit 1;
+fi
+
+if [ -z "$TENANT_ID" ]; then
+    exit 1;
+fi
+
+if [ -z "$SUBSCRIPTION_ID_TO_CLEANUP" ]; then
+    exit 1;
+fi
+
+if [ -z "$EXPIRATION_IN_HOURS" ]; then
+    EXPIRATION_IN_HOURS=2
+fi
+
+set -eu -o pipefail
+
+az login --service-principal \
+		--username "${SERVICE_PRINCIPAL_CLIENT_ID}" \
+		--password "${SERVICE_PRINCIPAL_CLIENT_SECRET}" \
+		--tenant "${TENANT_ID}" &>/dev/null
+
+# set to the sub id we want to cleanup
+az account set -s $SUBSCRIPTION_ID_TO_CLEANUP
+
+# convert to seconds so we can compare it against the "tags.now" property in the resource group metadata
+expirationInSecs=$(echo "${EXPIRATION_IN_HOURS} * 60 * 60" | bc )
+# deadline = the "date +%s" representation of the oldest age we're willing to keep
+(( deadline=$(date +%s)-${expirationInSecs%.*} ))
+# find resource groups created before our deadline
+for resourceGroup in `az group list | jq -r ".[] | select((.tags.now|tonumber < $deadline)).name"`; do
+    echo "Will delete resource group ${resourceGroup}..."
+    # delete old resource groups
+    az group delete -n $resourceGroup -y --no-wait
+done

--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -40,5 +40,5 @@ az account set -s $SUBSCRIPTION_ID_TO_CLEANUP
 for resourceGroup in `az group list | jq -r ".[] | select((.tags.now|tonumber < $deadline)).name"`; do
     echo "Will delete resource group ${resourceGroup}..."
     # delete old resource groups
-    az group delete -n $resourceGroup -y --no-wait
+    az group delete -n $resourceGroup -y --no-wait >> delete.log
 done

--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -33,7 +33,7 @@ az login --service-principal \
 az account set -s $SUBSCRIPTION_ID_TO_CLEANUP
 
 # convert to seconds so we can compare it against the "tags.now" property in the resource group metadata
-expirationInSecs=$(echo "${EXPIRATION_IN_HOURS} * 60 * 60" | bc )
+(( expirationInSecs = ${EXPIRATION_IN_HOURS} * 60 * 60 ))
 # deadline = the "date +%s" representation of the oldest age we're willing to keep
 (( deadline=$(date +%s)-${expirationInSecs%.*} ))
 # find resource groups created before our deadline

--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -3,18 +3,22 @@
 ####################################################
 
 if [ -z "$SERVICE_PRINCIPAL_CLIENT_ID" ]; then
+    echo "must provide a SERVICE_PRINCIPAL_CLIENT_ID env var"
     exit 1;
 fi
 
 if [ -z "$SERVICE_PRINCIPAL_CLIENT_SECRET" ]; then
+    echo "must provide a SERVICE_PRINCIPAL_CLIENT_SECRET env var"
     exit 1;
 fi
 
 if [ -z "$TENANT_ID" ]; then
+    echo "must provide a TENANT_ID env var"
     exit 1;
 fi
 
 if [ -z "$SUBSCRIPTION_ID_TO_CLEANUP" ]; then
+    echo "must provide a SUBSCRIPTION_ID_TO_CLEANUP env var"
     exit 1;
 fi
 
@@ -37,6 +41,7 @@ az account set -s $SUBSCRIPTION_ID_TO_CLEANUP
 # deadline = the "date +%s" representation of the oldest age we're willing to keep
 (( deadline=$(date +%s)-${expirationInSecs%.*} ))
 # find resource groups created before our deadline
+echo "Looking for resource groups created over ${EXPIRATION_IN_HOURS} hours ago..."
 for resourceGroup in `az group list | jq -r ".[] | select((.tags.now|tonumber < $deadline)).name"`; do
     echo "Will delete resource group ${resourceGroup}..."
     # delete old resource groups


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Adds a resource group cleanup script so we can periodically clean up e2e resources when our e2e runs fail in unexpected ways and don't clean up after themselves

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1356)
<!-- Reviewable:end -->
