### PR TITLE
K8s test validation DNS != first service ip

### DIFF
--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -170,6 +170,14 @@ func Test_KubernetesConfig_Validate(t *testing.T) {
 		}
 
 		c = KubernetesConfig{
+			DnsServiceIP: "172.99.0.1",
+			ServiceCidr:  "172.99.0.1/16",
+		}
+		if err := c.Validate(k8sRelease); err == nil {
+			t.Error("should error when DnsServiceIP is first IP of ServiceCidr")
+		}
+
+		c = KubernetesConfig{
 			DnsServiceIP: "172.99.255.10",
 			ServiceCidr:  "172.99.0.1/16",
 		}


### PR DESCRIPTION
**What this PR does / why we need it**: Follow-up to pull #546 to add a missing test into `validate_test.go` that verifies that the validation routine checks that the DNS IP is not the first IP of the service subnet.

**Release note**:

```
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1357)
<!-- Reviewable:end -->
