### PR TITLE
westcentralus is stable, we may resume E2E there

### DIFF
--- a/test/acs-engine-test/main.go
+++ b/test/acs-engine-test/main.go
@@ -468,7 +468,6 @@ func mainInternal() error {
 		case "chinaeast": // private cloud
 		case "chinanorth": // private cloud
 		case "koreacentral": // TODO make sure our versions of azure-cli support this cloud
-		case "westcentralus": // TODO re-enable when this region's reliability has been upgraded
 		case "centraluseuap": // TODO determine why this region is flaky
 		case "brazilsouth": // canary region
 		default:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: resume sending E2E tests to westcentralus

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1363)
<!-- Reviewable:end -->
