### PR TITLE
correct merge method for vlabs

### DIFF
--- a/pkg/api/vlabs/merge.go
+++ b/pkg/api/vlabs/merge.go
@@ -6,14 +6,23 @@ import (
 
 // Merge existing containerService attribute into cs
 func (cs *ContainerService) Merge(ecs *ContainerService) error {
-	if err := mergo.Merge(cs.Properties.ServicePrincipalProfile,
-		*ecs.Properties.ServicePrincipalProfile); err != nil {
-		return err
+	if ecs.Properties.ServicePrincipalProfile != nil {
+		if cs.Properties.ServicePrincipalProfile == nil {
+			cs.Properties.ServicePrincipalProfile = &ServicePrincipalProfile{}
+		}
+		if err := mergo.Merge(cs.Properties.ServicePrincipalProfile,
+			*ecs.Properties.ServicePrincipalProfile); err != nil {
+			return err
+		}
 	}
-
-	if err := mergo.Merge(cs.Properties.WindowsProfile,
-		*ecs.Properties.WindowsProfile); err != nil {
-		return err
+	if ecs.Properties.WindowsProfile != nil {
+		if cs.Properties.WindowsProfile == nil {
+			cs.Properties.WindowsProfile = &WindowsProfile{}
+		}
+		if err := mergo.Merge(cs.Properties.WindowsProfile,
+			*ecs.Properties.WindowsProfile); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/api/vlabs/merge_test.go
+++ b/pkg/api/vlabs/merge_test.go
@@ -53,3 +53,56 @@ func TestMerge(t *testing.T) {
 	}
 
 }
+
+func TestMergeWithNil(t *testing.T) {
+	newCS := &ContainerService{
+		Properties: &Properties{
+			ServicePrincipalProfile: &ServicePrincipalProfile{
+				ClientID: "fakeID",
+				Secret:   "",
+				KeyvaultSecretRef: &KeyvaultSecretRef{
+					VaultID:    "keyVaultRefNew",
+					SecretName: "secret-name",
+				},
+			},
+		},
+	}
+
+	existingCS := &ContainerService{
+		Properties: &Properties{
+			ServicePrincipalProfile: &ServicePrincipalProfile{
+				ClientID: "existingFakeID",
+				Secret:   "existingSecret",
+				KeyvaultSecretRef: &KeyvaultSecretRef{
+					VaultID:    "keyVaultRefExisting",
+					SecretName: "secret-name",
+				},
+			},
+			WindowsProfile: &WindowsProfile{
+				AdminUsername: "azureuser",
+				AdminPassword: "existingPassword",
+			},
+		},
+	}
+	if err := newCS.Merge(existingCS); err != nil {
+		t.Fatalf("unexpectedly detected merge failure, %+v", err)
+	}
+	if newCS.Properties.ServicePrincipalProfile.ClientID != "fakeID" {
+		t.Fatalf("unexpected Properties.ServicePrincipalProfile.ClientID changed")
+	}
+	if newCS.Properties.ServicePrincipalProfile.Secret != "existingSecret" {
+		t.Fatalf("unexpected Properties.ServicePrincipalProfile.Secret not updated")
+	}
+	if newCS.Properties.ServicePrincipalProfile.KeyvaultSecretRef.VaultID != "keyVaultRefNew" {
+		t.Fatalf("unexpected Properties.ServicePrincipalProfile.KeyvaultSecretRef changed")
+	}
+	if newCS.Properties.WindowsProfile == nil {
+		t.Fatalf("unexpected Properties.WindowsProfile not updated")
+	}
+	if newCS.Properties.WindowsProfile.AdminUsername != "azureuser" {
+		t.Fatalf("unexpected Properties.WindowsProfile.AdminUsername not updated")
+	}
+	if newCS.Properties.WindowsProfile.AdminPassword != "existingPassword" {
+		t.Fatalf("unexpected Properties.WindowsProfile.AdminPassword not updated")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1269 
vlabs was missed when the correction for nil pointer was fixed.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/acs-engine/1368)
<!-- Reviewable:end -->
