### PR TITLE
K8s v1.7.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir /tmp/azurecli \
 
 RUN curl -fsSL https://get.docker.com/ | sh
 
-ENV KUBECTL_VERSION 1.6.6
+ENV KUBECTL_VERSION 1.7.5
 RUN curl "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" > /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -100,17 +100,17 @@ const (
 // For instance, Kubernetes release "1.7" would contain the version "1.7.2"
 var KubeConfigs = map[string]map[string]string{
 	api.KubernetesRelease1Dot7: {
-		"hyperkube":       "hyperkube-amd64:v1.7.4",
+		"hyperkube":       "hyperkube-amd64:v1.7.5",
 		"dashboard":       "kubernetes-dashboard-amd64:v1.6.3",
 		"exechealthz":     "exechealthz-amd64:1.2",
 		"addonresizer":    "addon-resizer:1.7",
-		"heapster":        "heapster-amd64:v1.4.1",
+		"heapster":        "heapster-amd64:v1.4.2",
 		"dns":             "k8s-dns-kube-dns-amd64:1.14.4",
 		"addonmanager":    "kube-addon-manager-amd64:v6.4-beta.2",
 		"dnsmasq":         "k8s-dns-dnsmasq-amd64:1.14.4",
 		"pause":           "pause-amd64:3.0",
 		"tiller":          DefaultTillerImage,
-		"windowszip":      "v1.7.2intwinnat.zip",
+		"windowszip":      "v1.7.5-1intwinnat.zip",
 		"nodestatusfreq":  DefaultKubernetesNodeStatusUpdateFrequency,
 		"nodegraceperiod": DefaultKubernetesCtrlMgrNodeMonitorGracePeriod,
 		"podeviction":     DefaultKubernetesCtrlMgrPodEvictionTimeout,

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -51,7 +51,7 @@ const (
 
 // KubeReleaseToVersion maps a major.minor release to an full major.minor.patch version
 var KubeReleaseToVersion = map[string]string{
-	KubernetesRelease1Dot7: "1.7.4",
+	KubernetesRelease1Dot7: "1.7.5",
 	KubernetesRelease1Dot6: "1.6.6",
 	KubernetesRelease1Dot5: "1.5.7",
 }

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -81,7 +81,7 @@ var DCOSReleaseToVersion = map[string]string{
 
 // KubernetesReleaseToVersion maps a major.minor release to an full major.minor.patch version
 var KubernetesReleaseToVersion = map[string]string{
-	KubernetesRelease1Dot7: "1.7.4",
+	KubernetesRelease1Dot7: "1.7.5",
 	KubernetesRelease1Dot6: "1.6.6",
 	KubernetesRelease1Dot5: "1.5.7",
 }


### PR DESCRIPTION
Bumps v1.7 release to v1.7.5:

- Supports retrieving Azure access tokens via Managed Identity Extension
- Bumped Heapster version to 1.4.2
- Made v1.7.5 default version in Dockerfile 

I've built the Windows zip which is available at https://acsmirror.blob.core.windows.net/wink8s/v1.7.5-1intwinnat.zip (non-CDN URL). 

@lachie83 @jackfrancis @JiangtianLi 