### PR TITLE
Remove deprecated kubelet/apiserver/etc options

### DIFF
--- a/parts/kuberneteskubelet.service
+++ b/parts/kuberneteskubelet.service
@@ -38,7 +38,6 @@ ExecStart=/usr/bin/docker run \
         --address=0.0.0.0 \
         --allow-privileged=true \
         --enable-server \
-        --enable-debugging-handlers \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster-dns=${KUBELET_CLUSTER_DNS} \
         --cluster-domain=cluster.local \
@@ -46,7 +45,6 @@ ExecStart=/usr/bin/docker run \
         --cloud-provider=azure \
         --cloud-config=/etc/kubernetes/azure.json \
         --azure-container-registry-config=/etc/kubernetes/azure.json \
-        --hairpin-mode=promiscuous-bridge \
         --network-plugin=${KUBELET_NETWORK_PLUGIN} \
         --max-pods=${KUBELET_MAX_PODS} \
         --node-status-update-frequency=${KUBELET_NODE_STATUS_UPDATE_FREQUENCY} \

--- a/parts/kuberneteswindowssetup.ps1
+++ b/parts/kuberneteswindowssetup.ps1
@@ -301,7 +301,7 @@ catch
 
     $kubeProxyStartStr = @"
 `$env:INTERFACE_TO_ADD_SERVICE_IP="vEthernet (forwarder)"
-c:\k\kube-proxy.exe --v=3 --proxy-mode=userspace --hostname-override=$AzureHostname --kubeconfig=c:\k\config
+c:\k\kube-proxy.exe --proxy-mode=userspace --hostname-override=$AzureHostname --kubeconfig=c:\k\config
 "@
 
     $kubeProxyStartStr | Out-File -encoding ASCII -filepath $global:KubeProxyStartFile

--- a/parts/kuberneteswindowssetup.ps1
+++ b/parts/kuberneteswindowssetup.ps1
@@ -301,7 +301,7 @@ catch
 
     $kubeProxyStartStr = @"
 `$env:INTERFACE_TO_ADD_SERVICE_IP="vEthernet (forwarder)"
-c:\k\kube-proxy.exe --proxy-mode=userspace --hostname-override=$AzureHostname --kubeconfig=c:\k\config
+c:\k\kube-proxy.exe --v=3 --proxy-mode=userspace --hostname-override=$AzureHostname --kubeconfig=c:\k\config
 "@
 
     $kubeProxyStartStr | Out-File -encoding ASCII -filepath $global:KubeProxyStartFile


### PR DESCRIPTION
* remove deprecated `--register-schedulable` kubelet option for k8s >= v1.6.0
* Removed explicit setting of `--enable-debugging-handlers` and `--hairpin-mode=promiscuous-bridge` which are both default options since v1.6.0 at least.

@jackfrancis @jchauncey 


