### PR TITLE
updated CNI URL to plugins repo

### DIFF
--- a/parts/kubernetesmastercustomscript.sh
+++ b/parts/kubernetesmastercustomscript.sh
@@ -21,7 +21,7 @@ TARGET_ENVIRONMENT="${13}"
 NETWORK_POLICY="${14}"
 FQDNSuffix="${15}"
 AZURE_VNET_CNI_URL="${16}"
-AZURE_CNI_URL="${17}"
+AZURE_CNI_PLUGIN_URL="${17}"
 CALICO_CONFIG_URL="${18}"
 MAX_PODS="${19}"
 
@@ -197,7 +197,7 @@ function configAzureNetworkPolicy() {
     # Mirror from https://github.com/Azure/azure-container-networking/releases/tag/$AZURE_PLUGIN_VER/azure-vnet-cni-linux-amd64-$AZURE_PLUGIN_VER.tgz
     downloadUrl ${AZURE_VNET_CNI_URL} | tar -xz -C $CNI_BIN_DIR
     # Mirror from https://github.com/containernetworking/cni/releases/download/$CNI_RELEASE_VER/cni-amd64-$CNI_RELEASE_VERSION.tgz
-    downloadUrl ${AZURE_CNI_URL} | tar -xz -C $CNI_BIN_DIR ./loopback
+    downloadUrl ${AZURE_CNI_PLUGIN_URL} | tar -xz -C $CNI_BIN_DIR ./loopback
     chown -R root:root $CNI_BIN_DIR
     chmod -R 755 $CNI_BIN_DIR
 

--- a/parts/kubernetesmastercustomscript.sh
+++ b/parts/kubernetesmastercustomscript.sh
@@ -21,7 +21,7 @@ TARGET_ENVIRONMENT="${13}"
 NETWORK_POLICY="${14}"
 FQDNSuffix="${15}"
 AZURE_VNET_CNI_URL="${16}"
-AZURE_CNI_PLUGIN_URL="${17}"
+AZURE_CNI_PLUGINS_URL="${17}"
 CALICO_CONFIG_URL="${18}"
 MAX_PODS="${19}"
 
@@ -197,7 +197,7 @@ function configAzureNetworkPolicy() {
     # Mirror from https://github.com/Azure/azure-container-networking/releases/tag/$AZURE_PLUGIN_VER/azure-vnet-cni-linux-amd64-$AZURE_PLUGIN_VER.tgz
     downloadUrl ${AZURE_VNET_CNI_URL} | tar -xz -C $CNI_BIN_DIR
     # Mirror from https://github.com/containernetworking/cni/releases/download/$CNI_RELEASE_VER/cni-amd64-$CNI_RELEASE_VERSION.tgz
-    downloadUrl ${AZURE_CNI_PLUGIN_URL} | tar -xz -C $CNI_BIN_DIR ./loopback
+    downloadUrl ${AZURE_CNI_PLUGINS_URL} | tar -xz -C $CNI_BIN_DIR ./loopback
     chown -R root:root $CNI_BIN_DIR
     chmod -R 755 $CNI_BIN_DIR
 

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -12,12 +12,12 @@ import (
 var (
 	//DefaultKubernetesSpecConfig is the default Docker image source of Kubernetes
 	DefaultKubernetesSpecConfig = KubernetesSpecConfig{
-		KubernetesImageBase:       "gcrio.azureedge.net/google_containers/",
-		TillerImageBase:           "gcrio.azureedge.net/kubernetes-helm/",
-		KubeBinariesSASURLBase:    "https://acs-mirror.azureedge.net/wink8s/",
-		CalicoConfigDownloadURL:   "https://raw.githubusercontent.com/projectcalico/calico/a4ebfbad55ab1b7f10fdf3b39585471f8012e898/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager",
-		AzureCNIPluginDownloadURL: "https://acs-mirror.azureedge.net/cni/cni-plugin-amd64-latest.tgz",
-		AzureVnetCNIDownloadURL:   "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-latest.tgz",
+		KubernetesImageBase:        "gcrio.azureedge.net/google_containers/",
+		TillerImageBase:            "gcrio.azureedge.net/kubernetes-helm/",
+		KubeBinariesSASURLBase:     "https://acs-mirror.azureedge.net/wink8s/",
+		CalicoConfigDownloadURL:    "https://raw.githubusercontent.com/projectcalico/calico/a4ebfbad55ab1b7f10fdf3b39585471f8012e898/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager",
+		AzureCNIPluginsDownloadURL: "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-latest.tgz",
+		AzureVnetCNIDownloadURL:    "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-latest.tgz",
 	}
 
 	//DefaultDCOSSpecConfig is the default DC/OS binary download URL.
@@ -93,11 +93,11 @@ var (
 		},
 		//KubernetesSpecConfig - Due to Chinese firewall issue, the default containers from google is blocked, use the Chinese local mirror instead
 		KubernetesSpecConfig: KubernetesSpecConfig{
-			KubernetesImageBase:       "crproxy.trafficmanager.net:6000/google_containers/",
-			TillerImageBase:           "mirror.azure.cn:5000/kubernetes-helm/",
-			CalicoConfigDownloadURL:   "https://acsengine.blob.core.chinacloudapi.cn/cni",
-			AzureVnetCNIDownloadURL:   "https://acsengine.blob.core.chinacloudapi.cn/cni/azure-vnet-cni-linux-amd64-latest.tar",
-			AzureCNIPluginDownloadURL: "https://acsengine.blob.core.chinacloudapi.cn/cni/cni-plugin-amd64-latest.tar",
+			KubernetesImageBase:        "crproxy.trafficmanager.net:6000/google_containers/",
+			TillerImageBase:            "mirror.azure.cn:5000/kubernetes-helm/",
+			CalicoConfigDownloadURL:    "https://acsengine.blob.core.chinacloudapi.cn/cni",
+			AzureVnetCNIDownloadURL:    "https://acsengine.blob.core.chinacloudapi.cn/cni/azure-vnet-cni-linux-amd64-latest.tar",
+			AzureCNIPluginsDownloadURL: "https://acsengine.blob.core.chinacloudapi.cn/cni/cni-plugins-amd64-latest.tar",
 		},
 		DCOSSpecConfig: DCOSSpecConfig{
 			DCOS173BootstrapDownloadURL:     fmt.Sprintf(AzureChinaCloudDCOSBootstrapDownloadURL, "df308b6fc3bd91e1277baa5a3db928ae70964722"),

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -12,12 +12,12 @@ import (
 var (
 	//DefaultKubernetesSpecConfig is the default Docker image source of Kubernetes
 	DefaultKubernetesSpecConfig = KubernetesSpecConfig{
-		KubernetesImageBase:     "gcrio.azureedge.net/google_containers/",
-		TillerImageBase:         "gcrio.azureedge.net/kubernetes-helm/",
-		KubeBinariesSASURLBase:  "https://acs-mirror.azureedge.net/wink8s/",
-		CalicoConfigDownloadURL: "https://raw.githubusercontent.com/projectcalico/calico/a4ebfbad55ab1b7f10fdf3b39585471f8012e898/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager",
-		AzureCNIDownloadURL:     "https://acs-mirror.azureedge.net/cni/cni-amd64-latest.tgz",
-		AzureVnetCNIDownloadURL: "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-latest.tgz",
+		KubernetesImageBase:       "gcrio.azureedge.net/google_containers/",
+		TillerImageBase:           "gcrio.azureedge.net/kubernetes-helm/",
+		KubeBinariesSASURLBase:    "https://acs-mirror.azureedge.net/wink8s/",
+		CalicoConfigDownloadURL:   "https://raw.githubusercontent.com/projectcalico/calico/a4ebfbad55ab1b7f10fdf3b39585471f8012e898/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager",
+		AzureCNIPluginDownloadURL: "https://acs-mirror.azureedge.net/cni/cni-plugin-amd64-latest.tgz",
+		AzureVnetCNIDownloadURL:   "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-latest.tgz",
 	}
 
 	//DefaultDCOSSpecConfig is the default DC/OS binary download URL.
@@ -93,11 +93,11 @@ var (
 		},
 		//KubernetesSpecConfig - Due to Chinese firewall issue, the default containers from google is blocked, use the Chinese local mirror instead
 		KubernetesSpecConfig: KubernetesSpecConfig{
-			KubernetesImageBase:     "crproxy.trafficmanager.net:6000/google_containers/",
-			TillerImageBase:         "mirror.azure.cn:5000/kubernetes-helm/",
-			CalicoConfigDownloadURL: "https://acsengine.blob.core.chinacloudapi.cn/cni",
-			AzureVnetCNIDownloadURL: "https://acsengine.blob.core.chinacloudapi.cn/cni/azure-vnet-cni-linux-amd64-latest.tar",
-			AzureCNIDownloadURL:     "https://acsengine.blob.core.chinacloudapi.cn/cni/cni-amd64-latest.tar",
+			KubernetesImageBase:       "crproxy.trafficmanager.net:6000/google_containers/",
+			TillerImageBase:           "mirror.azure.cn:5000/kubernetes-helm/",
+			CalicoConfigDownloadURL:   "https://acsengine.blob.core.chinacloudapi.cn/cni",
+			AzureVnetCNIDownloadURL:   "https://acsengine.blob.core.chinacloudapi.cn/cni/azure-vnet-cni-linux-amd64-latest.tar",
+			AzureCNIPluginDownloadURL: "https://acsengine.blob.core.chinacloudapi.cn/cni/cni-plugin-amd64-latest.tar",
 		},
 		DCOSSpecConfig: DCOSSpecConfig{
 			DCOS173BootstrapDownloadURL:     fmt.Sprintf(AzureChinaCloudDCOSBootstrapDownloadURL, "df308b6fc3bd91e1277baa5a3db928ae70964722"),

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -522,7 +522,7 @@ func getParameters(cs *api.ContainerService, isClassicMode bool) (paramsMap, err
 		addValue(parametersMap, "dockerBridgeCidr", properties.OrchestratorProfile.KubernetesConfig.DockerBridgeSubnet)
 		addValue(parametersMap, "networkPolicy", properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy)
 		addValue(parametersMap, "azureVnetCniURL", cloudSpecConfig.KubernetesSpecConfig.AzureVnetCNIDownloadURL)
-		addValue(parametersMap, "azureCniURL", cloudSpecConfig.KubernetesSpecConfig.AzureCNIPluginDownloadURL)
+		addValue(parametersMap, "azureCniURL", cloudSpecConfig.KubernetesSpecConfig.AzureCNIPluginsDownloadURL)
 		addValue(parametersMap, "calicoConfigURL", cloudSpecConfig.KubernetesSpecConfig.CalicoConfigDownloadURL)
 		addValue(parametersMap, "maxPods", properties.OrchestratorProfile.KubernetesConfig.MaxPods)
 

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -522,7 +522,7 @@ func getParameters(cs *api.ContainerService, isClassicMode bool) (paramsMap, err
 		addValue(parametersMap, "dockerBridgeCidr", properties.OrchestratorProfile.KubernetesConfig.DockerBridgeSubnet)
 		addValue(parametersMap, "networkPolicy", properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy)
 		addValue(parametersMap, "azureVnetCniURL", cloudSpecConfig.KubernetesSpecConfig.AzureVnetCNIDownloadURL)
-		addValue(parametersMap, "azureCniURL", cloudSpecConfig.KubernetesSpecConfig.AzureCNIDownloadURL)
+		addValue(parametersMap, "azureCniURL", cloudSpecConfig.KubernetesSpecConfig.AzureCNIPluginDownloadURL)
 		addValue(parametersMap, "calicoConfigURL", cloudSpecConfig.KubernetesSpecConfig.CalicoConfigDownloadURL)
 		addValue(parametersMap, "maxPods", properties.OrchestratorProfile.KubernetesConfig.MaxPods)
 

--- a/pkg/acsengine/types.go
+++ b/pkg/acsengine/types.go
@@ -42,12 +42,12 @@ type DCOSSpecConfig struct {
 
 //KubernetesSpecConfig is the kubernetes container images used.
 type KubernetesSpecConfig struct {
-	KubernetesImageBase       string
-	TillerImageBase           string
-	KubeBinariesSASURLBase    string
-	AzureVnetCNIDownloadURL   string
-	AzureCNIPluginDownloadURL string
-	CalicoConfigDownloadURL   string
+	KubernetesImageBase        string
+	TillerImageBase            string
+	KubeBinariesSASURLBase     string
+	AzureVnetCNIDownloadURL    string
+	AzureCNIPluginsDownloadURL string
+	CalicoConfigDownloadURL    string
 }
 
 //AzureEndpointConfig describes an Azure endpoint

--- a/pkg/acsengine/types.go
+++ b/pkg/acsengine/types.go
@@ -42,12 +42,12 @@ type DCOSSpecConfig struct {
 
 //KubernetesSpecConfig is the kubernetes container images used.
 type KubernetesSpecConfig struct {
-	KubernetesImageBase     string
-	TillerImageBase         string
-	KubeBinariesSASURLBase  string
-	AzureVnetCNIDownloadURL string
-	AzureCNIDownloadURL     string
-	CalicoConfigDownloadURL string
+	KubernetesImageBase       string
+	TillerImageBase           string
+	KubeBinariesSASURLBase    string
+	AzureVnetCNIDownloadURL   string
+	AzureCNIPluginDownloadURL string
+	CalicoConfigDownloadURL   string
 }
 
 //AzureEndpointConfig describes an Azure endpoint


### PR DESCRIPTION
CNI plugins have been moved to their own repo

https://github.com/containernetworking/plugins/releases