### PR TITLE
Decrease max size of docker logs, and rotation

### DIFF
--- a/parts/kubernetesagentcustomdata.yml
+++ b/parts/kubernetesagentcustomdata.yml
@@ -24,8 +24,8 @@ write_files:
       "live-restore": true,
       "log-driver": "json-file",
       "log-opts":  {
-         "max-size": "200m",
-         "max-file": "25"
+         "max-size": "50m",
+         "max-file": "5"
       }
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This change decreases maximum size of a log file down to 50 Mb and limits their number to 5 so that overall disk space occupied by logs could not exceed 250 Mb per container.

**Which issue this PR fixes**: fixes #1394

**Special notes for your reviewer**:
none 

**Release note**:
```release-note
Decrease maximum size of Docker log file to 50 Mb and maximum number of files to 5
```
