### PR TITLE
bug(agentpool): use current acs-engine defaults for agent subnet range

### DIFF
--- a/parts/kubernetesmastervars.t
+++ b/parts/kubernetesmastervars.t
@@ -135,7 +135,7 @@
     "virtualNetworkName": "[concat(variables('orchestratorName'), '-vnet-', variables('nameSuffix'))]",
   {{end}}
 {{else}}
-    "subnet": "10.0.0.0/16",
+    "subnet": "[parameters('masterSubnet')]",
     "subnetName": "[concat(variables('orchestratorName'), '-subnet')]",
     "virtualNetworkName": "[concat(variables('orchestratorName'), '-vnet-', variables('nameSuffix'))]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",

--- a/parts/masterparams.t
+++ b/parts/masterparams.t
@@ -29,6 +29,13 @@
   {{end}}
 {{end}}
 {{if IsHostedMaster}}
+    "masterSubnet": {
+      "defaultValue": "{{.HostedMasterProfile.Subnet}}",
+      "metadata": {
+        "description": "Sets the subnet for the VMs in the cluster."
+      },
+      "type": "string"
+    },
     "kubernetesEndpoint": {
       "defaultValue": "{{.HostedMasterProfile.FQDN}}",
       "metadata": {

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -123,6 +123,8 @@ func SetPropertiesDefaults(cs *api.ContainerService) (bool, error) {
 
 	setMasterNetworkDefaults(properties)
 
+	setHostedMasterNetworkDefaults(properties)
+
 	setAgentNetworkDefaults(properties)
 
 	setStorageDefaults(properties)
@@ -230,6 +232,14 @@ func setExtensionDefaults(a *api.Properties) {
 			extension.RootURL = DefaultExtensionsRootURL
 		}
 	}
+}
+
+// SetHostedMasterNetworkDefaults for hosted masters
+func setHostedMasterNetworkDefaults(a *api.Properties) {
+	if a.HostedMasterProfile == nil {
+		return
+	}
+	a.HostedMasterProfile.Subnet = DefaultKubernetesMasterSubnet
 }
 
 // SetMasterNetworkDefaults for masters

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -457,6 +457,9 @@ func getParameters(cs *api.ContainerService, isClassicMode bool) (paramsMap, err
 			addValue(parametersMap, "masterCount", properties.MasterProfile.Count)
 		}
 	}
+	if properties.HostedMasterProfile != nil {
+		addValue(parametersMap, "masterSubnet", properties.HostedMasterProfile.Subnet)
+	}
 	addValue(parametersMap, "sshRSAPublicKey", properties.LinuxProfile.SSH.PublicKeys[0].KeyData)
 	for i, s := range properties.LinuxProfile.Secrets {
 		addValue(parametersMap, fmt.Sprintf("linuxKeyVaultID%d", i), s.SourceVault.ID)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -296,6 +296,10 @@ type HostedMasterProfile struct {
 	// Not used during PUT, returned as part of GETFQDN
 	FQDN      string `json:"fqdn,omitempty"`
 	DNSPrefix string `json:"dnsPrefix"`
+	// Subnet holds the CIDR which defines the Azure Subnet in which
+	// Agents will be provisioned. This is stored on the HostedMasterProfile
+	// and will become `masterSubnet` in the compiled template.
+	Subnet string `json:"subnet"`
 }
 
 // AADProfile specifies attributes for AAD integration


### PR DESCRIPTION
Agent pool only cluster definitions use 10.0.0.0/16 range for the VM subnet rather than 10.240.0.0/16.

This PR instead uses the kubernetes master defaults for VMs leaving 10.0.0.0/16 open for K8S service addresses and kube-dns to take 10.0.0.10.

/cc @amanohar Would love feedback on this approach, not entirely sure I implemented the defaults in the right way!