### PR TITLE
Add how-to for upstream devs testing using ACS Engine

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -5,6 +5,7 @@
 
 * [Troubleshooting](kubernetes/troubleshooting.md) - Running into issues? Start here to troubleshoot Kubernetes.
 * [Features](kubernetes/features.md) - Guide to alpha, beta, and stable functionality in acs-engine.
+* [For Kubernetes Developers](kubernetes/k8s-developers.md) - Info for devs working on Kubernetes upstream and wanting to test using acs-engine.
 
 ## Known Issues
 

--- a/docs/kubernetes/k8s-developers.md
+++ b/docs/kubernetes/k8s-developers.md
@@ -1,0 +1,42 @@
+# For Kubernetes Developers
+
+If you're working on Kubernetes upstream, you can use ACS Engine to test your build of Kubernetes in the Azure environment.  The option that allows you to do this is `orchestratorProfile/kubernetesConfig/customHyperkubeImage`, which you should set to point to a Docker image containing your build of hyperkube.
+
+The following instructions describe in more detail how to create the required Docker image and deploy it using ACS Engine (replace `dockerhubid` and `sometag` with your Docker Hub ID and a unique tag for your build):
+
+## In the Kubernetes repo
+
+* Build Kubernetes:
+
+```
+bash build/run.sh make cross KUBE_FASTBUILD=true ARCH=amd64
+```
+
+* Build a Docker image containing your custom build of hyperkube:
+
+```
+cd cluster/images/hyperkube
+make VERSION=sometag
+cd ../../..
+```
+
+* Push your Docker image to Docker Hub:
+
+```
+docker tag gcr.io/google-containers/hyperkube-amd64:sometag dockerhubid/hyperkube-amd64:sometag
+docker push dockerhubid/hyperkube-amd64:sometag
+```
+
+(It's convenient to put these steps into a script.)
+
+## In the ACS repo
+
+* Open the ACS Engine input JSON (e.g. a file from the examples directory) and add the following to the `orchestratorProfile` section:
+
+```
+"kubernetesConfig": {
+    "customHyperkubeImage": "docker.io/dockerhubid/hyperkube-amd64:sometag"
+}
+```
+
+* Run `./bin/acs-engine deploy --api-model the_json_file_you_just_edited.json ...` [as normal](deploy.md).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This PR provides documentation on how to deploy a private Kubernetes build using ACS Engine.  We need it so that new devs working on upstream features in Azure can get started more easily.

**Which issue this PR fixes**: None

**Special notes for your reviewer**: None

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
