### PR TITLE
RHEL support for Docker swarm mode

### DIFF
--- a/examples/swarmmode-rhel.json
+++ b/examples/swarmmode-rhel.json
@@ -1,0 +1,37 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "SwarmMode"
+    },
+    "masterProfile": {
+      "count": 3,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpublic",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "dnsPrefix": "",
+        "ports": [
+          80,
+          443,
+          8080
+        ]
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      },
+      "distro": "rhel"
+    }
+  }
+}

--- a/examples/swarmmode-rhel.json
+++ b/examples/swarmmode-rhel.json
@@ -7,7 +7,8 @@
     "masterProfile": {
       "count": 3,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_D2_v2",
+      "distro": "rhel"
     },
     "agentPoolProfiles": [
       {
@@ -19,7 +20,8 @@
           80,
           443,
           8080
-        ]
+        ],
+        "distro": "rhel"
       }
     ],
     "linuxProfile": {
@@ -30,8 +32,7 @@
             "keyData": ""
           }
         ]
-      },
-      "distro": "rhel"
+      }
     }
   }
 }

--- a/parts/configure-swarmmode-cluster.sh
+++ b/parts/configure-swarmmode-cluster.sh
@@ -33,6 +33,7 @@ DOCKERCOMPOSEDOWNLOADURL=${10}
 VMNAME=`hostname`
 VMNUMBER=`echo $VMNAME | sed 's/.*[^0-9]\([0-9]\+\)*$/\1/'`
 VMPREFIX=`echo $VMNAME | sed 's/\(.*[^0-9]\)*[0-9]\+$/\1/'`
+OS="$(. /etc/os-release; echo $ID)"
 
 echo "Master Count: $MASTERCOUNT"
 echo "Master Prefix: $MASTERPREFIX"
@@ -41,10 +42,31 @@ echo "vmname: $VMNAME"
 echo "VMNUMBER: $VMNUMBER, VMPREFIX: $VMPREFIX"
 echo "BASESUBNET: $BASESUBNET"
 echo "AZUREUSER: $AZUREUSER"
+echo "OS ID: $OS"
 
 ###################
 # Common Functions
 ###################
+
+isUbuntu()
+{
+  if [ "$OS" == "ubuntu" ]
+  then
+    return 0
+  else
+    return 1
+  fi
+}
+
+isRHEL()
+{
+  if [ "$OS" == "rhel" ]
+  then
+    return 0
+  else
+    return 1
+  fi
+}
 
 ensureAzureNetwork()
 {
@@ -150,7 +172,7 @@ fi
 
 echo "Installing and configuring Docker"
 
-installDocker()
+installDockerUbuntu()
 {
   for i in {1..10}; do
     apt-get install -y apt-transport-https ca-certificates curl software-properties-common
@@ -168,6 +190,36 @@ installDocker()
     sleep 10
   done
 }
+
+installDockerRHEL()
+{
+  for i in {1..10}; do
+    yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    yum makecache fast
+    yum -y install docker-ce
+    if [ $? -eq 0 ]
+    then
+      systemctl enable docker
+      systemctl start docker
+      echo "Docker installed successfully"
+      break
+    fi
+    sleep 10
+  done
+}
+
+installDocker()
+{
+  if isUbuntu ; then
+    installDockerUbuntu
+  elif isRHEL ; then
+    installDockerRHEL
+  else
+    echo "OS not supported, aborting install"
+    exit 5
+  fi
+}
+
 time installDocker
 
 sudo usermod -aG docker $AZUREUSER
@@ -205,6 +257,14 @@ installDockerCompose()
 time installDockerCompose
 chmod +x /usr/local/bin/docker-compose
 
+if ismaster && isRHEL ; then
+  echo "Opening Docker ports"
+  firewall-cmd --add-port=2375/tcp --permanent
+  firewall-cmd --add-port=2377/tcp --permanent
+  firewall-cmd --reload
+fi
+
+echo "Restarting Docker"
 sudo systemctl daemon-reload
 sudo service docker restart
 

--- a/parts/masterparams.t
+++ b/parts/masterparams.t
@@ -80,34 +80,6 @@
       },
       "type": "string"
     },
-    "osImageOffer": {
-      "defaultValue": "UbuntuServer",
-      "metadata": {
-        "description": "Linux OS image type."
-      },
-      "type": "string"
-    }, 
-    "osImagePublisher": {
-      "defaultValue": "Canonical",
-      "metadata": {
-        "description": "OS image publisher."
-      },
-      "type": "string"
-    }, 
-    "osImageSKU": {
-      "defaultValue": "16.04-LTS",
-      "metadata": {
-        "description": "OS image SKU."
-      },
-      "type": "string"
-    }, 
-    "osImageVersion": {
-      "defaultValue": "16.04.201706191",
-      "metadata": {
-        "description": "OS image version."
-      },
-      "type": "string"
-    },
     "fqdnEndpointSuffix":{
       "defaultValue": "%s.%s.cloudapp.azure.com",
       "metadata": {

--- a/parts/masterparams.t
+++ b/parts/masterparams.t
@@ -80,6 +80,34 @@
       },
       "type": "string"
     },
+    "osImageOffer": {
+      "defaultValue": "UbuntuServer",
+      "metadata": {
+        "description": "Linux OS image type."
+      },
+      "type": "string"
+    }, 
+    "osImagePublisher": {
+      "defaultValue": "Canonical",
+      "metadata": {
+        "description": "OS image publisher."
+      },
+      "type": "string"
+    }, 
+    "osImageSKU": {
+      "defaultValue": "16.04-LTS",
+      "metadata": {
+        "description": "OS image SKU."
+      },
+      "type": "string"
+    }, 
+    "osImageVersion": {
+      "defaultValue": "16.04.201706191",
+      "metadata": {
+        "description": "OS image version."
+      },
+      "type": "string"
+    },
     "fqdnEndpointSuffix":{
       "defaultValue": "%s.%s.cloudapp.azure.com",
       "metadata": {

--- a/parts/swarmagentresourcesvmss.t
+++ b/parts/swarmagentresourcesvmss.t
@@ -185,7 +185,7 @@
                   "settings": {
                     "commandToExecute": "[variables('agentCustomScript')]",
                     "fileUris": [
-                      "[concat('https://raw.githubusercontent.com/tomconte/acs-engine/tco-rhel-swarmmode/parts/', variables('configureClusterScriptFile'))]"
+                      "[concat('{{ GetConfigurationScriptRootURL }}', variables('configureClusterScriptFile'))]"
                     ]
                   },
                   "type": "CustomScript",

--- a/parts/swarmagentresourcesvmss.t
+++ b/parts/swarmagentresourcesvmss.t
@@ -127,7 +127,9 @@
             "adminUsername": "[variables('adminUsername')]",
             "computerNamePrefix": "[variables('{{.Name}}VMNamePrefix')]",
 {{if IsSwarmMode}}
+  {{if not IsRHEL}}
             {{GetAgentSwarmModeCustomData .}} 
+  {{end}}
 {{else}}
             {{GetAgentSwarmCustomData .}} 
 {{end}}
@@ -173,6 +175,26 @@
 {{end}}
             }
           }
+{{if IsRHEL}}
+          ,"extensionProfile": {
+            "extensions": [
+              {
+                "name": "configure{{.Name}}",
+                "properties": {
+                  "publisher": "Microsoft.Azure.Extensions",
+                  "settings": {
+                    "commandToExecute": "[variables('agentCustomScript')]",
+                    "fileUris": [
+                      "[concat('https://raw.githubusercontent.com/tomconte/acs-engine/tco-rhel-swarmmode/parts/', variables('configureClusterScriptFile'))]"
+                    ]
+                  },
+                  "type": "CustomScript",
+                  "typeHandlerVersion": "2.0"
+                }
+              }
+            ]
+          }
+{{end}}
         }
       },
       "sku": {

--- a/parts/swarmagentresourcesvmss.t
+++ b/parts/swarmagentresourcesvmss.t
@@ -127,7 +127,7 @@
             "adminUsername": "[variables('adminUsername')]",
             "computerNamePrefix": "[variables('{{.Name}}VMNamePrefix')]",
 {{if IsSwarmMode}}
-  {{if not IsRHEL}}
+  {{if not .IsRHEL}}
             {{GetAgentSwarmModeCustomData .}} 
   {{end}}
 {{else}}
@@ -151,10 +151,10 @@
           },
           "storageProfile": {
             "imageReference": {
-              "offer": "[variables('osImageOffer')]",
-              "publisher": "[variables('osImagePublisher')]",
-              "sku": "[variables('osImageSKU')]",
-              "version": "[variables('osImageVersion')]"
+              "offer": "[variables('{{.Name}}OSImageOffer')]",
+              "publisher": "[variables('{{.Name}}OSImagePublisher')]",
+              "sku": "[variables('{{.Name}}OSImageSKU')]",
+              "version": "[variables('{{.Name}}OSImageVersion')]"
             },
             {{GetDataDisks .}}
             "osDisk": {
@@ -175,7 +175,7 @@
 {{end}}
             }
           }
-{{if IsRHEL}}
+{{if .IsRHEL}}
           ,"extensionProfile": {
             "extensions": [
               {

--- a/parts/swarmagentvars.t
+++ b/parts/swarmagentvars.t
@@ -1,5 +1,7 @@
+{{if not IsRHEL}}
     "{{.Name}}RunCmd": "[concat('runcmd:\n {{GetSwarmAgentPreprovisionExtensionCommands .}} \n-  [ /bin/bash, /opt/azure/containers/install-cluster.sh ]\n\n')]", 
     "{{.Name}}RunCmdFile": "[concat(' -  content: |\n        #!/bin/bash\n        ','sudo mkdir -p /var/log/azure\n        ',variables('agentCustomScript'),'\n    path: /opt/azure/containers/install-cluster.sh\n    permissions: \"0744\"\n')]",
+{{end}}
     "{{.Name}}Count": "[parameters('{{.Name}}Count')]", 
     "{{.Name}}VMNamePrefix": "[concat(variables('orchestratorName'), '-{{.Name}}-', variables('nameSuffix'))]", 
     "{{.Name}}VMSize": "[parameters('{{.Name}}VMSize')]", 

--- a/parts/swarmagentvars.t
+++ b/parts/swarmagentvars.t
@@ -1,7 +1,11 @@
-{{if not IsRHEL}}
+{{if not .IsRHEL}}
     "{{.Name}}RunCmd": "[concat('runcmd:\n {{GetSwarmAgentPreprovisionExtensionCommands .}} \n-  [ /bin/bash, /opt/azure/containers/install-cluster.sh ]\n\n')]", 
     "{{.Name}}RunCmdFile": "[concat(' -  content: |\n        #!/bin/bash\n        ','sudo mkdir -p /var/log/azure\n        ',variables('agentCustomScript'),'\n    path: /opt/azure/containers/install-cluster.sh\n    permissions: \"0744\"\n')]",
 {{end}}
+    "{{.Name}}OSImageOffer": {{GetAgentOSImageOffer .}}, 
+    "{{.Name}}OSImagePublisher": {{GetAgentOSImagePublisher .}}, 
+    "{{.Name}}OSImageSKU": {{GetAgentOSImageSKU .}}, 
+    "{{.Name}}OSImageVersion": {{GetAgentOSImageVersion .}},
     "{{.Name}}Count": "[parameters('{{.Name}}Count')]", 
     "{{.Name}}VMNamePrefix": "[concat(variables('orchestratorName'), '-{{.Name}}-', variables('nameSuffix'))]", 
     "{{.Name}}VMSize": "[parameters('{{.Name}}VMSize')]", 

--- a/parts/swarmmasterresources.t
+++ b/parts/swarmmasterresources.t
@@ -230,10 +230,17 @@
         },
         "storageProfile": {
           "imageReference": {
+            {{if .OrchestratorProfile.IsSwarmMode}}
             "offer": "[variables('masterOSImageOffer')]",
             "publisher": "[variables('masterOSImagePublisher')]",
             "sku": "[variables('masterOSImageSKU')]",
             "version": "[variables('masterOSImageVersion')]"
+            {{else}}
+            "offer": "[variables('osImageOffer')]",
+            "publisher": "[variables('osImagePublisher')]",
+            "sku": "[variables('osImageSKU')]",
+            "version": "[variables('osImageVersion')]"
+            {{end}}
           },
           "osDisk": {
             "caching": "ReadWrite"

--- a/parts/swarmmasterresources.t
+++ b/parts/swarmmasterresources.t
@@ -206,7 +206,7 @@
           "adminUsername": "[variables('adminUsername')]",
           "computername": "[concat(variables('masterVMNamePrefix'), copyIndex())]",
           {{if .OrchestratorProfile.IsSwarmMode}}
-            {{if not .LinuxProfile.IsRHEL}}
+            {{if not .MasterProfile.IsRHEL}}
               {{GetMasterSwarmModeCustomData}}
             {{end}}
           {{else}}
@@ -230,10 +230,10 @@
         },
         "storageProfile": {
           "imageReference": {
-            "offer": "[variables('osImageOffer')]",
-            "publisher": "[variables('osImagePublisher')]",
-            "sku": "[variables('osImageSKU')]",
-            "version": "[variables('osImageVersion')]"
+            "offer": "[variables('masterOSImageOffer')]",
+            "publisher": "[variables('masterOSImagePublisher')]",
+            "sku": "[variables('masterOSImageSKU')]",
+            "version": "[variables('masterOSImageVersion')]"
           },
           "osDisk": {
             "caching": "ReadWrite"
@@ -268,7 +268,7 @@
         "settings": {
           "commandToExecute": "[variables('masterCustomScript')]",
           "fileUris": [
-{{if IsRHEL}}
+{{if .MasterProfile.IsRHEL}}
             "[concat('{{ GetConfigurationScriptRootURL }}', variables('configureClusterScriptFile'))]"
 {{end}}
           ]

--- a/parts/swarmmasterresources.t
+++ b/parts/swarmmasterresources.t
@@ -269,7 +269,7 @@
           "commandToExecute": "[variables('masterCustomScript')]",
           "fileUris": [
 {{if IsRHEL}}
-            "[concat('https://raw.githubusercontent.com/tomconte/acs-engine/tco-rhel-swarmmode/parts/', variables('configureClusterScriptFile'))]"
+            "[concat('{{ GetConfigurationScriptRootURL }}', variables('configureClusterScriptFile'))]"
 {{end}}
           ]
         },

--- a/parts/swarmmasterresources.t
+++ b/parts/swarmmasterresources.t
@@ -206,7 +206,9 @@
           "adminUsername": "[variables('adminUsername')]",
           "computername": "[concat(variables('masterVMNamePrefix'), copyIndex())]",
           {{if .OrchestratorProfile.IsSwarmMode}}
-            {{GetMasterSwarmModeCustomData}}
+            {{if not .LinuxProfile.IsRHEL}}
+              {{GetMasterSwarmModeCustomData}}
+            {{end}}
           {{else}}
             {{GetMasterSwarmCustomData}}
           {{end}}
@@ -262,13 +264,17 @@
       "location": "[variables('location')]",
       "name": "[concat(variables('masterVMNamePrefix'), copyIndex(), '/configuremaster')]",
       "properties": {
-        "publisher": "Microsoft.OSTCExtensions",
+        "publisher": "Microsoft.Azure.Extensions",
         "settings": {
           "commandToExecute": "[variables('masterCustomScript')]",
-          "fileUris": []
+          "fileUris": [
+{{if IsRHEL}}
+            "[concat('https://raw.githubusercontent.com/tomconte/acs-engine/tco-rhel-swarmmode/parts/', variables('configureClusterScriptFile'))]"
+{{end}}
+          ]
         },
-        "type": "CustomScriptForLinux",
-        "typeHandlerVersion": "1.4"
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0"
       },
       "type": "Microsoft.Compute/virtualMachines/extensions"
     }

--- a/parts/swarmmastervars.t
+++ b/parts/swarmmastervars.t
@@ -100,15 +100,17 @@
         }
       ]
     ],
-    "masterOSImageOffer": {{GetMasterOSImageOffer}}, 
-    "masterOSImagePublisher": {{GetMasterOSImagePublisher}}, 
 {{if .OrchestratorProfile.IsSwarmMode}}
     "orchestratorName": "swarmm", 
+    "masterOSImageOffer": {{GetMasterOSImageOffer}}, 
+    "masterOSImagePublisher": {{GetMasterOSImagePublisher}}, 
     "masterOSImageSKU": {{GetMasterOSImageSKU}}, 
     "masterOSImageVersion": {{GetMasterOSImageVersion}},
     {{GetSwarmModeVersions}}
 {{else}}
     "orchestratorName": "swarm", 
+    "osImageOffer": "[parameters('osImageOffer')]", 
+    "osImagePublisher": "[parameters('osImagePublisher')]",
     "osImageSKU": "14.04.5-LTS",
     "osImageVersion": "14.04.201706190",
     {{getSwarmVersions}}

--- a/parts/swarmmastervars.t
+++ b/parts/swarmmastervars.t
@@ -6,7 +6,11 @@
 {{else}}
     "configureClusterScriptFile": "configure-swarm-cluster.sh",
 {{end}}
+{{if .LinuxProfile.IsRHEL}}
+    "agentCustomScript": "[concat('/usr/bin/nohup /bin/bash -c \"/bin/bash ',variables('configureClusterScriptFile'), ' ',variables('clusterInstallParameters'),' >> /var/log/azure/cluster-bootstrap.log 2>&1 &\" &')]",
+{{else}}
     "agentCustomScript": "[concat('/usr/bin/nohup /bin/bash -c \"/bin/bash /opt/azure/containers/',variables('configureClusterScriptFile'), ' ',variables('clusterInstallParameters'),' >> /var/log/azure/cluster-bootstrap.log 2>&1 &\" &')]",
+{{end}}
     "agentMaxVMs": 100,
     "clusterInstallParameters": "[concat(variables('orchestratorVersion'), ' ',variables('dockerComposeVersion'), ' ',variables('masterCount'), ' ',variables('masterVMNamePrefix'), ' ',variables('masterFirstAddrOctet4'), ' ',variables('adminUsername'),' ',variables('postInstallScriptURI'),' ',variables('masterFirstAddrPrefix'),' ', parameters('dockerEngineDownloadRepo'), ' ', parameters('dockerComposeDownloadURL'))]",
 {{if .LinuxProfile.HasSecrets}}
@@ -36,7 +40,11 @@
 {{else}}
     "masterCount": {{.MasterProfile.Count}}, 
 {{end}} 
+{{if .LinuxProfile.IsRHEL}}
+    "masterCustomScript": "[concat('/bin/bash -c \"/bin/bash ',variables('configureClusterScriptFile'), ' ',variables('clusterInstallParameters'),' >> /var/log/azure/cluster-bootstrap.log 2>&1\"')]", 
+{{else}}
     "masterCustomScript": "[concat('/bin/bash -c \"/bin/bash /opt/azure/containers/',variables('configureClusterScriptFile'), ' ',variables('clusterInstallParameters'),' >> /var/log/azure/cluster-bootstrap.log 2>&1\"')]", 
+{{end}}
     "masterEndpointDNSNamePrefix": "[tolower(parameters('masterEndpointDNSNamePrefix'))]", 
     "masterLbBackendPoolName": "[concat(variables('orchestratorName'), '-master-pool-', variables('nameSuffix'))]", 
     "masterLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('masterLbName'))]", 

--- a/parts/swarmmastervars.t
+++ b/parts/swarmmastervars.t
@@ -6,7 +6,7 @@
 {{else}}
     "configureClusterScriptFile": "configure-swarm-cluster.sh",
 {{end}}
-{{if .LinuxProfile.IsRHEL}}
+{{if .MasterProfile.IsRHEL}}
     "agentCustomScript": "[concat('/usr/bin/nohup /bin/bash -c \"/bin/bash ',variables('configureClusterScriptFile'), ' ',variables('clusterInstallParameters'),' >> /var/log/azure/cluster-bootstrap.log 2>&1 &\" &')]",
 {{else}}
     "agentCustomScript": "[concat('/usr/bin/nohup /bin/bash -c \"/bin/bash /opt/azure/containers/',variables('configureClusterScriptFile'), ' ',variables('clusterInstallParameters'),' >> /var/log/azure/cluster-bootstrap.log 2>&1 &\" &')]",
@@ -40,7 +40,7 @@
 {{else}}
     "masterCount": {{.MasterProfile.Count}}, 
 {{end}} 
-{{if .LinuxProfile.IsRHEL}}
+{{if .MasterProfile.IsRHEL}}
     "masterCustomScript": "[concat('/bin/bash -c \"/bin/bash ',variables('configureClusterScriptFile'), ' ',variables('clusterInstallParameters'),' >> /var/log/azure/cluster-bootstrap.log 2>&1\"')]", 
 {{else}}
     "masterCustomScript": "[concat('/bin/bash -c \"/bin/bash /opt/azure/containers/',variables('configureClusterScriptFile'), ' ',variables('clusterInstallParameters'),' >> /var/log/azure/cluster-bootstrap.log 2>&1\"')]", 
@@ -100,12 +100,12 @@
         }
       ]
     ],
-    "osImageOffer": "[parameters('osImageOffer')]", 
-    "osImagePublisher": "[parameters('osImagePublisher')]", 
+    "masterOSImageOffer": {{GetMasterOSImageOffer}}, 
+    "masterOSImagePublisher": {{GetMasterOSImagePublisher}}, 
 {{if .OrchestratorProfile.IsSwarmMode}}
     "orchestratorName": "swarmm", 
-    "osImageSKU": "[parameters('osImageSKU')]", 
-    "osImageVersion": "[parameters('osImageVersion')]",
+    "masterOSImageSKU": {{GetMasterOSImageSKU}}, 
+    "masterOSImageVersion": {{GetMasterOSImageVersion}},
     {{GetSwarmModeVersions}}
 {{else}}
     "orchestratorName": "swarm", 

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -175,3 +175,8 @@ const (
 	AzureChinaCloudDCOSBootstrapDownloadURL = "https://acsengine.blob.core.chinacloudapi.cn/dcos/%s.bootstrap.tar.xz"
 	//AzureEdgeDCOSWindowsBootstrapDownloadURL
 )
+
+const (
+	//ConfigurationScriptRootURL  Root URL for configuration script (used for script extension on RHEL)
+	ConfigurationScriptRootURL = "https://raw.githubusercontent.com/Azure/acs-engine/master/parts/"
+)

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -177,6 +177,6 @@ const (
 )
 
 const (
-	//ConfigurationScriptRootURL  Root URL for configuration script (used for script extension on RHEL)
-	ConfigurationScriptRootURL = "https://raw.githubusercontent.com/Azure/acs-engine/master/parts/"
+	//DefaultConfigurationScriptRootURL  Root URL for configuration script (used for script extension on RHEL)
+	DefaultConfigurationScriptRootURL = "https://raw.githubusercontent.com/Azure/acs-engine/master/parts/"
 )

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -44,6 +44,14 @@ var (
 		ImageVersion:   "16.04.201706191",
 	}
 
+	//RHELOSImageConfig is the RHEL Linux distribution.
+	RHELOSImageConfig = AzureOSImageConfig{
+		ImageOffer:     "RHEL",
+		ImageSku:       "7.3",
+		ImagePublisher: "RedHat",
+		ImageVersion:   "latest",
+	}
+
 	//AzureCloudSpec is the default configurations for global azure.
 	AzureCloudSpec = AzureEnvironmentSpecConfig{
 		//DockerSpecConfig specify the docker engine download repo

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -36,16 +36,16 @@ var (
 		DockerComposeDownloadURL: "https://github.com/docker/compose/releases/download",
 	}
 
-	//DefaultOSImageConfig is the default Linux distribution.
-	DefaultOSImageConfig = AzureOSImageConfig{
+	//DefaultUbuntuImageConfig is the default Linux distribution.
+	DefaultUbuntuImageConfig = AzureOSImageConfig{
 		ImageOffer:     "UbuntuServer",
 		ImageSku:       "16.04-LTS",
 		ImagePublisher: "Canonical",
 		ImageVersion:   "16.04.201706191",
 	}
 
-	//RHELOSImageConfig is the RHEL Linux distribution.
-	RHELOSImageConfig = AzureOSImageConfig{
+	//DefaultRHELOSImageConfig is the RHEL Linux distribution.
+	DefaultRHELOSImageConfig = AzureOSImageConfig{
 		ImageOffer:     "RHEL",
 		ImageSku:       "7.3",
 		ImagePublisher: "RedHat",
@@ -64,7 +64,10 @@ var (
 			ResourceManagerVMDNSSuffix: "cloudapp.azure.com",
 		},
 
-		OSImageConfig: DefaultOSImageConfig,
+		OSImageConfig: map[api.Distro]AzureOSImageConfig{
+			api.Ubuntu: DefaultUbuntuImageConfig,
+			api.RHEL:   DefaultRHELOSImageConfig,
+		},
 	}
 
 	//AzureGermanCloudSpec is the German cloud config.
@@ -75,11 +78,14 @@ var (
 		EndpointConfig: AzureEndpointConfig{
 			ResourceManagerVMDNSSuffix: "cloudapp.microsoftazure.de",
 		},
-		OSImageConfig: AzureOSImageConfig{
-			ImageOffer:     "UbuntuServer",
-			ImageSku:       "16.04-LTS",
-			ImagePublisher: "Canonical",
-			ImageVersion:   "16.04.201701130",
+		OSImageConfig: map[api.Distro]AzureOSImageConfig{
+			api.Ubuntu: {
+				ImageOffer:     "UbuntuServer",
+				ImageSku:       "16.04-LTS",
+				ImagePublisher: "Canonical",
+				ImageVersion:   "16.04.201701130",
+			},
+			api.RHEL: DefaultRHELOSImageConfig,
 		},
 	}
 
@@ -91,7 +97,10 @@ var (
 		EndpointConfig: AzureEndpointConfig{
 			ResourceManagerVMDNSSuffix: "cloudapp.windowsazure.us",
 		},
-		OSImageConfig: DefaultOSImageConfig,
+		OSImageConfig: map[api.Distro]AzureOSImageConfig{
+			api.Ubuntu: DefaultUbuntuImageConfig,
+			api.RHEL:   DefaultRHELOSImageConfig,
+		},
 	}
 
 	//AzureChinaCloudSpec is the configurations for Azure China (Mooncake)
@@ -120,7 +129,10 @@ var (
 		EndpointConfig: AzureEndpointConfig{
 			ResourceManagerVMDNSSuffix: "cloudapp.chinacloudapi.cn",
 		},
-		OSImageConfig: DefaultOSImageConfig,
+		OSImageConfig: map[api.Distro]AzureOSImageConfig{
+			api.Ubuntu: DefaultUbuntuImageConfig,
+			api.RHEL:   DefaultRHELOSImageConfig,
+		},
 	}
 )
 
@@ -262,6 +274,12 @@ func setMasterNetworkDefaults(a *api.Properties) {
 	if a.MasterProfile == nil {
 		return
 	}
+
+	// Set default Distro to Ubuntu
+	if a.MasterProfile.Distro == "" {
+		a.MasterProfile.Distro = api.Ubuntu
+	}
+
 	if !a.MasterProfile.IsCustomVNET() {
 		if a.OrchestratorProfile.OrchestratorType == api.Kubernetes {
 			if a.OrchestratorProfile.IsVNETIntegrated() {
@@ -319,6 +337,10 @@ func setAgentNetworkDefaults(a *api.Properties) {
 		// set default OSType to Linux
 		if profile.OSType == "" {
 			profile.OSType = api.Linux
+		}
+		// set default Distro to Ubuntu
+		if profile.Distro == "" {
+			profile.Distro = api.Ubuntu
 		}
 
 		// Set the default number of IP addresses allocated for agents.

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -1020,6 +1020,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"IsRHEL": func() bool {
 			return cs.Properties.LinuxProfile.IsRHEL()
 		},
+		"GetConfigurationScriptRootURL": func() string {
+			return ConfigurationScriptRootURL
+		},
 		"PopulateClassicModeDefaultValue": func(attr string) string {
 			var val string
 			if !t.ClassicMode {

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -449,6 +449,10 @@ func getParameters(cs *api.ContainerService, isClassicMode bool) (paramsMap, err
 
 	// Master Parameters
 	addValue(parametersMap, "location", location)
+	addValue(parametersMap, "osImageOffer", cloudSpecConfig.OSImageConfig[api.Ubuntu].ImageOffer)
+	addValue(parametersMap, "osImageSKU", cloudSpecConfig.OSImageConfig[api.Ubuntu].ImageSku)
+	addValue(parametersMap, "osImagePublisher", cloudSpecConfig.OSImageConfig[api.Ubuntu].ImagePublisher)
+	addValue(parametersMap, "osImageVersion", cloudSpecConfig.OSImageConfig[api.Ubuntu].ImageVersion)
 	addValue(parametersMap, "fqdnEndpointSuffix", cloudSpecConfig.EndpointConfig.ResourceManagerVMDNSSuffix)
 	addValue(parametersMap, "targetEnvironment", GetCloudTargetEnv(location))
 	addValue(parametersMap, "linuxAdminUsername", properties.LinuxProfile.AdminUsername)

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -1021,7 +1021,10 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return cs.Properties.LinuxProfile.IsRHEL()
 		},
 		"GetConfigurationScriptRootURL": func() string {
-			return ConfigurationScriptRootURL
+			if cs.Properties.LinuxProfile.ScriptRootURL == "" {
+				return DefaultConfigurationScriptRootURL
+			}
+			return cs.Properties.LinuxProfile.ScriptRootURL
 		},
 		"PopulateClassicModeDefaultValue": func(attr string) string {
 			var val string

--- a/pkg/acsengine/types.go
+++ b/pkg/acsengine/types.go
@@ -71,7 +71,7 @@ type AzureEnvironmentSpecConfig struct {
 	KubernetesSpecConfig KubernetesSpecConfig
 	DCOSSpecConfig       DCOSSpecConfig
 	EndpointConfig       AzureEndpointConfig
-	OSImageConfig        AzureOSImageConfig
+	OSImageConfig        map[api.Distro]AzureOSImageConfig
 }
 
 // Context represents the object that is passed to the package

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -20,6 +20,12 @@ const (
 	Linux   OSType = "Linux"
 )
 
+// the LinuxDistros supported by vlabs
+const (
+	Ubuntu Distro = "ubuntu"
+	RHEL   Distro = "rhel"
+)
+
 const (
 	// SwarmVersion is the Swarm orchestrator version
 	SwarmVersion = "swarm:1.1.0"

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -549,6 +549,7 @@ func convertLinuxProfileToVLabs(obj *LinuxProfile, vlabsProfile *vlabs.LinuxProf
 		vlabsProfile.Secrets = append(vlabsProfile.Secrets, *secret)
 	}
 	vlabsProfile.Distro = vlabs.Distro(obj.Distro)
+	vlabsProfile.ScriptRootURL = obj.ScriptRootURL
 }
 
 func convertWindowsProfileToV20160930(api *WindowsProfile, v20160930 *v20160930.WindowsProfile) {

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -548,6 +548,7 @@ func convertLinuxProfileToVLabs(obj *LinuxProfile, vlabsProfile *vlabs.LinuxProf
 		convertKeyVaultSecretsToVlabs(&s, secret)
 		vlabsProfile.Secrets = append(vlabsProfile.Secrets, *secret)
 	}
+	vlabsProfile.Distro = vlabs.Distro(obj.Distro)
 }
 
 func convertWindowsProfileToV20160930(api *WindowsProfile, v20160930 *v20160930.WindowsProfile) {

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -548,7 +548,6 @@ func convertLinuxProfileToVLabs(obj *LinuxProfile, vlabsProfile *vlabs.LinuxProf
 		convertKeyVaultSecretsToVlabs(&s, secret)
 		vlabsProfile.Secrets = append(vlabsProfile.Secrets, *secret)
 	}
-	vlabsProfile.Distro = vlabs.Distro(obj.Distro)
 	vlabsProfile.ScriptRootURL = obj.ScriptRootURL
 }
 
@@ -723,6 +722,7 @@ func convertMasterProfileToVLabs(api *MasterProfile, vlabsProfile *vlabs.MasterP
 		convertExtensionToVLabs(&extension, vlabsExtension)
 		vlabsProfile.Extensions = append(vlabsProfile.Extensions, *vlabsExtension)
 	}
+	vlabsProfile.Distro = vlabs.Distro(api.Distro)
 }
 
 func convertKeyVaultSecretsToVlabs(api *KeyVaultSecrets, vlabsSecrets *vlabs.KeyVaultSecrets) {
@@ -814,6 +814,7 @@ func convertAgentPoolProfileToVLabs(api *AgentPoolProfile, p *vlabs.AgentPoolPro
 		convertExtensionToVLabs(&extension, vlabsExtension)
 		p.Extensions = append(p.Extensions, *vlabsExtension)
 	}
+	p.Distro = vlabs.Distro(api.Distro)
 }
 
 func convertDiagnosticsProfileToV20160930(api *DiagnosticsProfile, dp *v20160930.DiagnosticsProfile) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -473,7 +473,6 @@ func convertVLabsLinuxProfile(vlabs *vlabs.LinuxProfile, api *LinuxProfile) {
 		convertVLabsKeyVaultSecrets(&s, secret)
 		api.Secrets = append(api.Secrets, *secret)
 	}
-	api.Distro = Distro(vlabs.Distro)
 	api.ScriptRootURL = vlabs.ScriptRootURL
 }
 
@@ -712,6 +711,8 @@ func convertVLabsMasterProfile(vlabs *vlabs.MasterProfile, api *MasterProfile) {
 		convertVLabsExtension(&extension, apiExtension)
 		api.Extensions = append(api.Extensions, *apiExtension)
 	}
+
+	api.Distro = Distro(vlabs.Distro)
 }
 
 func convertV20160930AgentPoolProfile(v20160930 *v20160930.AgentPoolProfile, availabilityProfile string, api *AgentPoolProfile) {
@@ -808,6 +809,7 @@ func convertVLabsAgentPoolProfile(vlabs *vlabs.AgentPoolProfile, api *AgentPoolP
 		convertVLabsExtension(&extension, apiExtension)
 		api.Extensions = append(api.Extensions, *apiExtension)
 	}
+	api.Distro = Distro(vlabs.Distro)
 }
 
 func convertVLabsKeyVaultSecrets(vlabs *vlabs.KeyVaultSecrets, api *KeyVaultSecrets) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -474,6 +474,7 @@ func convertVLabsLinuxProfile(vlabs *vlabs.LinuxProfile, api *LinuxProfile) {
 		api.Secrets = append(api.Secrets, *secret)
 	}
 	api.Distro = Distro(vlabs.Distro)
+	api.ScriptRootURL = vlabs.ScriptRootURL
 }
 
 func convertV20160930WindowsProfile(v20160930 *v20160930.WindowsProfile, api *WindowsProfile) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -473,6 +473,7 @@ func convertVLabsLinuxProfile(vlabs *vlabs.LinuxProfile, api *LinuxProfile) {
 		convertVLabsKeyVaultSecrets(&s, secret)
 		api.Secrets = append(api.Secrets, *secret)
 	}
+	api.Distro = Distro(vlabs.Distro)
 }
 
 func convertV20160930WindowsProfile(v20160930 *v20160930.WindowsProfile, api *WindowsProfile) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -190,6 +190,7 @@ type MasterProfile struct {
 	OAuthEnabled             bool        `json:"oauthEnabled"`
 	PreprovisionExtension    *Extension  `json:"preProvisionExtension"`
 	Extensions               []Extension `json:"extensions"`
+	Distro                   Distro      `json:"distro,omitempty"`
 
 	// Master LB public endpoint/FQDN with port
 	// The format will be FQDN:2376
@@ -231,6 +232,7 @@ type AgentPoolProfile struct {
 	VnetSubnetID        string `json:"vnetSubnetID,omitempty"`
 	Subnet              string `json:"subnet"`
 	IPAddressCount      int    `json:"ipAddressCount,omitempty"`
+	Distro              Distro `json:"distro,omitempty"`
 
 	FQDN                  string            `json:"fqdn,omitempty"`
 	CustomNodeLabels      map[string]string `json:"customNodeLabels,omitempty"`
@@ -429,6 +431,11 @@ func (m *MasterProfile) IsStorageAccount() bool {
 	return m.StorageProfile == StorageAccount
 }
 
+// IsRHEL returns true if the master specified a RHEL distro
+func (m *MasterProfile) IsRHEL() bool {
+	return m.Distro == RHEL
+}
+
 // IsCustomVNET returns true if the customer brought their own VNET
 func (a *AgentPoolProfile) IsCustomVNET() bool {
 	return len(a.VnetSubnetID) > 0
@@ -442,6 +449,11 @@ func (a *AgentPoolProfile) IsWindows() bool {
 // IsLinux returns true if the agent pool is linux
 func (a *AgentPoolProfile) IsLinux() bool {
 	return a.OSType == Linux
+}
+
+// IsRHEL returns true if the agent pool specified a RHEL distro
+func (a *AgentPoolProfile) IsRHEL() bool {
+	return a.OSType == Linux && a.Distro == RHEL
 }
 
 // IsAvailabilitySets returns true if the customer specified disks
@@ -502,9 +514,4 @@ func (o *OrchestratorProfile) IsVNETIntegrated() bool {
 // HasAadProfile  returns true if the has aad profile
 func (p *Properties) HasAadProfile() bool {
 	return p.AADProfile != nil
-}
-
-// IsRHEL returns true if the RHEL Linux distro is requested.
-func (l *LinuxProfile) IsRHEL() bool {
-	return l.Distro == RHEL
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -98,8 +98,9 @@ type LinuxProfile struct {
 	SSH           struct {
 		PublicKeys []PublicKey `json:"publicKeys"`
 	} `json:"ssh"`
-	Secrets []KeyVaultSecrets `json:"secrets,omitempty"`
-	Distro  Distro            `json:"distro,omitempty"`
+	Secrets       []KeyVaultSecrets `json:"secrets,omitempty"`
+	Distro        Distro            `json:"distro,omitempty"`
+	ScriptRootURL string            `json:"scriptroot,omitempty"`
 }
 
 // PublicKey represents an SSH key for LinuxProfile

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -99,6 +99,7 @@ type LinuxProfile struct {
 		PublicKeys []PublicKey `json:"publicKeys"`
 	} `json:"ssh"`
 	Secrets []KeyVaultSecrets `json:"secrets,omitempty"`
+	Distro  Distro            `json:"distro,omitempty"`
 }
 
 // PublicKey represents an SSH key for LinuxProfile
@@ -293,6 +294,9 @@ type KeyVaultCertificate struct {
 
 // OSType represents OS types of agents
 type OSType string
+
+// Distro represents Linux distro to use for Linux VMs
+type Distro string
 
 // HostedMasterProfile defines properties for a hosted master
 type HostedMasterProfile struct {
@@ -497,4 +501,9 @@ func (o *OrchestratorProfile) IsVNETIntegrated() bool {
 // HasAadProfile  returns true if the has aad profile
 func (p *Properties) HasAadProfile() bool {
 	return p.AADProfile != nil
+}
+
+// IsRHEL returns true if the RHEL Linux distro is requested.
+func (l *LinuxProfile) IsRHEL() bool {
+	return l.Distro == RHEL
 }

--- a/pkg/api/vlabs/const.go
+++ b/pkg/api/vlabs/const.go
@@ -25,8 +25,8 @@ const (
 
 // the LinuxDistros supported by vlabs
 const (
-	Ubuntu	Distro = "ubuntu"
-	RHEL   	Distro = "rhel"
+	Ubuntu Distro = "ubuntu"
+	RHEL   Distro = "rhel"
 )
 
 // validation values

--- a/pkg/api/vlabs/const.go
+++ b/pkg/api/vlabs/const.go
@@ -23,6 +23,12 @@ const (
 	Linux   OSType = "Linux"
 )
 
+// the LinuxDistros supported by vlabs
+const (
+	Ubuntu	Distro = "ubuntu"
+	RHEL   	Distro = "rhel"
+)
+
 // validation values
 const (
 	// MinAgentCount are the minimum number of agents per agent pool

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -103,7 +103,6 @@ type LinuxProfile struct {
 		PublicKeys []PublicKey `json:"publicKeys" validate:"required,len=1"`
 	} `json:"ssh" validate:"required"`
 	Secrets       []KeyVaultSecrets `json:"secrets,omitempty"`
-	Distro        Distro            `json:"distro,omitempty"`
 	ScriptRootURL string            `json:"scriptroot,omitempty"`
 }
 
@@ -218,6 +217,7 @@ type MasterProfile struct {
 	OAuthEnabled             bool        `json:"oauthEnabled"`
 	PreProvisionExtension    *Extension  `json:"preProvisionExtension"`
 	Extensions               []Extension `json:"extensions"`
+	Distro                   Distro      `json:"distro,omitempty"`
 
 	// subnet is internal
 	subnet string
@@ -264,6 +264,7 @@ type AgentPoolProfile struct {
 	DiskSizesGB         []int  `json:"diskSizesGB,omitempty" validate:"max=4,dive,min=1,max=1023"`
 	VnetSubnetID        string `json:"vnetSubnetID,omitempty"`
 	IPAddressCount      int    `json:"ipAddressCount,omitempty" validate:"min=0,max=256"`
+	Distro              Distro `json:"distro,omitempty"`
 
 	// subnet is internal
 	subnet string
@@ -350,6 +351,11 @@ func (m *MasterProfile) IsStorageAccount() bool {
 	return m.StorageProfile == StorageAccount
 }
 
+// IsRHEL returns true if the master specified a RHEL distro
+func (m *MasterProfile) IsRHEL() bool {
+	return m.Distro == RHEL
+}
+
 // IsCustomVNET returns true if the customer brought their own VNET
 func (a *AgentPoolProfile) IsCustomVNET() bool {
 	return len(a.VnetSubnetID) > 0
@@ -363,6 +369,11 @@ func (a *AgentPoolProfile) IsWindows() bool {
 // IsLinux returns true if the agent pool is linux
 func (a *AgentPoolProfile) IsLinux() bool {
 	return a.OSType == Linux
+}
+
+// IsRHEL returns true if the agent pool specified a RHEL distro
+func (a *AgentPoolProfile) IsRHEL() bool {
+	return a.OSType == Linux && a.Distro == RHEL
 }
 
 // IsAvailabilitySets returns true if the customer specified disks

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -103,6 +103,7 @@ type LinuxProfile struct {
 		PublicKeys []PublicKey `json:"publicKeys" validate:"required,len=1"`
 	} `json:"ssh" validate:"required"`
 	Secrets []KeyVaultSecrets `json:"secrets,omitempty"`
+	Distro  Distro            `json:"distro,omitempty"`
 }
 
 // PublicKey represents an SSH key for LinuxProfile
@@ -309,6 +310,9 @@ type KeyVaultCertificate struct {
 
 // OSType represents OS types of agents
 type OSType string
+
+// Distro represents Linux distro to use for Linux VMs
+type Distro string
 
 // HasWindows returns true if the cluster contains windows
 func (p *Properties) HasWindows() bool {

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -102,8 +102,9 @@ type LinuxProfile struct {
 	SSH           struct {
 		PublicKeys []PublicKey `json:"publicKeys" validate:"required,len=1"`
 	} `json:"ssh" validate:"required"`
-	Secrets []KeyVaultSecrets `json:"secrets,omitempty"`
-	Distro  Distro            `json:"distro,omitempty"`
+	Secrets       []KeyVaultSecrets `json:"secrets,omitempty"`
+	Distro        Distro            `json:"distro,omitempty"`
+	ScriptRootURL string            `json:"scriptroot,omitempty"`
 }
 
 // PublicKey represents an SSH key for LinuxProfile


### PR DESCRIPTION
**What this PR does / why we need it**:

Add RHEL support for Docker swarm mode.

**Special notes for your reviewer**:

This is more of a "strawman" PR to get feedback about the approach. A partner of mine wants to run Docker swarm mode on RHEL using ACS-Engine and I implemented this as a prototype. It probably needs polishing and testing (but it seems to work :).

Basically, I added an element "distro" to LinuxProfile, where you can request a different distro than the default e.g. "rhel". ACS-Engine then provides the supported SKU/version for that distro.

The main issue with RHEL is that it does not support Custom Data / cloud-init. I used regular CSE, pointing the fileUri to my fork at the moment. We could assemble a URL pointing to a specific release on the acs-engine repo instead.

**Release note**:

NONE