### PR TITLE
now using explicit PROMOTE_TO_FAILURE condition

### DIFF
--- a/test/acs-engine-test/main.go
+++ b/test/acs-engine-test/main.go
@@ -229,8 +229,8 @@ func (m *TestManager) testRun(d config.Deployment, index, attempt int, timeout t
 		d.Location = m.regions[randomIndex]
 	}
 	testName := strings.TrimSuffix(d.ClusterDefinition, filepath.Ext(d.ClusterDefinition))
-	instanceName := fmt.Sprintf("acse-%d-%s-%s-%d", rand.Intn(0x0ffffff), d.Location, os.Getenv("BUILD_NUM"), index)
-	resourceGroup := fmt.Sprintf("%s-%s-%s-%s-%d", rgPrefix, strings.Replace(testName, "/", "-", -1), d.Location, os.Getenv("BUILD_NUM"), index)
+	instanceName := fmt.Sprintf("acse-%d-%s-%s-%d-%d", rand.Intn(0x0ffffff), d.Location, os.Getenv("BUILD_NUM"), index, attempt)
+	resourceGroup := fmt.Sprintf("%s-%s-%s-%s-%d-%d", rgPrefix, strings.Replace(testName, "/", "-", -1), d.Location, os.Getenv("BUILD_NUM"), index, attempt)
 	logFile := fmt.Sprintf("%s/%s.log", logDir, resourceGroup)
 	validateLogFile := fmt.Sprintf("%s/validate-%s.log", logDir, resourceGroup)
 

--- a/test/acs-engine-test/main.go
+++ b/test/acs-engine-test/main.go
@@ -116,7 +116,7 @@ func (m *TestManager) Run() error {
 		fmt.Println("Using promote to failure to determine pass/fail")
 	} else {
 		// determine number of retries
-		retries, err := strconv.Atoi(os.Getenv("NUM_OF_RETRIES"))
+		retries, err = strconv.Atoi(os.Getenv("NUM_OF_RETRIES"))
 		if err != nil {
 			// Set default retries if not set
 			retries = 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: reconfigures our E2E test runner to explicitly opt into "promote to failure" behavior

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
