### PR TITLE
Pass extension parameters as parameter allow using keyvault to do so

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -25,7 +25,7 @@ The extensionProfiles contains the extensions that the cluster will install. The
 |---|---|---|
 |name|yes|the name of the extension.  This has to exactly match the name of a folder under the extensions folder|
 |version|yes|the version of the extension.  This has to exactly match the name of the folder under the extension name folder|
-|extensionParameters|optional|extension parameters may be required by extensions.  The format of the parameters is also extension dependant. If the index in the vm pool is needed add EXTENSION_LOOP_INDEX at the location you wan the index and it will be replaced with the string representation of the index(zero based)|
+|extensionParameters|optional|extension parameters may be required by extensions.  The format of the parameters is also extension dependant.|
 |rootURL|optional|url to the root location of extensions.  The rootURL must have an extensions child folder that follows the extensions convention.  The rootURL is mainly used for testing purposes.|
 |script|optional|Used for preprovision scripts this points to the location of the script to run inside of the extension folder.|
 

--- a/parts/masterparams.t
+++ b/parts/masterparams.t
@@ -15,7 +15,7 @@
         "metadata": {
         "description": "Parameters for the extension"
       }, 
-      "type": "string"
+      "type": "securestring"
       },
     {{end}}
 {{if not IsHostedMaster }}

--- a/parts/masterparams.t
+++ b/parts/masterparams.t
@@ -10,6 +10,14 @@
       }, 
       "type": "string"
     },
+    {{range .ExtensionProfiles}}
+      "{{.Name}}Parameters": {
+        "metadata": {
+        "description": "Parameters for the extension"
+      }, 
+      "type": "string"
+      },
+    {{end}}
 {{if not IsHostedMaster }}
   {{if .MasterProfile.IsCustomVNET}}
     "masterVnetSubnetID": {

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -1139,7 +1139,7 @@ func makeExtensionScriptCommands(extension *api.Extension, extensionProfiles []*
 		panic(fmt.Sprintf("%s extension referenced was not found in the extension profile", extension.Name))
 	}
 
-	extensionsParameterReference := fmt.Sprintf("parameters('%s'Parameters)", extensionProfile.Name)
+	extensionsParameterReference := fmt.Sprintf("parameters('%sParameters')", extensionProfile.Name)
 	scriptURL := getExtensionURL(extensionProfile.RootURL, extensionProfile.Name, extensionProfile.Version, extensionProfile.Script, extensionProfile.URLQuery)
 	scriptFilePath := fmt.Sprintf("/opt/azure/containers/extensions/%s/%s", extensionProfile.Name, extensionProfile.Script)
 	return fmt.Sprintf("- sudo /usr/bin/curl -o %s --create-dirs \"%s\" \n- sudo /bin/chmod 744 %s \n- sudo %s ',%s,' > /var/log/%s-output.log",
@@ -1726,7 +1726,7 @@ func internalGetPoolLinkedTemplateText(extTargetVMNamePrefix, orchestratorType, 
 	if e != nil {
 		return "", e
 	}
-	extensionsParameterReference := fmt.Sprintf("[parameters('%s'Parameters)]", extensionProfile.Name)
+	extensionsParameterReference := fmt.Sprintf("[parameters('%sParameters')]", extensionProfile.Name)
 	dta = strings.Replace(dta, "EXTENSION_PARAMETERS_REPLACE", extensionsParameterReference, -1)
 	dta = strings.Replace(dta, "EXTENSION_URL_REPLACE", extensionProfile.RootURL, -1)
 	dta = strings.Replace(dta, "EXTENSION_TARGET_VM_NAME_PREFIX", extTargetVMNamePrefix, -1)

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -604,6 +604,17 @@ func getParameters(cs *api.ContainerService, isClassicMode bool) (paramsMap, err
 		}
 	}
 
+	for _, extension := range properties.ExtensionProfiles {
+		if extension.ExtensionParametersKeyVaultRef != nil {
+			addKeyvaultReference(parametersMap, fmt.Sprintf("%sParameters", extension.Name),
+				extension.ExtensionParametersKeyVaultRef.VaultID,
+				extension.ExtensionParametersKeyVaultRef.SecretName,
+				extension.ExtensionParametersKeyVaultRef.SecretVersion)
+		} else {
+			addValue(parametersMap, fmt.Sprintf("%sParameters", extension.Name), extension.ExtensionParameters)
+		}
+	}
+
 	return parametersMap, nil
 }
 
@@ -1128,11 +1139,11 @@ func makeExtensionScriptCommands(extension *api.Extension, extensionProfiles []*
 		panic(fmt.Sprintf("%s extension referenced was not found in the extension profile", extension.Name))
 	}
 
+	extensionsParameterReference := fmt.Sprintf("parameters('%s'Parameters)", extensionProfile.Name)
 	scriptURL := getExtensionURL(extensionProfile.RootURL, extensionProfile.Name, extensionProfile.Version, extensionProfile.Script, extensionProfile.URLQuery)
 	scriptFilePath := fmt.Sprintf("/opt/azure/containers/extensions/%s/%s", extensionProfile.Name, extensionProfile.Script)
-	parameters := strings.Replace(extensionProfile.ExtensionParameters, "EXTENSION_LOOP_INDEX", copyIndex, -1)
-	return fmt.Sprintf("- sudo /usr/bin/curl -o %s --create-dirs \"%s\" \n- sudo /bin/chmod 744 %s \n- sudo %s %s > /var/log/%s-output.log",
-		scriptFilePath, scriptURL, scriptFilePath, scriptFilePath, parameters, extensionProfile.Name)
+	return fmt.Sprintf("- sudo /usr/bin/curl -o %s --create-dirs \"%s\" \n- sudo /bin/chmod 744 %s \n- sudo %s ',%s,' > /var/log/%s-output.log",
+		scriptFilePath, scriptURL, scriptFilePath, scriptFilePath, extensionsParameterReference, extensionProfile.Name)
 }
 
 func getPackageGUID(orchestratorType string, orchestratorRelease string, masterCount int) string {
@@ -1711,13 +1722,12 @@ func getAgentPoolLinkedTemplateText(agentPoolProfile *api.AgentPoolProfile, orch
 }
 
 func internalGetPoolLinkedTemplateText(extTargetVMNamePrefix, orchestratorType, loopCount, loopOffset string, extensionProfile *api.ExtensionProfile) (string, error) {
-	dta, e := getLinkedTemplateTextForURL(orchestratorType, extensionProfile.Name, extensionProfile.Version, extensionProfile.RootURL, extensionProfile.URLQuery)
+	dta, e := getLinkedTemplateTextForURL(extensionProfile.RootURL, orchestratorType, extensionProfile.Name, extensionProfile.Version, extensionProfile.URLQuery)
 	if e != nil {
 		return "", e
 	}
-	parmetersString := strings.Replace(extensionProfile.ExtensionParameters, "EXTENSION_LOOP_INDEX",
-		"copyIndex(EXTENSION_LOOP_OFFSET)", -1)
-	dta = strings.Replace(dta, "EXTENSION_PARAMETERS_REPLACE", parmetersString, -1)
+	extensionsParameterReference := fmt.Sprintf("[parameters('%s'Parameters)]", extensionProfile.Name)
+	dta = strings.Replace(dta, "EXTENSION_PARAMETERS_REPLACE", extensionsParameterReference, -1)
 	dta = strings.Replace(dta, "EXTENSION_URL_REPLACE", extensionProfile.RootURL, -1)
 	dta = strings.Replace(dta, "EXTENSION_TARGET_VM_NAME_PREFIX", extTargetVMNamePrefix, -1)
 	dta = strings.Replace(dta, "EXTENSION_LOOP_COUNT", loopCount, -1)

--- a/pkg/acsengine/testdata/extensions/dcos.json
+++ b/pkg/acsengine/testdata/extensions/dcos.json
@@ -45,7 +45,7 @@
       { 
         "name": "hello-world", 
         "version": "v1", 
-        "rootURL": "https://raw.githubusercontent.com/Azure/acs-engine/RobBagby-extension-support/",
+        "rootURL": "https://raw.githubusercontent.com/Azure/acs-engine/master/",
         "script": "hello.sh"
       }
     ]

--- a/pkg/acsengine/testdata/extensions/kubernetes.json
+++ b/pkg/acsengine/testdata/extensions/kubernetes.json
@@ -49,7 +49,11 @@
       { 
         "name": "hello-world-k8s", 
         "version": "v1", 
-        "rootURL": "https://raw.githubusercontent.com/Azure/acs-engine/RobBagby-extension-support/" 
+        "parametersKeyvaultSecretRef":{
+          "vaultID":"id",
+          "secretName":"name"
+        },
+        "rootURL": "https://raw.githubusercontent.com/Azure/acs-engine/master/" 
       }
     ],
     "servicePrincipalProfile": {

--- a/pkg/acsengine/testdata/extensions/kubernetes.json
+++ b/pkg/acsengine/testdata/extensions/kubernetes.json
@@ -49,10 +49,6 @@
       { 
         "name": "hello-world-k8s", 
         "version": "v1", 
-        "parametersKeyvaultSecretRef":{
-          "vaultID":"id",
-          "secretName":"name"
-        },
         "rootURL": "https://raw.githubusercontent.com/Azure/acs-engine/master/" 
       }
     ],

--- a/pkg/acsengine/testdata/extensions/swarmmode.json
+++ b/pkg/acsengine/testdata/extensions/swarmmode.json
@@ -66,7 +66,8 @@
       { 
         "name": "hello-world-k8s", 
         "version": "v1", 
-        "rootURL": "https://raw.githubusercontent.com/Azure/acs-engine/RobBagby-extension-support/",
+        "extensionParameters": "extensionParameters",
+        "rootURL": "https://raw.githubusercontent.com/Azure/acs-engine/master/",
         "script": "test.sh"
       }
     ],

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -503,13 +503,20 @@ func convertLinuxProfileToV20170131(api *LinuxProfile, obj *v20170131.LinuxProfi
 	}
 }
 
-func convertExtensionProfileToVLabs(api *ExtensionProfile, vlabs *vlabs.ExtensionProfile) {
-	vlabs.Name = api.Name
-	vlabs.Version = api.Version
-	vlabs.ExtensionParameters = api.ExtensionParameters
-	vlabs.RootURL = api.RootURL
-	vlabs.Script = api.Script
-	vlabs.URLQuery = api.URLQuery
+func convertExtensionProfileToVLabs(api *ExtensionProfile, obj *vlabs.ExtensionProfile) {
+	obj.Name = api.Name
+	obj.Version = api.Version
+	obj.ExtensionParameters = api.ExtensionParameters
+	if api.ExtensionParametersKeyVaultRef != nil {
+		obj.ExtensionParametersKeyVaultRef = &vlabs.KeyvaultSecretRef{
+			VaultID:       api.ExtensionParametersKeyVaultRef.VaultID,
+			SecretName:    api.ExtensionParametersKeyVaultRef.SecretName,
+			SecretVersion: api.ExtensionParametersKeyVaultRef.SecretVersion,
+		}
+	}
+	obj.RootURL = api.RootURL
+	obj.Script = api.Script
+	obj.URLQuery = api.URLQuery
 }
 
 func convertExtensionToVLabs(api *Extension, vlabs *vlabs.Extension) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -432,6 +432,13 @@ func convertVLabsExtensionProfile(vlabs *vlabs.ExtensionProfile, api *ExtensionP
 	api.Name = vlabs.Name
 	api.Version = vlabs.Version
 	api.ExtensionParameters = vlabs.ExtensionParameters
+	if vlabs.ExtensionParametersKeyVaultRef != nil {
+		api.ExtensionParametersKeyVaultRef = &KeyvaultSecretRef{
+			VaultID:       vlabs.ExtensionParametersKeyVaultRef.VaultID,
+			SecretName:    vlabs.ExtensionParametersKeyVaultRef.SecretName,
+			SecretVersion: vlabs.ExtensionParametersKeyVaultRef.SecretVersion,
+		}
+	}
 	api.RootURL = vlabs.RootURL
 	api.Script = vlabs.Script
 	api.URLQuery = vlabs.URLQuery

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -195,10 +195,11 @@ type MasterProfile struct {
 
 // ExtensionProfile represents an extension definition
 type ExtensionProfile struct {
-	Name                string `json:"name"`
-	Version             string `json:"version"`
-	ExtensionParameters string `json:"extensionParameters"`
-	RootURL             string `json:"rootURL"`
+	Name                           string             `json:"name"`
+	Version                        string             `json:"version"`
+	ExtensionParameters            string             `json:"extensionParameters"`
+	ExtensionParametersKeyVaultRef *KeyvaultSecretRef `json:"parametersKeyvaultSecretRef`
+	RootURL                        string             `json:"rootURL"`
 	// This is only needed for preprovision extensions and it needs to be a bash script
 	Script   string `json:"script"`
 	URLQuery string `json:"urlQuery"`

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -197,12 +197,12 @@ type MasterProfile struct {
 type ExtensionProfile struct {
 	Name                           string             `json:"name"`
 	Version                        string             `json:"version"`
-	ExtensionParameters            string             `json:"extensionParameters"`
-	ExtensionParametersKeyVaultRef *KeyvaultSecretRef `json:"parametersKeyvaultSecretRef`
-	RootURL                        string             `json:"rootURL"`
+	ExtensionParameters            string             `json:"extensionParameters,omitempty"`
+	ExtensionParametersKeyVaultRef *KeyvaultSecretRef `json:"parametersKeyvaultSecretRef,omitempty"`
+	RootURL                        string             `json:"rootURL,omitempty"`
 	// This is only needed for preprovision extensions and it needs to be a bash script
-	Script   string `json:"script"`
-	URLQuery string `json:"urlQuery"`
+	Script   string `json:"script,omitempty"`
+	URLQuery string `json:"urlQuery,omitempty"`
 }
 
 // Extension represents an extension definition in the master or agentPoolProfile

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -231,10 +231,11 @@ type ClassicAgentPoolProfileType string
 
 // ExtensionProfile represents an extension definition
 type ExtensionProfile struct {
-	Name                string `json:"name"`
-	Version             string `json:"version"`
-	ExtensionParameters string `json:"extensionParameters"`
-	RootURL             string `json:"rootURL"`
+	Name                           string             `json:"name"`
+	Version                        string             `json:"version"`
+	ExtensionParameters            string             `json:"extensionParameters"`
+	ExtensionParametersKeyVaultRef *KeyvaultSecretRef `json:"parametersKeyvaultSecretRef`
+	RootURL                        string             `json:"rootURL"`
 	// This is only needed for preprovision extensions and it needs to be a bash script
 	Script   string `json:"script"`
 	URLQuery string `json:"urlQuery"`

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -233,12 +233,12 @@ type ClassicAgentPoolProfileType string
 type ExtensionProfile struct {
 	Name                           string             `json:"name"`
 	Version                        string             `json:"version"`
-	ExtensionParameters            string             `json:"extensionParameters"`
-	ExtensionParametersKeyVaultRef *KeyvaultSecretRef `json:"parametersKeyvaultSecretRef`
-	RootURL                        string             `json:"rootURL"`
+	ExtensionParameters            string             `json:"extensionParameters,omitempty"`
+	ExtensionParametersKeyVaultRef *KeyvaultSecretRef `json:"parametersKeyvaultSecretRef,omitempty"`
+	RootURL                        string             `json:"rootURL,omitempty"`
 	// This is only needed for preprovision extensions and it needs to be a bash script
-	Script   string `json:"script"`
-	URLQuery string `json:"urlQuery"`
+	Script   string `json:"script,omitempty"`
+	URLQuery string `json:"urlQuery,omitempty"`
 }
 
 // Extension represents an extension definition in the master or agentPoolProfile

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -336,6 +336,20 @@ func (a *Properties) Validate() error {
 		}
 	}
 
+	for _, extension := range a.ExtensionProfiles {
+		if extension.ExtensionParametersKeyVaultRef != nil {
+			if e := validate.Var(extension.ExtensionParametersKeyVaultRef.VaultID, "required"); e != nil {
+				return fmt.Errorf("the Keyvault ID must be specified for Extension %s", extension.Name)
+			}
+			if e := validate.Var(extension.ExtensionParametersKeyVaultRef.SecretName, "required"); e != nil {
+				return fmt.Errorf("the Keyvault Secret must be specified for Extension %s", extension.Name)
+			}
+			if !keyvaultIDRegex.MatchString(extension.ExtensionParametersKeyVaultRef.VaultID) {
+				return fmt.Errorf("Extension %s's keyvault secret reference is of incorrect format", extension.Name)
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This causes extension parameters  to be put in into the template as a secure string parameter as well allowing them to be passed in using a keyvault ref. This allows makes it a better way to handle the secrets that will often be passed this way when an extension like the k8s oms extension is used.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Adding ability to pass extension parameters in through key vault
Removing extension loop index capability in extension parameters as it wouldn't work in key vault and can easily be parsed from the host name.
```
