### PR TITLE
Display output directory in generate message

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -126,7 +127,7 @@ func (gc *generateCmd) validate(cmd *cobra.Command, args []string) {
 }
 
 func (gc *generateCmd) run() error {
-	log.Infoln("Generating assets...")
+	log.Infoln(fmt.Sprintf("Generating assets into %s...", gc.outputDirectory))
 
 	ctx := acsengine.Context{
 		Translator: &i18n.Translator{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Displays the output directory in the output of `acs-engine generate` - this helps new users to more easily locate the generated ARM templates.

**Which issue this PR fixes**: fixes #1294

**Special notes for your reviewer**: None

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
