### PR TITLE
use overlay2 docker graph driver in k8s

### DIFF
--- a/parts/kubernetesagentcustomdata.yml
+++ b/parts/kubernetesagentcustomdata.yml
@@ -14,7 +14,7 @@ write_files:
   content: |
     [Service]
     ExecStart=
-    ExecStart=/usr/bin/docker daemon -H fd:// --storage-driver=overlay --bip={{WrapAsVariable "dockerBridgeCidr"}}
+    ExecStart=/usr/bin/docker daemon -H fd:// --storage-driver=overlay2 --bip={{WrapAsVariable "dockerBridgeCidr"}}
 
 - path: "/etc/docker/daemon.json"
   permissions: "0644"
@@ -147,6 +147,18 @@ write_files:
   content: !!binary |
     {{WrapAsVariable "provisionScript"}}
 
+- path: "/opt/azure/containers/useoverlay2.sh"
+  permissions: "0744"
+  owner: "root"
+  content: |
+    #!/bin/bash
+    # Use overlay2 for docker
+    set -x
+    if [ -f /etc/systemd/system/docker.service.d/exec_start.conf ]
+    then
+        sed -i "s/overlay /overlay2 /" /etc/systemd/system/docker.service.d/exec_start.conf
+    fi
+
 runcmd: 
 - apt-mark hold walinuxagent{{GetKubernetesAgentPreprovisionYaml .}}
 - apt-get update
@@ -161,6 +173,7 @@ runcmd:
 - apt-get update
 - apt-get install -y ebtables
 - apt-get install -y docker-engine
+- /opt/azure/containers/useoverlay2.sh
 - systemctl restart docker
 - mkdir -p /etc/kubernetes/manifests
 - usermod -aG docker {{WrapAsVariable "username"}}

--- a/parts/kubernetesagentcustomdata.yml
+++ b/parts/kubernetesagentcustomdata.yml
@@ -147,18 +147,6 @@ write_files:
   content: !!binary |
     {{WrapAsVariable "provisionScript"}}
 
-- path: "/opt/azure/containers/useoverlay2.sh"
-  permissions: "0744"
-  owner: "root"
-  content: |
-    #!/bin/bash
-    # Use overlay2 for docker
-    set -x
-    if [ -f /etc/systemd/system/docker.service.d/exec_start.conf ]
-    then
-        sed -i "s/overlay /overlay2 /" /etc/systemd/system/docker.service.d/exec_start.conf
-    fi
-
 runcmd: 
 - apt-mark hold walinuxagent{{GetKubernetesAgentPreprovisionYaml .}}
 - apt-get update
@@ -173,7 +161,6 @@ runcmd:
 - apt-get update
 - apt-get install -y ebtables
 - apt-get install -y docker-engine
-- /opt/azure/containers/useoverlay2.sh
 - systemctl restart docker
 - mkdir -p /etc/kubernetes/manifests
 - usermod -aG docker {{WrapAsVariable "username"}}

--- a/parts/kubernetesmastercustomdata.yml
+++ b/parts/kubernetesmastercustomdata.yml
@@ -315,18 +315,6 @@ write_files:
     fi
     mount $MOUNTPOINT
 
-- path: "/opt/azure/containers/useoverlay2.sh"
-  permissions: "0744"
-  owner: "root"
-  content: |
-    #!/bin/bash
-    # Use overlay2 for docker
-    set -x
-    if [ -f /etc/systemd/system/docker.service.d/exec_start.conf ]
-    then
-        sed -i "s/overlay /overlay2 /" /etc/systemd/system/docker.service.d/exec_start.conf
-    fi
-
 runcmd: 
 - apt-mark hold walinuxagent {{GetKubernetesMasterPreprovisionYaml}}
 - /bin/echo DAEMON_ARGS=--name "{{WrapAsVerbatim "variables('masterVMNames')[copyIndex(variables('masterOffset'))]"}}" --initial-advertise-peer-urls "{{WrapAsVerbatim "variables('masterEtcdPeerURLs')[copyIndex(variables('masterOffset'))]"}}" --listen-peer-urls "{{WrapAsVerbatim "variables('masterEtcdPeerURLs')[copyIndex(variables('masterOffset'))]"}}" --advertise-client-urls "{{WrapAsVerbatim "variables('masterEtcdClientURLs')[copyIndex(variables('masterOffset'))]"}}" --listen-client-urls "{{WrapAsVerbatim "concat(variables('masterEtcdClientURLs')[copyIndex(variables('masterOffset'))], ',http://127.0.0.1:', variables('masterEtcdClientPort'))"}}" --initial-cluster-token "k8s-etcd-cluster" --initial-cluster "{{WrapAsVerbatim "variables('masterEtcdClusterStates')[div(variables('masterCount'), 2)]"}} --data-dir "/var/lib/etcddisk"" --initial-cluster-state "new" | tee -a /etc/default/etcd
@@ -346,7 +334,6 @@ runcmd:
 - retrycmd_if_failure apt-get update
 - retrycmd_if_failure apt-get install -y ebtables
 - retrycmd_if_failure apt-get install -y docker-engine
-- /opt/azure/containers/useoverlay2.sh
 - systemctl restart docker
 - mkdir -p /etc/kubernetes/manifests
 - usermod -aG docker {{WrapAsVariable "username"}}

--- a/parts/kubernetesmastercustomdata.yml
+++ b/parts/kubernetesmastercustomdata.yml
@@ -19,7 +19,7 @@ write_files:
   content: |
     [Service]
     ExecStart=
-    ExecStart=/usr/bin/docker daemon -H fd:// --storage-driver=overlay --bip={{WrapAsVariable "dockerBridgeCidr"}}
+    ExecStart=/usr/bin/docker daemon -H fd:// --storage-driver=overlay2 --bip={{WrapAsVariable "dockerBridgeCidr"}}
 
 - path: "/etc/docker/daemon.json"
   permissions: "0644"
@@ -315,6 +315,18 @@ write_files:
     fi
     mount $MOUNTPOINT
 
+- path: "/opt/azure/containers/useoverlay2.sh"
+  permissions: "0744"
+  owner: "root"
+  content: |
+    #!/bin/bash
+    # Use overlay2 for docker
+    set -x
+    if [ -f /etc/systemd/system/docker.service.d/exec_start.conf ]
+    then
+        sed -i "s/overlay /overlay2 /" /etc/systemd/system/docker.service.d/exec_start.conf
+    fi
+
 runcmd: 
 - apt-mark hold walinuxagent {{GetKubernetesMasterPreprovisionYaml}}
 - /bin/echo DAEMON_ARGS=--name "{{WrapAsVerbatim "variables('masterVMNames')[copyIndex(variables('masterOffset'))]"}}" --initial-advertise-peer-urls "{{WrapAsVerbatim "variables('masterEtcdPeerURLs')[copyIndex(variables('masterOffset'))]"}}" --listen-peer-urls "{{WrapAsVerbatim "variables('masterEtcdPeerURLs')[copyIndex(variables('masterOffset'))]"}}" --advertise-client-urls "{{WrapAsVerbatim "variables('masterEtcdClientURLs')[copyIndex(variables('masterOffset'))]"}}" --listen-client-urls "{{WrapAsVerbatim "concat(variables('masterEtcdClientURLs')[copyIndex(variables('masterOffset'))], ',http://127.0.0.1:', variables('masterEtcdClientPort'))"}}" --initial-cluster-token "k8s-etcd-cluster" --initial-cluster "{{WrapAsVerbatim "variables('masterEtcdClusterStates')[div(variables('masterCount'), 2)]"}} --data-dir "/var/lib/etcddisk"" --initial-cluster-state "new" | tee -a /etc/default/etcd
@@ -334,6 +346,7 @@ runcmd:
 - retrycmd_if_failure apt-get update
 - retrycmd_if_failure apt-get install -y ebtables
 - retrycmd_if_failure apt-get install -y docker-engine
+- /opt/azure/containers/useoverlay2.sh
 - systemctl restart docker
 - mkdir -p /etc/kubernetes/manifests
 - usermod -aG docker {{WrapAsVariable "username"}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Uses overlay2 as the docker graph driver instead of overlay.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #555

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
use overlay2 docker graph driver in k8s clusters (instead of overlay)
```
