### PR TITLE
Option to specify agent Windows OS image version

### DIFF
--- a/examples/windows/dcos-win-version.json
+++ b/examples/windows/dcos-win-version.json
@@ -1,0 +1,44 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "DCOS"
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "dcos-mstr",
+      "vmSize": "Standard_D2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "win2",
+        "count": 2,
+        "vmSize": "Standard_D2_v2",
+        "availabilityProfile": "AvailabilitySet",
+        "osType": "Windows",
+        "dnsPrefix": "agnt",
+        "ports": [
+             80,
+             443,
+             8080,
+             3389
+          ]
+      }
+    ],
+    "windowsProfile": {
+      "adminUsername": "azureuser",
+      "adminPassword": "replacepassword1234$",
+      "imageVersion": "2016.127.20170411"
+    },
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    }
+  }
+}

--- a/examples/windows/kubernetes-windows-version.json
+++ b/examples/windows/kubernetes-windows-version.json
@@ -1,0 +1,41 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes"
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "windowspool2",
+        "count": 2,
+        "vmSize": "Standard_D2",
+        "availabilityProfile": "AvailabilitySet",
+        "osType": "Windows"
+      }
+    ],
+    "windowsProfile": {
+      "adminUsername": "azureuser",
+      "adminPassword": "replacepassword1234$",
+      "imageVersion": "2016.127.20170510"
+    },
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    }
+  }
+}

--- a/parts/dcosmastervars.t
+++ b/parts/dcosmastervars.t
@@ -32,7 +32,7 @@
     "agentWindowsPublisher": "MicrosoftWindowsServer",
     "agentWindowsOffer": "WindowsServer",
     "agentWindowsSku": "2016-Datacenter-with-Containers",
-    "agentWindowsVersion": "latest",
+    "agentWindowsVersion": "[parameters('agentWindowsVersion')]",
     "dcosWindowsBootstrapURL" : "[parameters('dcosWindowsBootstrapURL')]",
     "windowsCustomScriptSuffix": " $inputFile = '%SYSTEMDRIVE%\\AzureData\\CustomData.bin' ; $outputFile = '%SYSTEMDRIVE%\\AzureData\\dcosWindowsProvision.ps1' ; $inputStream = New-Object System.IO.FileStream $inputFile, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read) ; $sr = New-Object System.IO.StreamReader(New-Object System.IO.Compression.GZipStream($inputStream, [System.IO.Compression.CompressionMode]::Decompress)) ; $sr.ReadToEnd() | Out-File($outputFile) ; Invoke-Expression('{0} {1}' -f $outputFile, $arguments) ; ",
     "windowsMasterCustomScriptArguments": "[concat('$arguments = ', variables('singleQuote'),'-MasterCount ', variables('masterCount'), ' -firstMasterIP ', parameters('firstConsecutiveStaticIP'), variables('singleQuote'), ' ; ')]",

--- a/parts/kubernetesmastervars.t
+++ b/parts/kubernetesmastervars.t
@@ -264,7 +264,7 @@
     "agentWindowsPublisher": "MicrosoftWindowsServer",
     "agentWindowsOffer": "WindowsServer",
     "agentWindowsSku": "2016-Datacenter-with-Containers",
-    "agentWindowsVersion": "latest",
+    "agentWindowsVersion": "[parameters('agentWindowsVersion')]",
     "singleQuote": "'",
     "windowsCustomScriptSuffix": " $inputFile = '%SYSTEMDRIVE%\\AzureData\\CustomData.bin' ; $outputFile = '%SYSTEMDRIVE%\\AzureData\\CustomDataSetupScript.ps1' ; Copy-Item $inputFile $outputFile ; Invoke-Expression('{0} {1}' -f $outputFile, $arguments) ; "
 {{end}}

--- a/parts/swarmmastervars.t
+++ b/parts/swarmmastervars.t
@@ -139,7 +139,7 @@
     "agentWindowsPublisher": "MicrosoftWindowsServer",
     "agentWindowsOffer": "WindowsServer",
     "agentWindowsSku": "2016-Datacenter-with-Containers",
-    "agentWindowsVersion": "latest",
+    "agentWindowsVersion": "[parameters('agentWindowsVersion')]",
     "singleQuote": "'",
     "windowsCustomScriptArguments": "[concat('$arguments = ', variables('singleQuote'),'-SwarmMasterIP ', variables('masterFirstAddrPrefix'), variables('masterFirstAddrOctet4'), variables('singleQuote'), ' ; ')]",
     "windowsCustomScriptSuffix": " $inputFile = '%SYSTEMDRIVE%\\AzureData\\CustomData.bin' ; $outputFile = '%SYSTEMDRIVE%\\AzureData\\CustomDataSetupScript.ps1' ; $inputStream = New-Object System.IO.FileStream $inputFile, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read) ; $sr = New-Object System.IO.StreamReader(New-Object System.IO.Compression.GZipStream($inputStream, [System.IO.Compression.CompressionMode]::Decompress)) ; $sr.ReadToEnd() | Out-File($outputFile) ; Invoke-Expression('{0} {1}' -f $outputFile, $arguments) ; ",

--- a/parts/swarmwinagentresourcesvmas.t
+++ b/parts/swarmwinagentresourcesvmas.t
@@ -216,7 +216,7 @@
             "publisher": "[variables('agentWindowsPublisher')]",
             "offer": "[variables('agentWindowsOffer')]",
             "sku": "[variables('agentWindowsSku')]",
-            "version": "latest"
+            "version": "[variables('agentWindowsVersion')]"
           }
           ,"osDisk": {
             "caching": "ReadOnly"

--- a/parts/swarmwinagentresourcesvmss.t
+++ b/parts/swarmwinagentresourcesvmss.t
@@ -161,7 +161,7 @@
               "publisher": "[variables('agentWindowsPublisher')]",
               "offer": "[variables('agentWindowsOffer')]",
               "sku": "[variables('agentWindowsSku')]",
-              "version": "latest"
+              "version": "[variables('agentWindowsVersion')]"
             }, 
             "osDisk": {
               "caching": "ReadWrite"

--- a/parts/windowsparams.t
+++ b/parts/windowsparams.t
@@ -9,4 +9,11 @@
       "metadata": {
         "description": "Password for the Windows Swarm Agent Virtual Machines."
       }
+    },
+    "agentWindowsVersion": {
+      "defaultValue": "latest",
+      "metadata": {
+        "description": "Version of the Windows Server 2016 OS image to use for the agent virtual machines."
+      },
+      "type": "string"
     }

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -600,6 +600,9 @@ func getParameters(cs *api.ContainerService, isClassicMode bool) (paramsMap, err
 	if properties.HasWindows() {
 		addValue(parametersMap, "windowsAdminUsername", properties.WindowsProfile.AdminUsername)
 		addSecret(parametersMap, "windowsAdminPassword", properties.WindowsProfile.AdminPassword, false)
+		if properties.WindowsProfile.ImageVersion != "" {
+			addValue(parametersMap, "agentWindowsVersion", properties.WindowsProfile.ImageVersion)
+		}
 		if properties.OrchestratorProfile.OrchestratorType == api.Kubernetes {
 			KubernetesRelease := properties.OrchestratorProfile.OrchestratorRelease
 			addValue(parametersMap, "kubeBinariesSASURL", cloudSpecConfig.KubernetesSpecConfig.KubeBinariesSASURLBase+KubeConfigs[KubernetesRelease]["windowszip"])

--- a/pkg/api/agentPoolOnlyApi/vlabs/types.go
+++ b/pkg/api/agentPoolOnlyApi/vlabs/types.go
@@ -95,6 +95,7 @@ type PublicKey struct {
 type WindowsProfile struct {
 	AdminUsername string `json:"adminUsername,omitempty" validate:"required"`
 	AdminPassword string `json:"adminPassword,omitempty" validate:"required"`
+	ImageVersion  string `json:"imageVersion,omitempty"`
 }
 
 // ProvisioningState represents the current state of container service resource.

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -573,6 +573,7 @@ func convertWindowsProfileToV20170701(api *WindowsProfile, v20170701Profile *v20
 func convertWindowsProfileToVLabs(api *WindowsProfile, vlabsProfile *vlabs.WindowsProfile) {
 	vlabsProfile.AdminUsername = api.AdminUsername
 	vlabsProfile.AdminPassword = api.AdminPassword
+	vlabsProfile.ImageVersion = api.ImageVersion
 	vlabsProfile.Secrets = []vlabs.KeyVaultSecrets{}
 	for _, s := range api.Secrets {
 		secret := &vlabs.KeyVaultSecrets{}

--- a/pkg/api/convertertoagentpoolonlyapi.go
+++ b/pkg/api/convertertoagentpoolonlyapi.go
@@ -174,6 +174,7 @@ func convertV20170831AgentPoolOnlyWindowsProfile(obj *v20170831.WindowsProfile) 
 func convertVLabsAgentPoolOnlyWindowsProfile(vlabs *vlabs.WindowsProfile, api *WindowsProfile) {
 	api.AdminUsername = vlabs.AdminUsername
 	api.AdminPassword = vlabs.AdminPassword
+	api.ImageVersion = vlabs.ImageVersion
 	// api.Secrets = []KeyVaultSecrets{}
 	// for _, s := range vlabs.Secrets {
 	// 	secret := &KeyVaultSecrets{}

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -498,6 +498,7 @@ func convertV20170701WindowsProfile(v20170701 *v20170701.WindowsProfile, api *Wi
 func convertVLabsWindowsProfile(vlabs *vlabs.WindowsProfile, api *WindowsProfile) {
 	api.AdminUsername = vlabs.AdminUsername
 	api.AdminPassword = vlabs.AdminPassword
+	api.ImageVersion = vlabs.ImageVersion
 	api.Secrets = []KeyVaultSecrets{}
 	for _, s := range vlabs.Secrets {
 		secret := &KeyVaultSecrets{}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -110,6 +110,7 @@ type PublicKey struct {
 type WindowsProfile struct {
 	AdminUsername string            `json:"adminUsername"`
 	AdminPassword string            `json:"adminPassword"`
+	ImageVersion  string            `json:"imageVersion"`
 	Secrets       []KeyVaultSecrets `json:"secrets,omitempty"`
 }
 

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -114,6 +114,7 @@ type PublicKey struct {
 type WindowsProfile struct {
 	AdminUsername string            `json:"adminUsername,omitempty"`
 	AdminPassword string            `json:"adminPassword,omitempty"`
+	ImageVersion  string            `json:"imageVersion,omitempty"`
 	Secrets       []KeyVaultSecrets `json:"secrets,omitempty"`
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: The ARM template generated by acs-engine always specifies "latest" as the agentWindowsVersion.  We have a user request to be able to specify a specific version of the WindowsServer-2016-with-Containers OS image when provisioning Windows agents.

**Which issue this PR fixes**: fixes #1383 

**Special notes for your reviewer**:

1. Is this feature desirable?  Most customers should use 'latest' so as to pick up security patches, though it's possible some customers need to lock to a specific version for compliance or validation reasons.

2. Is this the right scope?  I have put it at the global `windowsProfile` level but it could be per-agent-pool (we allow different OSes on different agent pools so why not different OS versions).

3. Is it the right property name in the apimodel?  `imageVersion` might not be specific enough...  (Also, have I put it in the right version?  I added it to vlabs; please let me know if that's not right.)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added new `windowsProfile` option `imageVersion` to control the version of the WindowsServer 2016-Datacenter-with-Containers OS disk image for agent VMs.
```