### PR TITLE
remove obsolete swarm windows test from e2e

### DIFF
--- a/test/e2e/swarm-deployments.json
+++ b/test/e2e/swarm-deployments.json
@@ -1,7 +1,7 @@
 {
 	"deployments": [
 		{
-			"cluster_definition": "disks-managed/swarm-preAttachedDisks-vmas-windows.json",
+			"cluster_definition": "swarm.json",
 			"location": "westus2"
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: replaces windows swarm test (non-existent) with vanilla linux swarm test

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
