### PR TITLE
update dns to support dnsmasq-nanny and configmap

### DIFF
--- a/parts/kubernetesmasteraddons-kube-dns-deployment.yaml
+++ b/parts/kubernetesmasteraddons-kube-dns-deployment.yaml
@@ -113,6 +113,12 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - args:
+        - "-v=2"
+        - "-logtostderr"
+        - "-configDir=/kube-dns-config"
+        - "-restartDnsmasq=true"
+        - "--"
+        - "-k"
         - "--cache-size=1000"
         - "--no-resolv"
         - "--server=127.0.0.1#10053"
@@ -128,6 +134,9 @@ spec:
         - containerPort: 53
           name: dns-tcp
           protocol: TCP
+        volumeMounts:
+        - mountPath: /kube-dns-config
+          name: kube-dns-config
       - args:
         - "--cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null"
         - "--url=/healthz-dnsmasq"

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -100,7 +100,7 @@ var KubeConfigs = map[string]map[string]string{
 		"heapster":        "heapster-amd64:v1.4.2",
 		"dns":             "k8s-dns-kube-dns-amd64:1.14.4",
 		"addonmanager":    "kube-addon-manager-amd64:v6.4-beta.2",
-		"dnsmasq":         "k8s-dns-dnsmasq-amd64:1.14.4",
+		"dnsmasq":         "k8s-dns-dnsmasq-nanny-amd64:1.14.4",
 		"pause":           "pause-amd64:3.0",
 		"tiller":          DefaultTillerImage,
 		"windowszip":      "v1.7.5-3intwinnat.zip",

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -125,7 +125,7 @@ var KubeConfigs = map[string]map[string]string{
 		"heapster":        "heapster-amd64:v1.3.0",
 		"dns":             "k8s-dns-kube-dns-amd64:1.14.4",
 		"addonmanager":    "kube-addon-manager-amd64:v6.4-beta.2",
-		"dnsmasq":         "k8s-dns-dnsmasq-amd64:1.13.0",
+		"dnsmasq":         "k8s-dns-dnsmasq-nanny-amd64:1.14.4",
 		"pause":           "pause-amd64:3.0",
 		"tiller":          DefaultTillerImage,
 		"windowszip":      "v1.6.9-3intwinnat.zip",


### PR DESCRIPTION
Enables this to work -- http://blog.kubernetes.io/2017/04/configuring-private-dns-zones-upstream-nameservers-kubernetes.html