### PR TITLE
Don't present agent-pool-only validation results for full-cluster apimodels

### DIFF
--- a/pkg/api/convertertoagentpoolonlyapi.go
+++ b/pkg/api/convertertoagentpoolonlyapi.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"encoding/json"
+
 	"github.com/Azure/acs-engine/pkg/api/agentPoolOnlyApi/v20170831"
 	"github.com/Azure/acs-engine/pkg/api/agentPoolOnlyApi/vlabs"
 )
@@ -263,4 +265,24 @@ func convertVLabsAgentPoolOnlyCertificateProfile(vlabs *vlabs.CertificateProfile
 	api.ClientPrivateKey = vlabs.ClientPrivateKey
 	api.KubeConfigCertificate = vlabs.KubeConfigCertificate
 	api.KubeConfigPrivateKey = vlabs.KubeConfigPrivateKey
+}
+
+func isAgentPoolOnlyClusterJSON(contents []byte) bool {
+	properties, propertiesPresent := propertiesAsMap(contents)
+	if !propertiesPresent {
+		return false
+	}
+	_, masterProfilePresent := properties["masterProfile"]
+	return !masterProfilePresent
+}
+
+func propertiesAsMap(contents []byte) (map[string]interface{}, bool) {
+	var raw interface{}
+	json.Unmarshal(contents, &raw)
+	jsonMap := raw.(map[string]interface{})
+	properties, propertiesPresent := jsonMap["properties"]
+	if !propertiesPresent {
+		return nil, false
+	}
+	return properties.(map[string]interface{}), true
 }

--- a/pkg/api/convertertoagentpoolonlyapi_test.go
+++ b/pkg/api/convertertoagentpoolonlyapi_test.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestIfMasterProfileIsMissingThenApiModelIsAgentPoolOnly(t *testing.T) {
+	json := `
+	{
+		"apiVersion": "vlabs",
+		"properties": {
+			"dnsPrefix": "dp",
+			"fqdn": "fqdn",
+			"agentPoolProfiles": [],
+			"servicePrincipalProfile": {}
+		}
+	}
+	`
+	isAgentPool := isAgentPoolOnlyClusterJSON([]byte(json))
+	if !isAgentPool {
+		t.Error("Expected JSON without masterProfile to be interpreted as agent pool, but it was not")
+	}
+}
+
+func TestIfMasterProfileIsPresentThenApiModelIsFullCluster(t *testing.T) {
+	json := `
+	{
+		"apiVersion": "vlabs",
+		"properties": {
+			"orchestratorProfile": {},
+			"masterProfile": {},
+			"agentPoolProfiles": [],
+			"servicePrincipalProfile": {}
+		}
+	}
+	`
+	isAgentPool := isAgentPoolOnlyClusterJSON([]byte(json))
+	if isAgentPool {
+		t.Error("Expected JSON with masterProfile not to be interpreted as agent pool, but it was")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: If a user creates an apimodel for an ACS cluster, but omits a required field such as the service principal client ID, then `acs-engine generate` produces a spurious error message that the required DNS prefix is missing.  This occurs because if an apimodel fails validation then it is retried as an agent-pool-only apimodel, and if it fails validation against _that_ schema, then it is always the agent-pool-only validation error that is returned.  Since the APO schema has `dnsPrefix` as its first required field, and a full cluster has `dnsPrefix` under `masterProfile` rather than at the top level, this validation fails on `dnsPrefix` and so that is the error that gets displayed.

(Alternatively, if the user has specified a stable apiVersion instead of vlabs, they get a spurious error that they are using an unrecognised apiVersion, because the full cluster API versions are not valid for APO.)

An ideal solution to this would be to use different API namespaces, or to add a `specType` field or something like that, so that the user could clearly indicate the intent of the apimodel JSON.  This would be a breaking change for vlabs though.  Therefore, this PR takes a heuristic approach: if the apimodel validates as a full cluster or APO, we use that, but if it validates as _neither_, then we try to infer intent based first on the API version and then on which properties are present in the apimodel JSON.  Whichever intent we infer, we report only the error from the appropriate validation.

**Which issue this PR fixes**: fixes #1427 

**Special notes for your reviewer**: None

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```