### PR TITLE
Add RHEL support for Swarm Mode

### DIFF
--- a/examples/swarmmode-rhel.json
+++ b/examples/swarmmode-rhel.json
@@ -1,0 +1,38 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "SwarmMode"
+    },
+    "masterProfile": {
+      "count": 3,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v2",
+      "distro": "rhel"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpublic",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "dnsPrefix": "",
+        "ports": [
+          80,
+          443,
+          8080
+        ],
+        "distro": "rhel"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    }
+  }
+}

--- a/parts/configure-swarmmode-cluster.sh
+++ b/parts/configure-swarmmode-cluster.sh
@@ -33,6 +33,7 @@ DOCKERCOMPOSEDOWNLOADURL=${10}
 VMNAME=`hostname`
 VMNUMBER=`echo $VMNAME | sed 's/.*[^0-9]\([0-9]\+\)*$/\1/'`
 VMPREFIX=`echo $VMNAME | sed 's/\(.*[^0-9]\)*[0-9]\+$/\1/'`
+OS="$(. /etc/os-release; echo $ID)"
 
 echo "Master Count: $MASTERCOUNT"
 echo "Master Prefix: $MASTERPREFIX"
@@ -41,10 +42,31 @@ echo "vmname: $VMNAME"
 echo "VMNUMBER: $VMNUMBER, VMPREFIX: $VMPREFIX"
 echo "BASESUBNET: $BASESUBNET"
 echo "AZUREUSER: $AZUREUSER"
+echo "OS ID: $OS"
 
 ###################
 # Common Functions
 ###################
+
+isUbuntu()
+{
+  if [ "$OS" == "ubuntu" ]
+  then
+    return 0
+  else
+    return 1
+  fi
+}
+
+isRHEL()
+{
+  if [ "$OS" == "rhel" ]
+  then
+    return 0
+  else
+    return 1
+  fi
+}
 
 ensureAzureNetwork()
 {
@@ -150,7 +172,7 @@ fi
 
 echo "Installing and configuring Docker"
 
-installDocker()
+installDockerUbuntu()
 {
   for i in {1..10}; do
     apt-get install -y apt-transport-https ca-certificates curl software-properties-common
@@ -168,6 +190,36 @@ installDocker()
     sleep 10
   done
 }
+
+installDockerRHEL()
+{
+  for i in {1..10}; do
+    yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    yum makecache fast
+    yum -y install docker-ce
+    if [ $? -eq 0 ]
+    then
+      systemctl enable docker
+      systemctl start docker
+      echo "Docker installed successfully"
+      break
+    fi
+    sleep 10
+  done
+}
+
+installDocker()
+{
+  if isUbuntu ; then
+    installDockerUbuntu
+  elif isRHEL ; then
+    installDockerRHEL
+  else
+    echo "OS not supported, aborting install"
+    exit 5
+  fi
+}
+
 time installDocker
 
 sudo usermod -aG docker $AZUREUSER
@@ -205,6 +257,14 @@ installDockerCompose()
 time installDockerCompose
 chmod +x /usr/local/bin/docker-compose
 
+if ismaster && isRHEL ; then
+  echo "Opening Docker ports"
+  firewall-cmd --add-port=2375/tcp --permanent
+  firewall-cmd --add-port=2377/tcp --permanent
+  firewall-cmd --reload
+fi
+
+echo "Restarting Docker"
 sudo systemctl daemon-reload
 sudo service docker restart
 

--- a/parts/swarmagentresourcesclassic.t
+++ b/parts/swarmagentresourcesclassic.t
@@ -128,7 +128,9 @@
             "adminUsername": "[variables('adminUsername')]", 
             "computerNamePrefix": "[variables('{{.Name}}VMNamePrefix')]", 
 {{if IsSwarmMode}}
+  {{if not .IsRHEL}}
             {{GetAgentSwarmModeCustomData .}} 
+  {{end}}
 {{else}}
             {{GetAgentSwarmCustomData .}} 
 {{end}}
@@ -170,6 +172,26 @@
 {{end}}
             }
           }
+{{if .IsRHEL}}
+          ,"extensionProfile": {
+            "extensions": [
+              {
+                "name": "configure{{.Name}}",
+                "properties": {
+                  "publisher": "Microsoft.Azure.Extensions",
+                  "settings": {
+                    "commandToExecute": "[variables('agentCustomScript')]",
+                    "fileUris": [
+                      "[concat('{{ GetConfigurationScriptRootURL }}', variables('configureClusterScriptFile'))]"
+                    ]
+                  },
+                  "type": "CustomScript",
+                  "typeHandlerVersion": "2.0"
+                }
+              }
+            ]
+          }
+{{end}}
         }
       }, 
       "sku": {

--- a/parts/swarmagentresourcesvmas.t
+++ b/parts/swarmagentresourcesvmas.t
@@ -182,7 +182,9 @@
           "adminUsername": "[variables('adminUsername')]",
           "computername": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
 {{if IsSwarmMode}}
+  {{if not .IsRHEL}}
             {{GetAgentSwarmModeCustomData .}} 
+  {{end}}
 {{else}}
             {{GetAgentSwarmCustomData .}} 
 {{end}}
@@ -205,10 +207,10 @@
         "storageProfile": {
           {{GetDataDisks .}}
           "imageReference": {
-            "offer": "[variables('osImageOffer')]",
-            "publisher": "[variables('osImagePublisher')]",
-            "sku": "[variables('osImageSKU')]",
-            "version": "[variables('osImageVersion')]"
+            "offer": "[variables('{{.Name}}OSImageOffer')]",
+            "publisher": "[variables('{{.Name}}OSImagePublisher')]",
+            "sku": "[variables('{{.Name}}OSImageSKU')]",
+            "version": "[variables('{{.Name}}OSImageVersion')]"
           }
 
           ,"osDisk": {
@@ -228,3 +230,29 @@
       },
       "type": "Microsoft.Compute/virtualMachines"
     }
+{{if .IsRHEL}}
+    ,{
+      "apiVersion": "[variables('apiVersionDefault')]",
+      "copy": {
+        "count": "[variables('{{.Name}}Count')]",
+        "name": "vmLoopNode"
+      },
+      "dependsOn": [
+          "[concat('Microsoft.Compute/virtualMachines/', concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset'))))]"
+      ],
+      "location": "[variables('location')]",
+      "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '/configureagent')]",
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "settings": {
+          "commandToExecute": "[variables('agentCustomScript')]",
+          "fileUris": [
+            "[concat('{{ GetConfigurationScriptRootURL }}', variables('configureClusterScriptFile'))]"
+          ]
+        },
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0"
+      },
+      "type": "Microsoft.Compute/virtualMachines/extensions"
+    }
+{{end}}

--- a/parts/swarmagentresourcesvmss.t
+++ b/parts/swarmagentresourcesvmss.t
@@ -127,7 +127,9 @@
             "adminUsername": "[variables('adminUsername')]",
             "computerNamePrefix": "[variables('{{.Name}}VMNamePrefix')]",
 {{if IsSwarmMode}}
+  {{if not .IsRHEL}}
             {{GetAgentSwarmModeCustomData .}} 
+  {{end}}
 {{else}}
             {{GetAgentSwarmCustomData .}} 
 {{end}}
@@ -149,10 +151,10 @@
           },
           "storageProfile": {
             "imageReference": {
-              "offer": "[variables('osImageOffer')]",
-              "publisher": "[variables('osImagePublisher')]",
-              "sku": "[variables('osImageSKU')]",
-              "version": "[variables('osImageVersion')]"
+              "offer": "[variables('{{.Name}}OSImageOffer')]",
+              "publisher": "[variables('{{.Name}}OSImagePublisher')]",
+              "sku": "[variables('{{.Name}}OSImageSKU')]",
+              "version": "[variables('{{.Name}}OSImageVersion')]"
             },
             {{GetDataDisks .}}
             "osDisk": {
@@ -173,6 +175,26 @@
 {{end}}
             }
           }
+{{if .IsRHEL}}
+          ,"extensionProfile": {
+            "extensions": [
+              {
+                "name": "configure{{.Name}}",
+                "properties": {
+                  "publisher": "Microsoft.Azure.Extensions",
+                  "settings": {
+                    "commandToExecute": "[variables('agentCustomScript')]",
+                    "fileUris": [
+                      "[concat('{{ GetConfigurationScriptRootURL }}', variables('configureClusterScriptFile'))]"
+                    ]
+                  },
+                  "type": "CustomScript",
+                  "typeHandlerVersion": "2.0"
+                }
+              }
+            ]
+          }
+{{end}}
         }
       },
       "sku": {

--- a/parts/swarmagentvars.t
+++ b/parts/swarmagentvars.t
@@ -2,10 +2,17 @@
     "{{.Name}}RunCmd": "[concat('runcmd:\n {{GetSwarmAgentPreprovisionExtensionCommands .}} \n-  [ /bin/bash, /opt/azure/containers/install-cluster.sh ]\n\n')]", 
     "{{.Name}}RunCmdFile": "[concat(' -  content: |\n        #!/bin/bash\n        ','sudo mkdir -p /var/log/azure\n        ',variables('agentCustomScript'),'\n    path: /opt/azure/containers/install-cluster.sh\n    permissions: \"0744\"\n')]",
 {{end}}
+{{if IsSwarmMode }}
     "{{.Name}}OSImageOffer": {{GetAgentOSImageOffer .}}, 
     "{{.Name}}OSImagePublisher": {{GetAgentOSImagePublisher .}}, 
     "{{.Name}}OSImageSKU": {{GetAgentOSImageSKU .}}, 
     "{{.Name}}OSImageVersion": {{GetAgentOSImageVersion .}},
+{{else}}
+    "{{.Name}}OSImageOffer": "[variables('osImageOffer')]",
+    "{{.Name}}OSImagePublisher": "[variables('osImagePublisher')]",
+    "{{.Name}}OSImageSKU": "[variables('osImageSKU')]",
+    "{{.Name}}OSImageVersion": "[variables('osImageVersion')]",
+{{end}}
     "{{.Name}}Count": "[parameters('{{.Name}}Count')]", 
     "{{.Name}}VMNamePrefix": "[concat(variables('orchestratorName'), '-{{.Name}}-', variables('nameSuffix'))]", 
     "{{.Name}}VMSize": "[parameters('{{.Name}}VMSize')]", 

--- a/parts/swarmagentvars.t
+++ b/parts/swarmagentvars.t
@@ -1,5 +1,11 @@
+{{if not .IsRHEL}}
     "{{.Name}}RunCmd": "[concat('runcmd:\n {{GetSwarmAgentPreprovisionExtensionCommands .}} \n-  [ /bin/bash, /opt/azure/containers/install-cluster.sh ]\n\n')]", 
     "{{.Name}}RunCmdFile": "[concat(' -  content: |\n        #!/bin/bash\n        ','sudo mkdir -p /var/log/azure\n        ',variables('agentCustomScript'),'\n    path: /opt/azure/containers/install-cluster.sh\n    permissions: \"0744\"\n')]",
+{{end}}
+    "{{.Name}}OSImageOffer": {{GetAgentOSImageOffer .}}, 
+    "{{.Name}}OSImagePublisher": {{GetAgentOSImagePublisher .}}, 
+    "{{.Name}}OSImageSKU": {{GetAgentOSImageSKU .}}, 
+    "{{.Name}}OSImageVersion": {{GetAgentOSImageVersion .}},
     "{{.Name}}Count": "[parameters('{{.Name}}Count')]", 
     "{{.Name}}VMNamePrefix": "[concat(variables('orchestratorName'), '-{{.Name}}-', variables('nameSuffix'))]", 
     "{{.Name}}VMSize": "[parameters('{{.Name}}VMSize')]", 

--- a/parts/swarmmastervars.t
+++ b/parts/swarmmastervars.t
@@ -6,7 +6,11 @@
 {{else}}
     "configureClusterScriptFile": "configure-swarm-cluster.sh",
 {{end}}
+{{if .MasterProfile.IsRHEL}}
+    "agentCustomScript": "[concat('/usr/bin/nohup /bin/bash -c \"/bin/bash ',variables('configureClusterScriptFile'), ' ',variables('clusterInstallParameters'),' >> /var/log/azure/cluster-bootstrap.log 2>&1 &\" &')]",
+{{else}}
     "agentCustomScript": "[concat('/usr/bin/nohup /bin/bash -c \"/bin/bash /opt/azure/containers/',variables('configureClusterScriptFile'), ' ',variables('clusterInstallParameters'),' >> /var/log/azure/cluster-bootstrap.log 2>&1 &\" &')]",
+{{end}}
     "agentMaxVMs": 100,
     "clusterInstallParameters": "[concat(variables('orchestratorVersion'), ' ',variables('dockerComposeVersion'), ' ',variables('masterCount'), ' ',variables('masterVMNamePrefix'), ' ',variables('masterFirstAddrOctet4'), ' ',variables('adminUsername'),' ',variables('postInstallScriptURI'),' ',variables('masterFirstAddrPrefix'),' ', parameters('dockerEngineDownloadRepo'), ' ', parameters('dockerComposeDownloadURL'))]",
 {{if .LinuxProfile.HasSecrets}}
@@ -36,7 +40,11 @@
 {{else}}
     "masterCount": {{.MasterProfile.Count}}, 
 {{end}} 
+{{if .MasterProfile.IsRHEL}}
+    "masterCustomScript": "[concat('/bin/bash -c \"/bin/bash ',variables('configureClusterScriptFile'), ' ',variables('clusterInstallParameters'),' >> /var/log/azure/cluster-bootstrap.log 2>&1\"')]", 
+{{else}}
     "masterCustomScript": "[concat('/bin/bash -c \"/bin/bash /opt/azure/containers/',variables('configureClusterScriptFile'), ' ',variables('clusterInstallParameters'),' >> /var/log/azure/cluster-bootstrap.log 2>&1\"')]", 
+{{end}}
     "masterEndpointDNSNamePrefix": "[tolower(parameters('masterEndpointDNSNamePrefix'))]", 
     "masterLbBackendPoolName": "[concat(variables('orchestratorName'), '-master-pool-', variables('nameSuffix'))]", 
     "masterLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('masterLbName'))]", 
@@ -92,15 +100,17 @@
         }
       ]
     ],
-    "osImageOffer": "[parameters('osImageOffer')]", 
-    "osImagePublisher": "[parameters('osImagePublisher')]", 
 {{if .OrchestratorProfile.IsSwarmMode}}
     "orchestratorName": "swarmm", 
-    "osImageSKU": "[parameters('osImageSKU')]", 
-    "osImageVersion": "[parameters('osImageVersion')]",
+    "masterOSImageOffer": {{GetMasterOSImageOffer}}, 
+    "masterOSImagePublisher": {{GetMasterOSImagePublisher}}, 
+    "masterOSImageSKU": {{GetMasterOSImageSKU}}, 
+    "masterOSImageVersion": {{GetMasterOSImageVersion}},
     {{GetSwarmModeVersions}}
 {{else}}
     "orchestratorName": "swarm", 
+    "osImageOffer": "[parameters('osImageOffer')]", 
+    "osImagePublisher": "[parameters('osImagePublisher')]",
     "osImageSKU": "14.04.5-LTS",
     "osImageVersion": "14.04.201706190",
     {{getSwarmVersions}}

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -179,3 +179,8 @@ const (
 	AzureChinaCloudDCOSBootstrapDownloadURL = "https://acsengine.blob.core.chinacloudapi.cn/dcos/%s.bootstrap.tar.xz"
 	//AzureEdgeDCOSWindowsBootstrapDownloadURL
 )
+
+const (
+	//DefaultConfigurationScriptRootURL  Root URL for configuration script (used for script extension on RHEL)
+	DefaultConfigurationScriptRootURL = "https://raw.githubusercontent.com/Azure/acs-engine/master/parts/"
+)

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -37,12 +37,20 @@ var (
 		DockerComposeDownloadURL: "https://github.com/docker/compose/releases/download",
 	}
 
-	//DefaultOSImageConfig is the default Linux distribution.
-	DefaultOSImageConfig = AzureOSImageConfig{
+	//DefaultUbuntuImageConfig is the default Linux distribution.
+	DefaultUbuntuImageConfig = AzureOSImageConfig{
 		ImageOffer:     "UbuntuServer",
 		ImageSku:       "16.04-LTS",
 		ImagePublisher: "Canonical",
 		ImageVersion:   "16.04.201706191",
+	}
+
+	//DefaultRHELOSImageConfig is the RHEL Linux distribution.
+	DefaultRHELOSImageConfig = AzureOSImageConfig{
+		ImageOffer:     "RHEL",
+		ImageSku:       "7.3",
+		ImagePublisher: "RedHat",
+		ImageVersion:   "latest",
 	}
 
 	//AzureCloudSpec is the default configurations for global azure.
@@ -57,7 +65,10 @@ var (
 			ResourceManagerVMDNSSuffix: "cloudapp.azure.com",
 		},
 
-		OSImageConfig: DefaultOSImageConfig,
+		OSImageConfig: map[api.Distro]AzureOSImageConfig{
+			api.Ubuntu: DefaultUbuntuImageConfig,
+			api.RHEL:   DefaultRHELOSImageConfig,
+		},
 	}
 
 	//AzureGermanCloudSpec is the German cloud config.
@@ -68,11 +79,14 @@ var (
 		EndpointConfig: AzureEndpointConfig{
 			ResourceManagerVMDNSSuffix: "cloudapp.microsoftazure.de",
 		},
-		OSImageConfig: AzureOSImageConfig{
-			ImageOffer:     "UbuntuServer",
-			ImageSku:       "16.04-LTS",
-			ImagePublisher: "Canonical",
-			ImageVersion:   "16.04.201701130",
+		OSImageConfig: map[api.Distro]AzureOSImageConfig{
+			api.Ubuntu: {
+				ImageOffer:     "UbuntuServer",
+				ImageSku:       "16.04-LTS",
+				ImagePublisher: "Canonical",
+				ImageVersion:   "16.04.201701130",
+			},
+			api.RHEL: DefaultRHELOSImageConfig,
 		},
 	}
 
@@ -84,7 +98,10 @@ var (
 		EndpointConfig: AzureEndpointConfig{
 			ResourceManagerVMDNSSuffix: "cloudapp.windowsazure.us",
 		},
-		OSImageConfig: DefaultOSImageConfig,
+		OSImageConfig: map[api.Distro]AzureOSImageConfig{
+			api.Ubuntu: DefaultUbuntuImageConfig,
+			api.RHEL:   DefaultRHELOSImageConfig,
+		},
 	}
 
 	//AzureChinaCloudSpec is the configurations for Azure China (Mooncake)
@@ -113,7 +130,10 @@ var (
 		EndpointConfig: AzureEndpointConfig{
 			ResourceManagerVMDNSSuffix: "cloudapp.chinacloudapi.cn",
 		},
-		OSImageConfig: DefaultOSImageConfig,
+		OSImageConfig: map[api.Distro]AzureOSImageConfig{
+			api.Ubuntu: DefaultUbuntuImageConfig,
+			api.RHEL:   DefaultRHELOSImageConfig,
+		},
 	}
 )
 
@@ -255,6 +275,12 @@ func setMasterNetworkDefaults(a *api.Properties) {
 	if a.MasterProfile == nil {
 		return
 	}
+
+	// Set default Distro to Ubuntu
+	if a.MasterProfile.Distro == "" {
+		a.MasterProfile.Distro = api.Ubuntu
+	}
+
 	if !a.MasterProfile.IsCustomVNET() {
 		if a.OrchestratorProfile.OrchestratorType == api.Kubernetes {
 			if a.OrchestratorProfile.IsVNETIntegrated() {
@@ -312,6 +338,10 @@ func setAgentNetworkDefaults(a *api.Properties) {
 		// set default OSType to Linux
 		if profile.OSType == "" {
 			profile.OSType = api.Linux
+		}
+		// set default Distro to Ubuntu
+		if profile.Distro == "" {
+			profile.Distro = api.Ubuntu
 		}
 
 		// Set the default number of IP addresses allocated for agents.

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io/ioutil"
+	"log"
 	"math/rand"
 	"net/http"
 	"regexp"
@@ -272,6 +273,10 @@ func (t *TemplateGenerator) GenerateTemplate(containerService *api.ContainerServ
 		}
 	}()
 
+	if !ValidateDistro(containerService) {
+		return templateRaw, parametersRaw, certsGenerated, fmt.Errorf("Invalid distro")
+	}
+
 	var b bytes.Buffer
 	if err = templ.ExecuteTemplate(&b, baseFile, properties); err != nil {
 		return templateRaw, parametersRaw, certsGenerated, err
@@ -403,6 +408,23 @@ func GetCloudSpecConfig(location string) AzureEnvironmentSpecConfig {
 	}
 }
 
+// ValidateDistro checks if the requested orchestrator type is supported on the requested Linux distro.
+func ValidateDistro(cs *api.ContainerService) bool {
+	// Check Master distro
+	if cs.Properties.MasterProfile != nil && cs.Properties.MasterProfile.Distro == api.RHEL && cs.Properties.OrchestratorProfile.OrchestratorType != api.SwarmMode {
+		log.Fatalf("Orchestrator type %s not suported on RHEL Master", cs.Properties.OrchestratorProfile.OrchestratorType)
+		return false
+	}
+	// Check Agent distros
+	for _, agentProfile := range cs.Properties.AgentPoolProfiles {
+		if agentProfile.Distro == api.RHEL && cs.Properties.OrchestratorProfile.OrchestratorType != api.SwarmMode {
+			log.Fatalf("Orchestrator type %s not suported on RHEL Agent", cs.Properties.OrchestratorProfile.OrchestratorType)
+			return false
+		}
+	}
+	return true
+}
+
 // GetCloudTargetEnv determines and returns whether the region is a sovereign cloud which
 // have their own data compliance regulations (China/Germany/USGov) or standard
 //  Azure public cloud
@@ -428,10 +450,10 @@ func getParameters(cs *api.ContainerService, isClassicMode bool) (paramsMap, err
 
 	// Master Parameters
 	addValue(parametersMap, "location", location)
-	addValue(parametersMap, "osImageOffer", cloudSpecConfig.OSImageConfig.ImageOffer)
-	addValue(parametersMap, "osImageSKU", cloudSpecConfig.OSImageConfig.ImageSku)
-	addValue(parametersMap, "osImagePublisher", cloudSpecConfig.OSImageConfig.ImagePublisher)
-	addValue(parametersMap, "osImageVersion", cloudSpecConfig.OSImageConfig.ImageVersion)
+	addValue(parametersMap, "osImageOffer", cloudSpecConfig.OSImageConfig[api.Ubuntu].ImageOffer)
+	addValue(parametersMap, "osImageSKU", cloudSpecConfig.OSImageConfig[api.Ubuntu].ImageSku)
+	addValue(parametersMap, "osImagePublisher", cloudSpecConfig.OSImageConfig[api.Ubuntu].ImagePublisher)
+	addValue(parametersMap, "osImageVersion", cloudSpecConfig.OSImageConfig[api.Ubuntu].ImageVersion)
 	addValue(parametersMap, "fqdnEndpointSuffix", cloudSpecConfig.EndpointConfig.ResourceManagerVMDNSSuffix)
 	addValue(parametersMap, "targetEnvironment", GetCloudTargetEnv(location))
 	addValue(parametersMap, "linuxAdminUsername", properties.LinuxProfile.AdminUsername)
@@ -1021,6 +1043,44 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		},
 		"HasWindowsSecrets": func() bool {
 			return cs.Properties.WindowsProfile.HasSecrets()
+		},
+		"GetConfigurationScriptRootURL": func() string {
+			if cs.Properties.LinuxProfile.ScriptRootURL == "" {
+				return DefaultConfigurationScriptRootURL
+			}
+			return cs.Properties.LinuxProfile.ScriptRootURL
+		},
+		"GetMasterOSImageOffer": func() string {
+			cloudSpecConfig := GetCloudSpecConfig(cs.Location)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[cs.Properties.MasterProfile.Distro].ImageOffer)
+		},
+		"GetMasterOSImagePublisher": func() string {
+			cloudSpecConfig := GetCloudSpecConfig(cs.Location)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[cs.Properties.MasterProfile.Distro].ImagePublisher)
+		},
+		"GetMasterOSImageSKU": func() string {
+			cloudSpecConfig := GetCloudSpecConfig(cs.Location)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[cs.Properties.MasterProfile.Distro].ImageSku)
+		},
+		"GetMasterOSImageVersion": func() string {
+			cloudSpecConfig := GetCloudSpecConfig(cs.Location)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[cs.Properties.MasterProfile.Distro].ImageVersion)
+		},
+		"GetAgentOSImageOffer": func(profile *api.AgentPoolProfile) string {
+			cloudSpecConfig := GetCloudSpecConfig(cs.Location)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[profile.Distro].ImageOffer)
+		},
+		"GetAgentOSImagePublisher": func(profile *api.AgentPoolProfile) string {
+			cloudSpecConfig := GetCloudSpecConfig(cs.Location)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[profile.Distro].ImagePublisher)
+		},
+		"GetAgentOSImageSKU": func(profile *api.AgentPoolProfile) string {
+			cloudSpecConfig := GetCloudSpecConfig(cs.Location)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[profile.Distro].ImageSku)
+		},
+		"GetAgentOSImageVersion": func(profile *api.AgentPoolProfile) string {
+			cloudSpecConfig := GetCloudSpecConfig(cs.Location)
+			return fmt.Sprintf("\"%s\"", cloudSpecConfig.OSImageConfig[profile.Distro].ImageVersion)
 		},
 		"PopulateClassicModeDefaultValue": func(attr string) string {
 			var val string

--- a/pkg/acsengine/types.go
+++ b/pkg/acsengine/types.go
@@ -72,7 +72,7 @@ type AzureEnvironmentSpecConfig struct {
 	KubernetesSpecConfig KubernetesSpecConfig
 	DCOSSpecConfig       DCOSSpecConfig
 	EndpointConfig       AzureEndpointConfig
-	OSImageConfig        AzureOSImageConfig
+	OSImageConfig        map[api.Distro]AzureOSImageConfig
 }
 
 // Context represents the object that is passed to the package

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -20,6 +20,12 @@ const (
 	Linux   OSType = "Linux"
 )
 
+// the LinuxDistros supported by vlabs
+const (
+	Ubuntu Distro = "ubuntu"
+	RHEL   Distro = "rhel"
+)
+
 const (
 	// SwarmVersion is the Swarm orchestrator version
 	SwarmVersion = "swarm:1.1.0"

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -548,6 +548,7 @@ func convertLinuxProfileToVLabs(obj *LinuxProfile, vlabsProfile *vlabs.LinuxProf
 		convertKeyVaultSecretsToVlabs(&s, secret)
 		vlabsProfile.Secrets = append(vlabsProfile.Secrets, *secret)
 	}
+	vlabsProfile.ScriptRootURL = obj.ScriptRootURL
 }
 
 func convertWindowsProfileToV20160930(api *WindowsProfile, v20160930 *v20160930.WindowsProfile) {
@@ -722,6 +723,7 @@ func convertMasterProfileToVLabs(api *MasterProfile, vlabsProfile *vlabs.MasterP
 		convertExtensionToVLabs(&extension, vlabsExtension)
 		vlabsProfile.Extensions = append(vlabsProfile.Extensions, *vlabsExtension)
 	}
+	vlabsProfile.Distro = vlabs.Distro(api.Distro)
 }
 
 func convertKeyVaultSecretsToVlabs(api *KeyVaultSecrets, vlabsSecrets *vlabs.KeyVaultSecrets) {
@@ -813,6 +815,7 @@ func convertAgentPoolProfileToVLabs(api *AgentPoolProfile, p *vlabs.AgentPoolPro
 		convertExtensionToVLabs(&extension, vlabsExtension)
 		p.Extensions = append(p.Extensions, *vlabsExtension)
 	}
+	p.Distro = vlabs.Distro(api.Distro)
 }
 
 func convertDiagnosticsProfileToV20160930(api *DiagnosticsProfile, dp *v20160930.DiagnosticsProfile) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -473,6 +473,7 @@ func convertVLabsLinuxProfile(vlabs *vlabs.LinuxProfile, api *LinuxProfile) {
 		convertVLabsKeyVaultSecrets(&s, secret)
 		api.Secrets = append(api.Secrets, *secret)
 	}
+	api.ScriptRootURL = vlabs.ScriptRootURL
 }
 
 func convertV20160930WindowsProfile(v20160930 *v20160930.WindowsProfile, api *WindowsProfile) {
@@ -711,6 +712,8 @@ func convertVLabsMasterProfile(vlabs *vlabs.MasterProfile, api *MasterProfile) {
 		convertVLabsExtension(&extension, apiExtension)
 		api.Extensions = append(api.Extensions, *apiExtension)
 	}
+
+	api.Distro = Distro(vlabs.Distro)
 }
 
 func convertV20160930AgentPoolProfile(v20160930 *v20160930.AgentPoolProfile, availabilityProfile string, api *AgentPoolProfile) {
@@ -807,6 +810,7 @@ func convertVLabsAgentPoolProfile(vlabs *vlabs.AgentPoolProfile, api *AgentPoolP
 		convertVLabsExtension(&extension, apiExtension)
 		api.Extensions = append(api.Extensions, *apiExtension)
 	}
+	api.Distro = Distro(vlabs.Distro)
 }
 
 func convertVLabsKeyVaultSecrets(vlabs *vlabs.KeyVaultSecrets, api *KeyVaultSecrets) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -98,7 +98,9 @@ type LinuxProfile struct {
 	SSH           struct {
 		PublicKeys []PublicKey `json:"publicKeys"`
 	} `json:"ssh"`
-	Secrets []KeyVaultSecrets `json:"secrets,omitempty"`
+	Secrets       []KeyVaultSecrets `json:"secrets,omitempty"`
+	Distro        Distro            `json:"distro,omitempty"`
+	ScriptRootURL string            `json:"scriptroot,omitempty"`
 }
 
 // PublicKey represents an SSH key for LinuxProfile
@@ -189,6 +191,7 @@ type MasterProfile struct {
 	OAuthEnabled             bool        `json:"oauthEnabled"`
 	PreprovisionExtension    *Extension  `json:"preProvisionExtension"`
 	Extensions               []Extension `json:"extensions"`
+	Distro                   Distro      `json:"distro,omitempty"`
 
 	// Master LB public endpoint/FQDN with port
 	// The format will be FQDN:2376
@@ -230,6 +233,7 @@ type AgentPoolProfile struct {
 	VnetSubnetID        string `json:"vnetSubnetID,omitempty"`
 	Subnet              string `json:"subnet"`
 	IPAddressCount      int    `json:"ipAddressCount,omitempty"`
+	Distro              Distro `json:"distro,omitempty"`
 
 	FQDN                  string            `json:"fqdn,omitempty"`
 	CustomNodeLabels      map[string]string `json:"customNodeLabels,omitempty"`
@@ -294,6 +298,9 @@ type KeyVaultCertificate struct {
 
 // OSType represents OS types of agents
 type OSType string
+
+// Distro represents Linux distro to use for Linux VMs
+type Distro string
 
 // HostedMasterProfile defines properties for a hosted master
 type HostedMasterProfile struct {
@@ -425,6 +432,11 @@ func (m *MasterProfile) IsStorageAccount() bool {
 	return m.StorageProfile == StorageAccount
 }
 
+// IsRHEL returns true if the master specified a RHEL distro
+func (m *MasterProfile) IsRHEL() bool {
+	return m.Distro == RHEL
+}
+
 // IsCustomVNET returns true if the customer brought their own VNET
 func (a *AgentPoolProfile) IsCustomVNET() bool {
 	return len(a.VnetSubnetID) > 0
@@ -438,6 +450,11 @@ func (a *AgentPoolProfile) IsWindows() bool {
 // IsLinux returns true if the agent pool is linux
 func (a *AgentPoolProfile) IsLinux() bool {
 	return a.OSType == Linux
+}
+
+// IsRHEL returns true if the agent pool specified a RHEL distro
+func (a *AgentPoolProfile) IsRHEL() bool {
+	return a.OSType == Linux && a.Distro == RHEL
 }
 
 // IsAvailabilitySets returns true if the customer specified disks

--- a/pkg/api/vlabs/const.go
+++ b/pkg/api/vlabs/const.go
@@ -23,6 +23,12 @@ const (
 	Linux   OSType = "Linux"
 )
 
+// the LinuxDistros supported by vlabs
+const (
+	Ubuntu Distro = "ubuntu"
+	RHEL   Distro = "rhel"
+)
+
 // validation values
 const (
 	// MinAgentCount are the minimum number of agents per agent pool

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -102,7 +102,8 @@ type LinuxProfile struct {
 	SSH           struct {
 		PublicKeys []PublicKey `json:"publicKeys" validate:"required,len=1"`
 	} `json:"ssh" validate:"required"`
-	Secrets []KeyVaultSecrets `json:"secrets,omitempty"`
+	Secrets       []KeyVaultSecrets `json:"secrets,omitempty"`
+	ScriptRootURL string            `json:"scriptroot,omitempty"`
 }
 
 // PublicKey represents an SSH key for LinuxProfile
@@ -217,6 +218,7 @@ type MasterProfile struct {
 	OAuthEnabled             bool        `json:"oauthEnabled"`
 	PreProvisionExtension    *Extension  `json:"preProvisionExtension"`
 	Extensions               []Extension `json:"extensions"`
+	Distro                   Distro      `json:"distro,omitempty"`
 
 	// subnet is internal
 	subnet string
@@ -263,6 +265,7 @@ type AgentPoolProfile struct {
 	DiskSizesGB         []int  `json:"diskSizesGB,omitempty" validate:"max=4,dive,min=1,max=1023"`
 	VnetSubnetID        string `json:"vnetSubnetID,omitempty"`
 	IPAddressCount      int    `json:"ipAddressCount,omitempty" validate:"min=0,max=256"`
+	Distro              Distro `json:"distro,omitempty"`
 
 	// subnet is internal
 	subnet string
@@ -311,6 +314,9 @@ type KeyVaultCertificate struct {
 // OSType represents OS types of agents
 type OSType string
 
+// Distro represents Linux distro to use for Linux VMs
+type Distro string
+
 // HasWindows returns true if the cluster contains windows
 func (p *Properties) HasWindows() bool {
 	for _, agentPoolProfile := range p.AgentPoolProfiles {
@@ -346,6 +352,11 @@ func (m *MasterProfile) IsStorageAccount() bool {
 	return m.StorageProfile == StorageAccount
 }
 
+// IsRHEL returns true if the master specified a RHEL distro
+func (m *MasterProfile) IsRHEL() bool {
+	return m.Distro == RHEL
+}
+
 // IsCustomVNET returns true if the customer brought their own VNET
 func (a *AgentPoolProfile) IsCustomVNET() bool {
 	return len(a.VnetSubnetID) > 0
@@ -359,6 +370,11 @@ func (a *AgentPoolProfile) IsWindows() bool {
 // IsLinux returns true if the agent pool is linux
 func (a *AgentPoolProfile) IsLinux() bool {
 	return a.OSType == Linux
+}
+
+// IsRHEL returns true if the agent pool specified a RHEL distro
+func (a *AgentPoolProfile) IsRHEL() bool {
+	return a.OSType == Linux && a.Distro == RHEL
 }
 
 // IsAvailabilitySets returns true if the customer specified disks


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow deploying Swarm Mode clusters on Red Hat by adding a "distro": "rhel" element to the master and agent configurations.

**Special notes for your reviewer**:
This is Take Two. I have rebased and squashed the changes from the previous PR, and added the changes required to get the two failing tests to work (examples/disks-managed/swarmmode-vmas.json and examples/disks-storageaccount/swarmmode.json). Tested using `e2e.sh` on the various swarmm configurations.
