### PR TITLE
Bump Kubernetes default version to 1.7 release channel

### DIFF
--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -46,7 +46,7 @@ const (
 	// KubernetesRelease1Dot5 is the major.minor string prefix for 1.5 versions of kubernetes
 	KubernetesRelease1Dot5 string = "1.5"
 	// KubernetesDefaultRelease is the default major.minor version for kubernetes
-	KubernetesDefaultRelease string = KubernetesRelease1Dot6
+	KubernetesDefaultRelease string = KubernetesRelease1Dot7
 )
 
 // KubeReleaseToVersion maps a major.minor release to an full major.minor.patch version

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -69,7 +69,7 @@ const (
 	// KubernetesRelease1Dot5 is the major.minor string prefix for 1.5 versions of kubernetes
 	KubernetesRelease1Dot5 string = "1.5"
 	// KubernetesDefaultRelease is the default major.minor version for kubernetes
-	KubernetesDefaultRelease string = KubernetesRelease1Dot6
+	KubernetesDefaultRelease string = KubernetesRelease1Dot7
 )
 
 const (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Bump the default release of Kubernetes deployments to `v1.7.x`

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Bump Kubernetes default version to 1.7
```
