### PR TITLE
Parameterize DNS service IP

### DIFF
--- a/parts/kubernetesmasteraddons-kube-dns-deployment.yaml
+++ b/parts/kubernetesmasteraddons-kube-dns-deployment.yaml
@@ -17,7 +17,7 @@ metadata:
   name: kube-dns
   namespace: kube-system
 spec:
-  clusterIP: 10.0.0.10
+  clusterIP: <kubeDNSServiceIP>
   ports:
   - name: dns
     port: 53


### PR DESCRIPTION
**What this PR does / why we need it**: Fix for DNS service IP when using a custom subnet for cluster services. See issue #1460. Broken for custom subnets since custom subnets were merged in pull #546 .

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: Fixes #1460