### PR TITLE
Fixed regression for extensions.  Updated docs to remove the rootURL …

### DIFF
--- a/extensions/hello-world-dcos/README.md
+++ b/extensions/hello-world-dcos/README.md
@@ -35,8 +35,7 @@ dcos task log hello-marathon
     "extensionProfiles": [
       { 
         "name": "hello-world-dcos", 
-        "version": "v1", 
-        "rootURL": "https://bagbyimages.blob.core.windows.net:443/" 
+        "version": "v1"
       }
     ]
     

--- a/extensions/hello-world/README.md
+++ b/extensions/hello-world/README.md
@@ -36,7 +36,6 @@ ls -l /var/log
       { 
         "name": "hello-world-dcos", 
         "version": "v1", 
-        "rootURL": "https://bagbyimages.blob.core.windows.net:443/",
         "script": "hello.sh" 
       }
     ]

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -1841,7 +1841,12 @@ func internalGetPoolLinkedTemplateText(extTargetVMNamePrefix, orchestratorType, 
 	dta = strings.Replace(dta, "EXTENSION_PARAMETERS_REPLACE", extensionsParameterReference, -1)
 	dta = strings.Replace(dta, "EXTENSION_URL_REPLACE", extensionProfile.RootURL, -1)
 	dta = strings.Replace(dta, "EXTENSION_TARGET_VM_NAME_PREFIX", extTargetVMNamePrefix, -1)
-	dta = strings.Replace(dta, "EXTENSION_LOOP_COUNT", loopCount, -1)
+	if _, err := strconv.Atoi(loopCount); err == nil {
+		dta = strings.Replace(dta, "\"EXTENSION_LOOP_COUNT\"", loopCount, -1)
+	} else {
+		dta = strings.Replace(dta, "EXTENSION_LOOP_COUNT", loopCount, -1)
+	}
+
 	dta = strings.Replace(dta, "EXTENSION_LOOP_OFFSET", loopOffset, -1)
 	return dta, nil
 }


### PR DESCRIPTION
This pull request address an issue with extensions.  The issue has to do with the following code that does the token replacement for EXTENSION_LOOP_COUNT.  

**Original Replace Code**
```javascript
dta = strings.Replace(dta, "EXTENSION_LOOP_COUNT", loopCount, -1)
```

**Template that has the token that is being replaced - template-link.json**
```json
{
    "name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'HelloWorldDcos')]",
    "type": "Microsoft.Resources/deployments",
    "apiVersion": "[variables('apiVersionLinkDefault')]",
    "dependsOn": [
        "[resourceId('Microsoft.Compute/virtualMachines/extensions', concat(variables('masterVMNamePrefix'), sub(variables('masterCount'), 1)), 'waitforleader')]"
    ],
    "copy": {
        "count": "EXTENSION_LOOP_COUNT",
        "name": "helloWorldExtensionLoop"
    },
```

In the event that the code that is replacing the token is an expression, everything is fine.  In the event that the code that the replacing code is an integer, this causes and error.  An integer cannot be surrounded by quotes.  This causes extensions such as hello-world-dcos to fail on deployment.  See failing code below:

```json
    {
      "apiVersion": "[variables('apiVersionLinkDefault')]",
      "copy": {
        "count": "1",
        "name": "helloWorldExtensionLoop"
      },
      "dependsOn": [
        "[resourceId('Microsoft.Compute/virtualMachines/extensions', concat(variables('masterVMNamePrefix'), sub(variables('masterCount'), 1)), 'waitforleader')]"
      ],
```

**Updated Code**
The changed code simply checks the replacing code to see if it is an integer or not.  If it is an integer it replaces the token, along with the surrounding quotes.  If not, it simply replaces the token.  See below.

```javascript
if _, err := strconv.Atoi(loopCount); err == nil {
    dta = strings.Replace(dta, "\"EXTENSION_LOOP_COUNT\"", loopCount, -1)
} else {
    dta = strings.Replace(dta, "EXTENSION_LOOP_COUNT", loopCount, -1)
}
```
2 other files were changed - both documentation - removing the reference to rootURL - which is a development concern.
