### PR TITLE
Promote to fail debug

### DIFF
--- a/test/acs-engine-test/main.go
+++ b/test/acs-engine-test/main.go
@@ -370,6 +370,8 @@ func (m *TestManager) testRun(d config.Deployment, index, attempt int, timeout t
 
 func isPromoteToFailureStep(step string) bool {
 	switch step {
+	case stepDeployTemplate:
+		return true
 	case stepValidate:
 		return true
 	case stepPostDeploy:

--- a/test/acs-engine-test/main.go
+++ b/test/acs-engine-test/main.go
@@ -164,7 +164,10 @@ func (m *TestManager) Run() error {
 							FailureCount: 1,
 						}
 
-						result, _ := promote.RunPromoteToFailure(sa, promToFailInfo)
+						result, err := promote.RunPromoteToFailure(sa, promToFailInfo)
+						if err != nil {
+							fmt.Printf("Got error from RunPromoteToFailure: %#v\n", err)
+						}
 						if result == true {
 							success[index] = false
 						} else {
@@ -188,6 +191,12 @@ func (m *TestManager) Run() error {
 
 					promote.RunPromoteToFailure(sa, promToFailInfo)
 
+				}
+
+				if success[index] {
+					fmt.Printf("Promote to Fail passed: SUCCESS [%s] [%s]\n", errorInfo.Step, testName)
+				} else {
+					fmt.Printf("Promote to Fail did not pass: ERROR [%s] [%s]\n", errorInfo.Step, testName)
 				}
 
 			} else {

--- a/test/acs-engine-test/promote/promote.go
+++ b/test/acs-engine-test/promote/promote.go
@@ -175,6 +175,7 @@ func RunPromoteToFailure(sa StorageAccount, testRunPromToFail DigitalSignalFilte
 
 	fmt.Printf("Existing Failure Count : %v\n\n", existingFailureCount)
 	newFailureCount := existingFailureCount.(float64) + testRunPromToFail.FailureCount
+	fmt.Printf("Incremented Failure Count to : %v\n\n", newFailureCount)
 	if err = updateEntity(entity, newFailureCount, testRunPromToFail.FailureStr); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: adds debug data and deployment errors to promote to fail for acse-regression

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
