### PR TITLE
rationalizes build-cross and dist Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,16 @@ GOFLAGS   :=
 endif
 
 # go option
-GO        ?= go
-TAGS      :=
-LDFLAGS   :=
-BINDIR    := $(CURDIR)/bin
-BINARIES  := acs-engine
-VERSION   ?= $(shell git rev-parse HEAD)
-GITTAG    := $(shell git describe --exact-match --tags $(shell git log -n1 --pretty='%h') 2> /dev/null)
+GO              ?= go
+TAGS            :=
+LDFLAGS         :=
+BINDIR          := $(CURDIR)/bin
+BINARIES        := acs-engine
+VERSION         ?= $(shell git rev-parse HEAD)
+VERSION_SHORT   ?= $(shell git rev-parse --short HEAD)
+GITTAG          := $(shell git describe --exact-match --tags $(shell git log -n1 --pretty='%h') 2> /dev/null)
 ifeq ($(GITTAG),)
-GITTAG := $(VERSION)
+GITTAG := $(VERSION_SHORT)
 endif
 
 REPO_PATH := github.com/Azure/acs-engine

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ LDFLAGS   :=
 BINDIR    := $(CURDIR)/bin
 BINARIES  := acs-engine
 VERSION   ?= $(shell git rev-parse HEAD)
+GITTAG    := $(shell git describe --exact-match --tags $(shell git log -n1 --pretty='%h') 2> /dev/null)
+ifeq ($(GITTAG),)
+GITTAG := $(VERSION)
+endif
 
 REPO_PATH := github.com/Azure/acs-engine
 DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.2.0
@@ -49,16 +53,17 @@ build-binary: generate
 
 # usage: make clean build-cross dist VERSION=v0.4.0
 .PHONY: build-cross
+build-cross: build
 build-cross: LDFLAGS += -extldflags "-static"
 build-cross:
-	CGO_ENABLED=0 gox -output="_dist/acs-engine-${VERSION}-{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)'
+	CGO_ENABLED=0 gox -output="_dist/acs-engine-${GITTAG}-{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)'
 
 .PHONY: build-windows-k8s
 build-windows-k8s:
 	./scripts/build-windows-k8s.sh -v ${K8S_VERSION} -p ${PATCH_VERSION}
 
 .PHONY: dist
-dist:
+dist: build-cross
 	( \
 		cd _dist && \
 		$(DIST_DIRS) cp ../LICENSE {} \; && \


### PR DESCRIPTION
- build-cross now depends on build, and uses the git tag if the checked out branch correlates with a tag
- dist now depends upon build-cross

This produces friendly artifacts with a `make dist` like so:

```
$ find _dist -maxdepth 1 -type f
_dist/acs-engine-a1af5fbc14aee06f19a9d4863dcc05fe7d437cab-darwin-amd64.tar.gz
_dist/acs-engine-a1af5fbc14aee06f19a9d4863dcc05fe7d437cab-darwin-amd64.zip
_dist/acs-engine-a1af5fbc14aee06f19a9d4863dcc05fe7d437cab-linux-amd64.tar.gz
_dist/acs-engine-a1af5fbc14aee06f19a9d4863dcc05fe7d437cab-linux-amd64.zip
_dist/acs-engine-a1af5fbc14aee06f19a9d4863dcc05fe7d437cab-windows-amd64.tar.gz
_dist/acs-engine-a1af5fbc14aee06f19a9d4863dcc05fe7d437cab-windows-amd64.zip
```

Or, for a release, when a release tag is checked out:

```
$ find _dist -maxdepth 1 -type f
_dist/acs-engine-v0.7.0-darwin-amd64.tar.gz
_dist/acs-engine-v0.7.0-darwin-amd64.zip
_dist/acs-engine-v0.7.0-linux-amd64.tar.gz
_dist/acs-engine-v0.7.0-linux-amd64.zip
_dist/acs-engine-v0.7.0-windows-amd64.tar.gz
_dist/acs-engine-v0.7.0-windows-amd64.zip
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
