### PR TITLE
null reference vector in e2e promote to fail

### DIFF
--- a/test/acs-engine-test/main.go
+++ b/test/acs-engine-test/main.go
@@ -194,9 +194,9 @@ func (m *TestManager) Run() error {
 				}
 
 				if success[index] {
-					fmt.Printf("Promote to Fail passed: SUCCESS [%s] [%s]\n", errorInfo.Step, testName)
+					fmt.Printf("Promote to Fail passed: SUCCESS [%s]\n", testName)
 				} else {
-					fmt.Printf("Promote to Fail did not pass: ERROR [%s] [%s]\n", errorInfo.Step, testName)
+					fmt.Printf("Promote to Fail did not pass: ERROR [%s]\n", testName)
 				}
 
 			} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
