### PR TITLE
fix regex for kube version

### DIFF
--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	//ServerVersion is used to parse out the version of the API running
-	ServerVersion = `(Server Version:\s)+(v\d.\d.\d)+`
+	ServerVersion = `(Server Version:\s)+(v\d+.\d+.\d+)+`
 )
 
 // Node represents the kubernetes Node Resource


### PR DESCRIPTION
The regex I was using to parse out the server version didnt take into account multiple digits in each place. This fixes that problem.