### PR TITLE
no longer explicitly testing 1.6 hybrid clusters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
           path: /go/src/github.com/Azure/acs-engine/_logs
       - store_artifacts:
           path: /go/src/github.com/Azure/acs-engine/_output
-  k8s-hybrid-1.6-release-e2e:
+  k8s-hybrid-1.7-release-e2e:
     working_directory: /go/src/github.com/Azure/acs-engine
     docker:
       - image: quay.io/deis/go-dev:v1.2.0
@@ -208,7 +208,7 @@ jobs:
     steps:
       - checkout
       - run: |
-          echo 'export ORCHESTRATOR_RELEASE=1.6' >> $BASH_ENV
+          echo 'export ORCHESTRATOR_RELEASE=1.7' >> $BASH_ENV
           echo 'export CLUSTER_DEFINITION=examples/windows/kubernetes-hybrid.json' >> $BASH_ENV
           echo 'export CLIENT_ID=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID}' >> $BASH_ENV
           echo 'export CLIENT_SECRET=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET}' >> $BASH_ENV
@@ -285,7 +285,7 @@ jobs:
           path: /go/src/github.com/Azure/acs-engine/_logs
       - store_artifacts:
           path: /go/src/github.com/Azure/acs-engine/_output
-  k8s-hybrid-1.6-release-e2e-master:
+  k8s-hybrid-1.7-release-e2e-master:
     working_directory: /go/src/github.com/Azure/acs-engine
     docker:
       - image: quay.io/deis/go-dev:v1.2.0
@@ -294,7 +294,7 @@ jobs:
     steps:
       - checkout
       - run: |
-          echo 'export ORCHESTRATOR_RELEASE=1.6' >> $BASH_ENV
+          echo 'export ORCHESTRATOR_RELEASE=1.7' >> $BASH_ENV
           echo 'export CLUSTER_DEFINITION=examples/windows/kubernetes-hybrid.json' >> $BASH_ENV
           echo 'export CLIENT_ID=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID}' >> $BASH_ENV
           echo 'export CLIENT_SECRET=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET}' >> $BASH_ENV
@@ -340,7 +340,7 @@ workflows:
           filters:
             branches:
               ignore: master
-      - k8s-hybrid-1.6-release-e2e:
+      - k8s-hybrid-1.7-release-e2e:
           requires:
             - pr-e2e-hold
           filters:
@@ -364,7 +364,7 @@ workflows:
           filters:
             branches:
               only: master
-      - k8s-hybrid-1.6-release-e2e-master:
+      - k8s-hybrid-1.7-release-e2e-master:
           requires:
             - test
           filters:

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ test/acs-engine-test/report/TestReport.json
 *.swp
 
 # I have no idea why these get generated when I run the e2e test
-test/e2e/kubernetes/translations/ 
+test/e2e/kubernetes/translations/

--- a/examples/windows/kubernetes-hybrid.json
+++ b/examples/windows/kubernetes-hybrid.json
@@ -2,8 +2,7 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.6"
+      "orchestratorType": "Kubernetes"
     },
     "masterProfile": {
       "count": 1,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

We don't want E2E to test 1.6 hybrid clusters.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
