### PR TITLE
Stricter parsing of API model keys

### DIFF
--- a/pkg/api/apiloader.go
+++ b/pkg/api/apiloader.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"io/ioutil"
+	"reflect"
 
 	"github.com/Azure/acs-engine/pkg/api/common"
 	"github.com/Azure/acs-engine/pkg/api/v20170930"
@@ -134,6 +135,9 @@ func (a *Apiloader) LoadContainerService(
 	case vlabs.APIVersion:
 		containerService := &vlabs.ContainerService{}
 		if e := json.Unmarshal(contents, &containerService); e != nil {
+			return nil, e
+		}
+		if e := checkJSONKeys(contents, reflect.TypeOf(*containerService), reflect.TypeOf(TypeMeta{})); e != nil {
 			return nil, e
 		}
 		if existingContainerService != nil {

--- a/pkg/api/strictjson.go
+++ b/pkg/api/strictjson.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+func checkJSONKeys(data []byte, types ...reflect.Type) error {
+	var raw interface{}
+	if e := json.Unmarshal(data, &raw); e != nil {
+		return e
+	}
+	o := raw.(map[string]interface{})
+	return checkMapKeys(o, types...)
+}
+
+func checkMapKeys(o map[string]interface{}, types ...reflect.Type) error {
+	fieldMap := createJSONFieldMap(types)
+	for k, v := range o {
+		f, present := fieldMap[strings.ToLower(k)]
+		if !present {
+			return fmt.Errorf("Unknown JSON tag %s", k)
+		}
+		if f.Type.Kind() == reflect.Struct && v != nil {
+			if childMap, exists := v.(map[string]interface{}); exists {
+				if e := checkMapKeys(childMap, f.Type); e != nil {
+					return e
+				}
+			}
+		}
+		if f.Type.Kind() == reflect.Slice && v != nil {
+			elementType := f.Type.Elem()
+			if elementType.Kind() == reflect.Ptr {
+				elementType = elementType.Elem()
+			}
+			if childSlice, exists := v.([]interface{}); exists {
+				for _, child := range childSlice {
+					if childMap, exists := child.(map[string]interface{}); exists {
+						if e := checkMapKeys(childMap, elementType); e != nil {
+							return e
+						}
+					}
+				}
+			}
+		}
+		if f.Type.Kind() == reflect.Ptr && v != nil {
+			elementType := f.Type.Elem()
+			if childMap, exists := v.(map[string]interface{}); exists {
+				if e := checkMapKeys(childMap, elementType); e != nil {
+					return e
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func createJSONFieldMap(types []reflect.Type) map[string]reflect.StructField {
+	fieldMap := make(map[string]reflect.StructField)
+	// Combine the permitted JSON fields from all types - handles the case
+	// where we need to see the same JSON as a TypeMeta and a ContainerService
+	for _, t := range types {
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			tag := f.Tag
+			fieldJSON := tag.Get("json")
+			if fieldJSON != "" {
+				fieldJSONkey := strings.SplitN(fieldJSON, ",", 2)[0]
+				fieldMap[strings.ToLower(fieldJSONkey)] = f
+			}
+		}
+	}
+	return fieldMap
+}

--- a/pkg/api/strictjson_test.go
+++ b/pkg/api/strictjson_test.go
@@ -1,0 +1,262 @@
+package api
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Azure/acs-engine/pkg/api/v20160330"
+	"github.com/Azure/acs-engine/pkg/api/v20160930"
+	"github.com/Azure/acs-engine/pkg/api/v20170131"
+	"github.com/Azure/acs-engine/pkg/api/v20170701"
+	"github.com/Azure/acs-engine/pkg/api/vlabs"
+)
+
+type SubTestProfile struct {
+	SP1 bool             `json:"sp1"`
+	SP2 bool             `json:"sp2"`
+	SP3 []SubTestProfile `json:"sp3,omitempty"`
+}
+
+type TestProfile struct {
+	Field1 int               `json:"f1"`
+	Field2 SubTestProfile    `json:"f2,omitempty"`
+	Field3 []SubTestProfile  `json:"f3,omitempty"`
+	Field4 *SubTestProfile   `json:"f4"`
+	Field5 []*SubTestProfile `json:"f5,omitempty"`
+}
+
+func TestIfAllJSONKeysAreExpectedThenCheckPasses(t *testing.T) {
+	json := `
+	{
+		"f1": 1,
+		"f2": {
+			"sp1": true,
+			"sp2": false
+		}
+	}
+	`
+	e := checkJSONKeys([]byte(json), reflect.TypeOf(TestProfile{}))
+	if e != nil {
+		t.Errorf("All JSON keys were expected but the check still failed: %v", e)
+	}
+}
+
+func TestIsCaseInsensitive(t *testing.T) {
+	json := `
+	{
+		"F1": 1,
+		"f2": {
+			"sP1": true,
+			"Sp2": false
+		}
+	}
+	`
+	e := checkJSONKeys([]byte(json), reflect.TypeOf(TestProfile{}))
+	if e != nil {
+		t.Errorf("All JSON keys were expected (allowing for case) but the check still failed: %v", e)
+	}
+}
+
+func TestCheckFailsOnUnexpectedJSONKeyAtTopLevel(t *testing.T) {
+	json := `
+	{
+		"f2": {
+			"sp1": true,
+			"sp2": false
+		},
+		"fx": "uh-oh"
+	}
+	`
+	e := checkJSONKeys([]byte(json), reflect.TypeOf(TestProfile{}))
+	if e == nil {
+		t.Fatal("Unexpected JSON key was not detected")
+	}
+	if !strings.Contains(e.Error(), "fx") {
+		t.Errorf("Error message did not name unexpected JSON key 'fx': was %v", e)
+	}
+}
+
+func TestCheckFailsOnUnexpectedJSONKeyAtSubLevel(t *testing.T) {
+	json := `
+	{
+		"f2": {
+			"sp1": true,
+			"spx": false
+		}
+	}
+	`
+	e := checkJSONKeys([]byte(json), reflect.TypeOf(TestProfile{}))
+	if e == nil {
+		t.Fatal("Unexpected JSON key was not detected")
+	}
+	if !strings.Contains(e.Error(), "spx") {
+		t.Errorf("Error message did not name unexpected JSON key 'spx': was %v", e) // TODO: f2.spx would be better
+	}
+}
+
+func TestCheckFailsOnUnexpectedJSONKeyInArray(t *testing.T) {
+	json := `
+	{
+		"f2": {
+			"sp1": true,
+			"sp3": [
+				{
+					"sp1": false,
+					"sp2": true
+				},
+				{
+					"sp2": false,
+					"spz": "unexpected"
+				}
+			]
+		},
+		"f3": []
+	}
+	`
+	e := checkJSONKeys([]byte(json), reflect.TypeOf(TestProfile{}))
+	if e == nil {
+		t.Fatal("Unexpected JSON key was not detected")
+	}
+	if !strings.Contains(e.Error(), "spz") {
+		t.Errorf("Error message did not name unexpected JSON key 'spz': was %v", e) // TODO: f2[1].spz might be better
+	}
+}
+
+func TestCheckFailsOnUnexpectedJSONKeyInArrayAtSubLevel(t *testing.T) {
+	json := `
+	{
+		"f2": {
+			"sp1": true
+		},
+		"f3": [
+			{
+				"sp1": true,
+				"spy": "unexpected"
+			},
+			{
+				"sp2": false,
+				"spz": "unexpected"
+			}
+		]
+	}
+	`
+	e := checkJSONKeys([]byte(json), reflect.TypeOf(TestProfile{}))
+	if e == nil {
+		t.Fatal("Unexpected JSON key was not detected")
+	}
+	if !strings.Contains(e.Error(), "spy") {
+		t.Errorf("Error message did not name unexpected JSON key 'spy': was %v", e) // TODO: f3[0].spy might be better
+	}
+}
+
+func TestCheckFailsOnUnexpectedJSONKeyAtSubLevelViaPointer(t *testing.T) {
+	json := `
+	{
+		"f4": {
+			"sp1": true,
+			"spx": false
+		}
+	}
+	`
+	e := checkJSONKeys([]byte(json), reflect.TypeOf(TestProfile{}))
+	if e == nil {
+		t.Fatal("Unexpected JSON key was not detected")
+	}
+	if !strings.Contains(e.Error(), "spx") {
+		t.Errorf("Error message did not name unexpected JSON key 'spx': was %v", e) // TODO: f4.spx would be better
+	}
+}
+
+func TestCheckFailsOnUnexpectedJSONKeyInArrayAtSubLevelViaPointer(t *testing.T) {
+	json := `
+	{
+		"f2": {
+			"sp1": true
+		},
+		"f5": [
+			{
+				"sp1": true,
+				"spy": "unexpected"
+			},
+			{
+				"sp2": false,
+				"spz": "unexpected"
+			}
+		]
+	}
+	`
+	e := checkJSONKeys([]byte(json), reflect.TypeOf(TestProfile{}))
+	if e == nil {
+		t.Fatal("Unexpected JSON key was not detected")
+	}
+	if !strings.Contains(e.Error(), "spy") {
+		t.Errorf("Error message did not name unexpected JSON key 'spy': was %v", e) // TODO: f3[0].spy might be better
+	}
+}
+
+const jsonWithTypo = `
+{
+	"apiVersion": "ignored",
+	"properties": {
+	  "orchestratorProfile": {
+		"orchestratorType": "DCOS"
+	  },
+	  "masterProfile": {
+		"count": 1,
+		"dnsprefix": "masterdns1",
+		"vmsize": "Standard_D2_v2",
+		"ventSubnetID": "/this/attribute/was/mistyped"
+	  },
+	  "agentPoolProfiles": [],
+	  "linuxProfile": {
+		"adminUsername": "azureuser",
+		"ssh": {
+		  "publicKeys": [
+			{
+			  "keyData": "ssh-rsa PUBLICKEY azureuser@linuxvm"
+			}
+		  ]
+		}
+	  },
+	  "servicePrincipalProfile": {
+		"clientId": "ServicePrincipalClientID",
+		"secret": "myServicePrincipalClientSecret"
+	  }
+	}
+}
+`
+
+func TestStrictJSONValidationIsNotAppliedToApiVersions20170701AndEarlier(t *testing.T) {
+	// These API versions existed before we added strict JSON validation:
+	// we cannot apply it retrospectively because it could break existing
+	// customer apimodels.
+	preStrictVersions := []string{v20160330.APIVersion, v20160930.APIVersion, v20170131.APIVersion, v20170701.APIVersion /*, v20170930.APIVersion */}
+	a := &Apiloader{
+		Translator: nil,
+	}
+
+	for _, version := range preStrictVersions {
+		_, e := a.LoadContainerService([]byte(jsonWithTypo), version, true, nil)
+		if e != nil {
+			t.Errorf("Expected mistyped 'ventSubnetID' key to be overlooked in version '%s' but it wasn't: error was %v", version, e)
+		}
+	}
+}
+
+func TestStrictJSONValidationIsAppliedToVersionsAbove20170701(t *testing.T) {
+	strictVersions := []string{vlabs.APIVersion}
+	a := &Apiloader{
+		Translator: nil,
+	}
+	for _, version := range strictVersions {
+		_, e := a.LoadContainerService([]byte(jsonWithTypo), version, true, nil)
+		if e == nil {
+			t.Error("Expected mistyped 'ventSubnetID' key to be detected but it wasn't")
+		} else {
+			if !strings.Contains(e.Error(), "ventSubnetID") {
+				t.Errorf("Expected error on 'ventSubnetID' but error was %v", e)
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: At the moment, if a user enters an unknown key in API model JSON, it's ignored.  This means that if the user typos an optional field name, or uses a field that isn't present in the API they're using, they won't get what they're expecting.  This PR enforces that keys in the API model JSON must be recognised.

Note that enforcement is _not_ applied to previous API versions.  This ensures that if a user has an API model that works today, it will not be broken by upgrading their copy of acs-engine.

Also note that we continue to treat JSON keys case-insensitively - that is, keys that differ by case from the recognised keys will not cause an error.  This is existing behaviour.

**Which issue this PR fixes**: fixes #1219 

**Special notes for your reviewer**: This PR currently treats unknown JSON as an error.  We could modify this to be a warning if we want to be more forgiving.  This would make implementing unit tests a bit trickier but would allow it to be backported to older API versions without breaking compatibility.  I'd also appreciate feedback on whether it is worth implementing 'JSON paths' in the error reporting e.g. reporting that 'foo.bar.baz' was unrecognised rather than just 'baz'.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
ACS Engine no longer permits unknown keys in API model JSON.
```
