### PR TITLE
increase delay before win outbound connection test in e2e

### DIFF
--- a/test/cluster-tests/kubernetes/k8s-utils.sh
+++ b/test/cluster-tests/kubernetes/k8s-utils.sh
@@ -129,7 +129,7 @@ function test_windows_deployment() {
   fi
 
   # TODO: There is an issue Windows POD has delay to talk to DNS, but not to other services
-  sleep 300
+  sleep 600
 
   count=30
   success="n"

--- a/test/cluster-tests/kubernetes/k8s-utils.sh
+++ b/test/cluster-tests/kubernetes/k8s-utils.sh
@@ -131,7 +131,7 @@ function test_windows_deployment() {
   # TODO: There is an issue Windows POD has delay to talk to DNS, but not to other services
   sleep 600
 
-  count=30
+  count=10
   success="n"
   while (( $count > 0 )); do
     log "  ... counting down $count"

--- a/test/cluster-tests/kubernetes/k8s-utils.sh
+++ b/test/cluster-tests/kubernetes/k8s-utils.sh
@@ -116,7 +116,7 @@ function test_windows_deployment() {
   fi
 
   log "Checking outbound connection"
-  count=30
+  count=10
   while (( $count > 0 )); do
     log "  ... counting down $count"
     winpodname=$(kubectl get pods --namespace=default | grep win-webserver | awk '{print $1}')
@@ -131,7 +131,7 @@ function test_windows_deployment() {
   # TODO: There is an issue Windows POD has delay to talk to DNS, but not to other services
   sleep 300
 
-  count=10
+  count=30
   success="n"
   while (( $count > 0 )); do
     log "  ... counting down $count"

--- a/test/cluster-tests/kubernetes/k8s-utils.sh
+++ b/test/cluster-tests/kubernetes/k8s-utils.sh
@@ -116,7 +116,7 @@ function test_windows_deployment() {
   fi
 
   log "Checking outbound connection"
-  count=10
+  count=30
   while (( $count > 0 )); do
     log "  ... counting down $count"
     winpodname=$(kubectl get pods --namespace=default | grep win-webserver | awk '{print $1}')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
