### PR TITLE
Mitigate service IP not update in time issue in windows kubeproxy sin…

### DIFF
--- a/parts/kuberneteswindowssetup.ps1
+++ b/parts/kuberneteswindowssetup.ps1
@@ -307,7 +307,7 @@ c:\k\kube-proxy.exe --v=3 --proxy-mode=userspace --hostname-override=$AzureHostn
     if ($global:KubeBinariesVersion -ge "1.7.0")
     {
         # 1.7.0 uses event-based service configuration so shorter duration (default 15m) is needed to update forwarder NIC
-        $kubeProxyStartStr += " --config-sync-period=10m"
+        $kubeProxyStartStr += " --config-sync-period=5m"
     }
 
     $kubeProxyStartStr | Out-File -encoding ASCII -filepath $global:KubeProxyStartFile

--- a/parts/kuberneteswindowssetup.ps1
+++ b/parts/kuberneteswindowssetup.ps1
@@ -304,6 +304,12 @@ catch
 c:\k\kube-proxy.exe --v=3 --proxy-mode=userspace --hostname-override=$AzureHostname --kubeconfig=c:\k\config
 "@
 
+    if ($global:KubeBinariesVersion -ge "1.7.0")
+    {
+        # 1.7.0 uses event-based service configuration so shorter duration (default 15m) is needed to update forwarder NIC
+        $kubeProxyStartStr += " --config-sync-period=10m"
+    }
+
     $kubeProxyStartStr | Out-File -encoding ASCII -filepath $global:KubeProxyStartFile
 }
 

--- a/test/cluster-tests/kubernetes/k8s-utils.sh
+++ b/test/cluster-tests/kubernetes/k8s-utils.sh
@@ -128,9 +128,6 @@ function test_windows_deployment() {
     exit 1
   fi
 
-  # TODO: There is an issue Windows POD has delay to talk to DNS, but not to other services
-  sleep 600
-
   count=10
   success="n"
   while (( $count > 0 )); do

--- a/test/cluster-tests/kubernetes/k8s-utils.sh
+++ b/test/cluster-tests/kubernetes/k8s-utils.sh
@@ -128,6 +128,20 @@ function test_windows_deployment() {
     exit 1
   fi
 
+  log "query DNS"
+  count=10
+  success="n"
+  while (( $count > 0 )); do
+    log "  ... counting down $count"
+    query=$(kubectl exec $winpodname -- powershell nslookup www.bing.com)
+    if [[ $(echo ${query} | grep "DNS request timed out" | wc -l) == 0 ]]; then
+      success="y"
+      break
+    fi
+    sleep 10; count=$((count-1))
+  done
+
+  log "curl external website"
   count=10
   success="n"
   while (( $count > 0 )); do


### PR DESCRIPTION
…ce 1.7.0 kubeproxy uses event-based service configuration

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Windows kubeproxy adds service IP to forwarder NIC OnServiceUpdate. Since 1.7.0, kubeproxy uses event-based service configuration and therefore kube-system services are not passed during POD service creation. It has to wait for the default 15m to get update and before that, cluster DNS is not reachable. This is a mitigation of the issue. 
