### PR TITLE
Install azure-vnet CNI plugin on K8S Windows agents

### DIFF
--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -633,8 +633,8 @@ func (a *Properties) validateNetworkPolicy() error {
 		return fmt.Errorf("unknown networkPolicy '%s' specified", networkPolicy)
 	}
 
-	// Temporary safety check, to be removed when Windows support is added.
-	if (networkPolicy == "calico" || networkPolicy == "azure") && a.HasWindows() {
+	// Temporary safety check, to be removed when Calico adds Windows support.
+	if networkPolicy == "calico" && a.HasWindows() {
 		return fmt.Errorf("networkPolicy '%s' is not supporting windows agents", networkPolicy)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR adds the logic to download, install and configure Azure VNET CNI plugins on Kubernetes Windows nodes. It brings Windows nodes to CNI-networking parity with Linux nodes in Kubernetes.

It also adds support for the "maxPods" kubelet parameter on Windows nodes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1504

**Special notes for your reviewer**:
This PR updates kuberneteswindowssetup.ps1 (runs on Windows nodes first boot) with the same logic in kubernetesmastercustomscript.sh (runs on Linux nodes first boot).

I am marking the PR "do-not-merge" for now, because
1) This PR requires #1480 to be merged first.
2) Azure VNET CNI plugin requires Windows Server 2016 RS3 release, which is not yet available as a VM image in Azure. Windows team may also require some changes on top of this PR to enable full functionality.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

@anhowe, @lachie83, @nisheeth-ms, @sharmasushant, @tamilmani1989, @dineshgovindasamy

fixes #1504.