### PR TITLE
Enable Kubernetes 1.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,72 @@ jobs:
           path: /go/src/github.com/Azure/acs-engine/_logs
       - store_artifacts:
           path: /go/src/github.com/Azure/acs-engine/_output
+  k8s-1.8-release-e2e:
+    working_directory: /go/src/github.com/Azure/acs-engine
+    docker:
+      - image: quay.io/deis/go-dev:v1.2.0
+        environment:
+          GOPATH: /go
+    steps:
+      - checkout
+      - run: |
+          echo 'export ORCHESTRATOR_RELEASE=1.8' >> $BASH_ENV
+          echo 'export CLUSTER_DEFINITION=examples/e2e-tests/kubernetes/release/default/definition.json' >> $BASH_ENV
+          echo 'export CREATE_VNET=true' >> $BASH_ENV
+          echo 'export CLIENT_ID=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID}' >> $BASH_ENV
+          echo 'export CLIENT_SECRET=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET}' >> $BASH_ENV
+      - run:
+          name: ginkgo k8s e2e tests
+          command: make build-binary test-kubernetes
+          no_output_timeout: "30m"
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_logs
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_output
+  k8s-windows-1.8-release-e2e:
+    working_directory: /go/src/github.com/Azure/acs-engine
+    docker:
+      - image: quay.io/deis/go-dev:v1.2.0
+        environment:
+          GOPATH: /go
+    steps:
+      - checkout
+      - run: |
+          echo 'export TIMEOUT=15m' >> $BASH_ENV
+          echo 'export ORCHESTRATOR_RELEASE=1.8' >> $BASH_ENV
+          echo 'export CLUSTER_DEFINITION=examples/windows/kubernetes.json' >> $BASH_ENV
+          echo 'export CLIENT_ID=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID}' >> $BASH_ENV
+          echo 'export CLIENT_SECRET=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET}' >> $BASH_ENV
+      - run:
+          name: ginkgo k8s windows e2e tests
+          command: make build-binary test-kubernetes
+          no_output_timeout: "30m"
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_logs
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_output
+  k8s-hybrid-1.8-release-e2e:
+    working_directory: /go/src/github.com/Azure/acs-engine
+    docker:
+      - image: quay.io/deis/go-dev:v1.2.0
+        environment:
+          GOPATH: /go
+    steps:
+      - checkout
+      - run: |
+          echo 'export ORCHESTRATOR_RELEASE=1.8' >> $BASH_ENV
+          echo 'export TIMEOUT=15m' >> $BASH_ENV
+          echo 'export CLUSTER_DEFINITION=examples/windows/kubernetes-hybrid.json' >> $BASH_ENV
+          echo 'export CLIENT_ID=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID}' >> $BASH_ENV
+          echo 'export CLIENT_SECRET=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET}' >> $BASH_ENV
+      - run:
+          name: ginkgo k8s hybrid e2e tests
+          command: make build-binary test-kubernetes
+          no_output_timeout: "30m"
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_logs
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_output
   k8s-1.6-release-e2e-master:
     working_directory: /go/src/github.com/Azure/acs-engine
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,6 +310,72 @@ jobs:
           path: /go/src/github.com/Azure/acs-engine/_logs
       - store_artifacts:
           path: /go/src/github.com/Azure/acs-engine/_output
+  k8s-1.8-release-e2e-master:
+    working_directory: /go/src/github.com/Azure/acs-engine
+    docker:
+      - image: quay.io/deis/go-dev:v1.2.0
+        environment:
+          GOPATH: /go
+    steps:
+      - checkout
+      - run: |
+          echo 'export ORCHESTRATOR_RELEASE=1.8' >> $BASH_ENV
+          echo 'export CLUSTER_DEFINITION=examples/e2e-tests/kubernetes/release/default/definition.json' >> $BASH_ENV
+          echo 'export CREATE_VNET=true' >> $BASH_ENV
+          echo 'export CLIENT_ID=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID}' >> $BASH_ENV
+          echo 'export CLIENT_SECRET=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET}' >> $BASH_ENV
+      - run:
+          name: ginkgo k8s e2e tests
+          command: make build-binary test-kubernetes
+          no_output_timeout: "30m"
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_logs
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_output
+  k8s-windows-1.8-release-e2e-master:
+    working_directory: /go/src/github.com/Azure/acs-engine
+    docker:
+      - image: quay.io/deis/go-dev:v1.2.0
+        environment:
+          GOPATH: /go
+    steps:
+      - checkout
+      - run: |
+          echo 'export TIMEOUT=15m' >> $BASH_ENV
+          echo 'export ORCHESTRATOR_RELEASE=1.8' >> $BASH_ENV
+          echo 'export CLUSTER_DEFINITION=examples/windows/kubernetes.json' >> $BASH_ENV
+          echo 'export CLIENT_ID=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID}' >> $BASH_ENV
+          echo 'export CLIENT_SECRET=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET}' >> $BASH_ENV
+      - run:
+          name: ginkgo k8s windows e2e tests
+          command: make build-binary test-kubernetes
+          no_output_timeout: "30m"
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_logs
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_output
+  k8s-hybrid-1.8-release-e2e-master:
+    working_directory: /go/src/github.com/Azure/acs-engine
+    docker:
+      - image: quay.io/deis/go-dev:v1.2.0
+        environment:
+          GOPATH: /go
+    steps:
+      - checkout
+      - run: |
+          echo 'export ORCHESTRATOR_RELEASE=1.8' >> $BASH_ENV
+          echo 'export TIMEOUT=15m' >> $BASH_ENV
+          echo 'export CLUSTER_DEFINITION=examples/windows/kubernetes-hybrid.json' >> $BASH_ENV
+          echo 'export CLIENT_ID=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_ID}' >> $BASH_ENV
+          echo 'export CLIENT_SECRET=${CLUSTER_SERVICE_PRINCIPAL_CLIENT_SECRET}' >> $BASH_ENV
+      - run:
+          name: ginkgo k8s hybrid e2e tests
+          command: make build-binary test-kubernetes
+          no_output_timeout: "30m"
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_logs
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_output
 workflows:
   version: 2
   build_and_test:
@@ -350,6 +416,24 @@ workflows:
           filters:
             branches:
               ignore: master
+      - k8s-1.8-release-e2e:
+          requires:
+            - pr-e2e-hold
+          filters:
+            branches:
+              ignore: master
+      - k8s-windows-1.8-release-e2e:
+          requires:
+            - pr-e2e-hold
+          filters:
+            branches:
+              ignore: master
+      - k8s-hybrid-1.8-release-e2e:
+          requires:
+            - pr-e2e-hold
+          filters:
+            branches:
+              ignore: master
       - k8s-1.6-release-e2e-master:
           requires:
             - test
@@ -373,7 +457,25 @@ workflows:
             - test
           filters:
             branches:
-              only: master              
+              only: master
+      - k8s-1.8-release-e2e-master:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master
+      - k8s-windows-1.8-release-e2e-master:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master
+      - k8s-hybrid-1.8-release-e2e-master:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master
       - swarm-e2e:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,24 +524,6 @@ workflows:
           filters:
             branches:
               only: master
-      - k8s-1.8-release-e2e-master:
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
-      - k8s-windows-1.8-release-e2e-master:
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
-      - k8s-hybrid-1.8-release-e2e-master:
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
       - swarm-e2e:
           requires:
             - test

--- a/parts/kubernetesmastercustomdata.yml
+++ b/parts/kubernetesmastercustomdata.yml
@@ -199,7 +199,7 @@ write_files:
     KUBELET_NETWORK_PLUGIN=
     KUBELET_MAX_PODS=110
     DOCKER_OPTS=
-    KUBELET_NODE_LABELS=role=master
+    KUBELET_NODE_LABELS=kubernetes.io/role=master
     KUBELET_POD_INFRA_CONTAINER_IMAGE={{WrapAsVariable "kubernetesPodInfraContainerSpec"}}
     KUBELET_NODE_STATUS_UPDATE_FREQUENCY={{WrapAsVariable "kubernetesNodeStatusUpdateFrequency"}}
     KUBE_CTRL_MGR_NODE_MONITOR_GRACE_PERIOD={{WrapAsVariable "kubernetesCtrlMgrNodeMonitorGracePeriod"}}

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -92,6 +92,31 @@ const (
 // KubeConfigs represents Docker images used for Kubernetes components based on Kubernetes releases (major.minor)
 // For instance, Kubernetes release "1.7" would contain the version "1.7.2"
 var KubeConfigs = map[string]map[string]string{
+	api.KubernetesRelease1Dot8: {
+		"hyperkube":       "hyperkube-amd64:v1.8.0",
+		"dashboard":       "kubernetes-dashboard-amd64:v1.7.0",
+		"exechealthz":     "exechealthz-amd64:1.2",
+		"addonresizer":    "addon-resizer:1.7",
+		"heapster":        "heapster-amd64:v1.4.2",
+		"dns":             "k8s-dns-kube-dns-amd64:1.14.5",
+		"addonmanager":    "kube-addon-manager-amd64:v6.4-beta.2",
+		"dnsmasq":         "k8s-dns-dnsmasq-nanny-amd64:1.14.5",
+		"pause":           "pause-amd64:3.0",
+		"tiller":          DefaultTillerImage,
+		"windowszip":      "v1.8.0-1intwinnat.zip",
+		"nodestatusfreq":  DefaultKubernetesNodeStatusUpdateFrequency,
+		"nodegraceperiod": DefaultKubernetesCtrlMgrNodeMonitorGracePeriod,
+		"podeviction":     DefaultKubernetesCtrlMgrPodEvictionTimeout,
+		"routeperiod":     DefaultKubernetesCtrlMgrRouteReconciliationPeriod,
+		"backoffretries":  strconv.Itoa(DefaultKubernetesCloudProviderBackoffRetries),
+		"backoffjitter":   strconv.FormatFloat(DefaultKubernetesCloudProviderBackoffJitter, 'f', -1, 64),
+		"backoffduration": strconv.Itoa(DefaultKubernetesCloudProviderBackoffDuration),
+		"backoffexponent": strconv.FormatFloat(DefaultKubernetesCloudProviderBackoffExponent, 'f', -1, 64),
+		"ratelimitqps":    strconv.FormatFloat(DefaultKubernetesCloudProviderRateLimitQPS, 'f', -1, 64),
+		"ratelimitbucket": strconv.Itoa(DefaultKubernetesCloudProviderRateLimitBucket),
+		"gchighthreshold": strconv.Itoa(DefaultKubernetesGCHighThreshold),
+		"gclowthreshold":  strconv.Itoa(DefaultKubernetesGCLowThreshold),
+	},
 	api.KubernetesRelease1Dot7: {
 		"hyperkube":       "hyperkube-amd64:v1.7.5",
 		"dashboard":       "kubernetes-dashboard-amd64:v1.6.3",

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -733,7 +733,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		},
 		"GetKubernetesLabels": func(profile *api.AgentPoolProfile) string {
 			var buf bytes.Buffer
-			buf.WriteString(fmt.Sprintf("role=agent,agentpool=%s", profile.Name))
+			buf.WriteString(fmt.Sprintf("kubernetes.io/role=agent,agentpool=%s", profile.Name))
 			if profile.StorageProfile == api.ManagedDisks {
 				storagetier, _ := getStorageAccountType(profile.VMSize)
 				buf.WriteString(fmt.Sprintf(",storageprofile=managed,storagetier=%s", storagetier))

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -39,6 +39,8 @@ const (
 )
 
 const (
+	// KubernetesRelease1Dot8 is the major.minor string prefix for 1.8 versions of kubernetes
+	KubernetesRelease1Dot8 string = "1.8"
 	// KubernetesRelease1Dot7 is the major.minor string prefix for 1.7 versions of kubernetes
 	KubernetesRelease1Dot7 string = "1.7"
 	// KubernetesRelease1Dot6 is the major.minor string prefix for 1.6 versions of kubernetes
@@ -51,6 +53,7 @@ const (
 
 // KubeReleaseToVersion maps a major.minor release to an full major.minor.patch version
 var KubeReleaseToVersion = map[string]string{
+	KubernetesRelease1Dot8: "1.8.0",
 	KubernetesRelease1Dot7: "1.7.5",
 	KubernetesRelease1Dot6: "1.6.9",
 	KubernetesRelease1Dot5: "1.5.7",

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -68,6 +68,8 @@ const (
 )
 
 const (
+	// KubernetesRelease1Dot8 is the major.minor string prefix for 1.8 versions of kubernetes
+	KubernetesRelease1Dot8 string = "1.8"
 	// KubernetesRelease1Dot7 is the major.minor string prefix for 1.7 versions of kubernetes
 	KubernetesRelease1Dot7 string = "1.7"
 	// KubernetesRelease1Dot6 is the major.minor string prefix for 1.6 versions of kubernetes

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -99,6 +99,7 @@ var DCOSReleaseToVersion = map[string]string{
 
 // KubernetesReleaseToVersion maps a major.minor release to an full major.minor.patch version
 var KubernetesReleaseToVersion = map[string]string{
+	KubernetesRelease1Dot8: "1.8.0",
 	KubernetesRelease1Dot7: "1.7.5",
 	KubernetesRelease1Dot6: "1.6.9",
 	KubernetesRelease1Dot5: "1.5.7",

--- a/pkg/api/convertertoagentpoolonlyapi.go
+++ b/pkg/api/convertertoagentpoolonlyapi.go
@@ -191,7 +191,7 @@ func convertV20170831AgentPoolOnlyOrchestratorProfile(kubernetesRelease string) 
 	}
 
 	switch kubernetesRelease {
-	case KubernetesRelease1Dot7, KubernetesRelease1Dot6, KubernetesRelease1Dot5:
+	case KubernetesRelease1Dot8, KubernetesRelease1Dot7, KubernetesRelease1Dot6, KubernetesRelease1Dot5:
 		orchestratorProfile.OrchestratorRelease = kubernetesRelease
 	default:
 		orchestratorProfile.OrchestratorRelease = KubernetesDefaultRelease
@@ -207,7 +207,7 @@ func convertVLabsAgentPoolOnlyOrchestratorProfile(kubernetesRelease string) *Orc
 	}
 
 	switch kubernetesRelease {
-	case KubernetesRelease1Dot7, KubernetesRelease1Dot6, KubernetesRelease1Dot5:
+	case KubernetesRelease1Dot8, KubernetesRelease1Dot7, KubernetesRelease1Dot6, KubernetesRelease1Dot5:
 		orchestratorProfile.OrchestratorRelease = kubernetesRelease
 	default:
 		orchestratorProfile.OrchestratorRelease = KubernetesDefaultRelease

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -563,7 +563,7 @@ func convertV20170701OrchestratorProfile(v20170701cs *v20170701.OrchestratorProf
 	switch api.OrchestratorType {
 	case Kubernetes:
 		switch v20170701cs.OrchestratorRelease {
-		case KubernetesRelease1Dot7, KubernetesRelease1Dot6, KubernetesRelease1Dot5:
+		case KubernetesRelease1Dot8, KubernetesRelease1Dot7, KubernetesRelease1Dot6, KubernetesRelease1Dot5:
 			api.OrchestratorRelease = v20170701cs.OrchestratorRelease
 		default:
 			api.OrchestratorRelease = KubernetesDefaultRelease
@@ -592,7 +592,7 @@ func convertVLabsOrchestratorProfile(vlabscs *vlabs.OrchestratorProfile, api *Or
 		}
 
 		switch vlabscs.OrchestratorRelease {
-		case KubernetesRelease1Dot7, KubernetesRelease1Dot6, KubernetesRelease1Dot5:
+		case KubernetesRelease1Dot8, KubernetesRelease1Dot7, KubernetesRelease1Dot6, KubernetesRelease1Dot5:
 			api.OrchestratorRelease = vlabscs.OrchestratorRelease
 		default:
 			api.OrchestratorRelease = KubernetesDefaultRelease

--- a/pkg/api/v20170701/validate.go
+++ b/pkg/api/v20170701/validate.go
@@ -38,6 +38,7 @@ func (o *OrchestratorProfile) Validate() error {
 	case DockerCE:
 	case Kubernetes:
 		switch o.OrchestratorRelease {
+		case common.KubernetesRelease1Dot8:
 		case common.KubernetesRelease1Dot7:
 		case common.KubernetesRelease1Dot6:
 		case common.KubernetesRelease1Dot5:

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -44,6 +44,7 @@ func (o *OrchestratorProfile) Validate() error {
 
 	case Kubernetes:
 		switch o.OrchestratorRelease {
+		case common.KubernetesRelease1Dot8:
 		case common.KubernetesRelease1Dot7:
 		case common.KubernetesRelease1Dot6:
 		case common.KubernetesRelease1Dot5:
@@ -58,8 +59,8 @@ func (o *OrchestratorProfile) Validate() error {
 				return err
 			}
 			if o.KubernetesConfig.EnableAggregatedAPIs {
-				if o.OrchestratorRelease != common.KubernetesRelease1Dot7 {
-					return fmt.Errorf("enableAggregatedAPIs is only available in Kubernetes version %s; unable to validate for Kubernetes version %s",
+				if (o.OrchestratorRelease != common.KubernetesRelease1Dot7) || (o.OrchestratorRelease != common.KubernetesRelease1Dot8) {
+					return fmt.Errorf("enableAggregatedAPIs is only available in Kubernetes version %s or greater; unable to validate for Kubernetes version %s",
 						common.KubernetesRelease1Dot7, o.OrchestratorRelease)
 				}
 
@@ -388,6 +389,7 @@ func (a *KubernetesConfig) Validate(k8sRelease string) error {
 	const minKubeletRetries = 4
 	// k8s releases that have cloudprovider backoff enabled
 	var backoffEnabledReleases = map[string]bool{
+		common.KubernetesRelease1Dot8: true,
 		common.KubernetesRelease1Dot7: true,
 		common.KubernetesRelease1Dot6: true,
 	}

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -59,7 +59,7 @@ func (o *OrchestratorProfile) Validate() error {
 				return err
 			}
 			if o.KubernetesConfig.EnableAggregatedAPIs {
-				if (o.OrchestratorRelease != common.KubernetesRelease1Dot7) || (o.OrchestratorRelease != common.KubernetesRelease1Dot8) {
+				if o.OrchestratorRelease == common.KubernetesRelease1Dot5 || o.OrchestratorRelease == common.KubernetesRelease1Dot6 {
 					return fmt.Errorf("enableAggregatedAPIs is only available in Kubernetes version %s or greater; unable to validate for Kubernetes version %s",
 						common.KubernetesRelease1Dot7, o.OrchestratorRelease)
 				}

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -53,7 +53,7 @@ func Test_OrchestratorProfile_Validate(t *testing.T) {
 
 func Test_KubernetesConfig_Validate(t *testing.T) {
 	// Tests that should pass across all releases
-	for _, k8sRelease := range []string{common.KubernetesRelease1Dot5, common.KubernetesRelease1Dot6, common.KubernetesRelease1Dot7} {
+	for _, k8sRelease := range []string{common.KubernetesRelease1Dot5, common.KubernetesRelease1Dot6, common.KubernetesRelease1Dot7, common.KubernetesRelease1Dot8} {
 		c := KubernetesConfig{}
 		if err := c.Validate(k8sRelease); err != nil {
 			t.Errorf("should not error on empty KubernetesConfig: %v, release %s", err, k8sRelease)
@@ -212,7 +212,7 @@ func Test_KubernetesConfig_Validate(t *testing.T) {
 	}
 
 	// Tests that apply to 1.6 and later releases
-	for _, k8sRelease := range []string{common.KubernetesRelease1Dot6, common.KubernetesRelease1Dot7} {
+	for _, k8sRelease := range []string{common.KubernetesRelease1Dot6, common.KubernetesRelease1Dot7, common.KubernetesRelease1Dot8} {
 		c := KubernetesConfig{
 			CloudProviderBackoff:   true,
 			CloudProviderRateLimit: true,

--- a/scripts/build-windows-k8s.sh
+++ b/scripts/build-windows-k8s.sh
@@ -87,11 +87,28 @@ k8s_17_cherry_pick() {
         git cherry-pick 51fab673e1..72b9c8f519
 }
 
+k8s_18_cherry_pick() {
+	# 72b9c8f519 Add start time for root container spec
+	# b7c4184821 Fix windows docker stats cpu units issue
+	# 51fab673e1 Merge pull request #3 from JiangtianLi/release-1.7
+	# 45ba7bb0fb Implement metrics for Windows Containers
+	# 76b94898ec Use dns policy to determine setting DNS servers on the correct NIC in Windows container
+	# 74a2f37447 Fix network config due to the split of start POD sandbox and start container from 1.7.0
+	# 5fc0a5e4a2 Workaround for Outbound Internet traffic in Azure Kubernetes (*) Connect a Nat Network to the container (Second adapter) (*) Modify the route so that internet traffic goes via Nat network, and POD traffic goes over the CONTAINER_NETWORK (*) Modify getContainerIP to return the IP corresponding to POD network, and ignore Nat Network (*) DNS Fix for ACS Kubernetes in Windows
+	# adeb88d774 Use adapter vEthernet (HNSTransparent) on Windows host network to find node IP
+	# 02549d6647 Merge pull request #50914 from shyamjvs/add-logging-to-logdump
+
+	git cherry-pick 02549d6647..45ba7bb0fb
+	git cherry-pick 51fab673e1..72b9c8f519
+}
+
 apply_acs_cherry_picks() {
 	if [ "${KUBERNETES_RELEASE}" == "1.6" ]; then
 		k8s_16_cherry_pick
 	elif [ "${KUBERNETES_RELEASE}" == "1.7" ]; then
 		k8s_17_cherry_pick
+	elif [ "${KUBERNETES_RELEASE}" == "1.8" ]; then
+		k8s_18_cherry_pick
 	else
 		echo "Unable to apply cherry picks for ${KUBERNETES_RELEASE}."
 		exit 1


### PR DESCRIPTION
This PR enables Kubernetes 1.8. It doesn't however add it to the upgrade logic in acs-engine.