### PR TITLE
updating k8s version const references of v1.5.7 to v1.5.8

### DIFF
--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -56,7 +56,7 @@ var KubeReleaseToVersion = map[string]string{
 	KubernetesRelease1Dot8: "1.8.0",
 	KubernetesRelease1Dot7: "1.7.7",
 	KubernetesRelease1Dot6: "1.6.11",
-	KubernetesRelease1Dot5: "1.5.7",
+	KubernetesRelease1Dot5: "1.5.8",
 }
 
 const (

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -102,7 +102,7 @@ var KubernetesReleaseToVersion = map[string]string{
 	KubernetesRelease1Dot8: "1.8.0",
 	KubernetesRelease1Dot7: "1.7.7",
 	KubernetesRelease1Dot6: "1.6.11",
-	KubernetesRelease1Dot5: "1.5.7",
+	KubernetesRelease1Dot5: "1.5.8",
 }
 
 // To identify programmatically generated public agent pools

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -67,7 +67,7 @@ func (mc *MockACSEngineClient) ListVirtualMachines(resourceGroup string) (comput
 	resourceNameSuffixString := "resourceNameSuffix"
 
 	creationSource := "acsengine-k8s-master-12345678-0"
-	orchestrator := "Kubernetes:1.5.7"
+	orchestrator := "Kubernetes:1.5.8"
 	resourceNameSuffix := "12345678"
 
 	tags := map[string]*string{
@@ -124,7 +124,7 @@ func (mc *MockACSEngineClient) GetVirtualMachine(resourceGroup, name string) (co
 	resourceNameSuffixString := "resourceNameSuffix"
 
 	creationSource := "acsengine-k8s-master-12345678-0"
-	orchestrator := "Kubernetes:1.5.7"
+	orchestrator := "Kubernetes:1.5.8"
 	resourceNameSuffix := "12345678"
 
 	tags := map[string]*string{

--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 
 		err := uc.UpgradeCluster(subID, "TestRg", cs, "12345678")
 		Expect(err).NotTo(BeNil())
-		Expect(err.Error()).To(Equal("Error while querying ARM for resources: Kubernetes:1.5.7 in non-upgradable to 1.7"))
+		Expect(err.Error()).To(Equal("Error while querying ARM for resources: Kubernetes:1.5.8 in non-upgradable to 1.7"))
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
