### PR TITLE
feat(v20170831): agent pools for v20170831 must use ManagedDisks

### DIFF
--- a/pkg/api/agentPoolOnlyApi/v20170831/const.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/const.go
@@ -26,8 +26,6 @@ const (
 
 // storage profiles
 const (
-	// StorageAccount means that the nodes use raw storage accounts for their os and attached volumes
-	StorageAccount = "StorageAccount"
 	// ManagedDisks means that the nodes use managed disks for their os and attached volumes
 	ManagedDisks = "ManagedDisks"
 )

--- a/pkg/api/agentPoolOnlyApi/v20170831/types.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/types.go
@@ -103,7 +103,7 @@ type AgentPoolProfile struct {
 	Count          int    `json:"count" validate:"required,min=1,max=100"`
 	VMSize         string `json:"vmSize" validate:"required"`
 	OSDiskSizeGB   int    `json:"osDiskSizeGB,omitempty" validate:"min=0,max=1023"`
-	StorageProfile string `json:"storageProfile" validate:"eq=StorageAccount|eq=ManagedDisks|len=0"`
+	StorageProfile string `json:"storageProfile" validate:"eq=ManagedDisks|len=0"`
 	VnetSubnetID   string `json:"vnetSubnetID,omitempty"`
 
 	// OSType is the operating system type for agents
@@ -137,8 +137,8 @@ func (a *AgentPoolProfile) UnmarshalJSON(b []byte) error {
 	}
 
 	if a.StorageProfile == "" {
-		// if StorageProfile is missing, set to default StorageAccount
-		a.StorageProfile = StorageAccount
+		// if StorageProfile is missing, set to default ManagedDisks
+		a.StorageProfile = ManagedDisks
 	}
 
 	if string(a.OSType) == "" {
@@ -195,9 +195,4 @@ func (a *AgentPoolProfile) SetSubnet(subnet string) {
 // IsManagedDisks returns true if the customer specified managed disks
 func (a *AgentPoolProfile) IsManagedDisks() bool {
 	return a.StorageProfile == ManagedDisks
-}
-
-// IsStorageAccount returns true if the customer specified storage account
-func (a *AgentPoolProfile) IsStorageAccount() bool {
-	return a.StorageProfile == StorageAccount
 }

--- a/pkg/api/agentPoolOnlyApi/v20170831/types_test.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/types_test.go
@@ -21,7 +21,7 @@ func TestAgentPoolProfile(t *testing.T) {
 		t.Fatalf("unexpectedly detected AgentPoolProfile.OSType != Linux after unmarshal")
 	}
 
-	if !ap.IsStorageAccount() {
-		t.Fatalf("unexpectedly detected AgentPoolProfile.StorageProfile != StorageAccount after unmarshal")
+	if !ap.IsManagedDisks() {
+		t.Fatalf("unexpectedly detected AgentPoolProfile.StorageProfile != ManagedDisks after unmarshal")
 	}
 }

--- a/pkg/api/agentPoolOnlyApi/v20170831/validate.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/validate.go
@@ -53,7 +53,7 @@ func handleValidationErrors(e validator.ValidationErrors) error {
 			case strings.HasSuffix(ns, ".OSDiskSizeGB"):
 				return fmt.Errorf("Invalid os disk size of %d specified.  The range of valid values are [%d, %d]", err.Value().(int), MinDiskSizeGB, MaxDiskSizeGB)
 			case strings.HasSuffix(ns, ".StorageProfile"):
-				return fmt.Errorf("Unknown storageProfile '%s'. Specify either %s or %s", err.Value().(string), StorageAccount, ManagedDisks)
+				return fmt.Errorf("Unknown storageProfile '%s'. Must specify %s", err.Value().(string), ManagedDisks)
 			default:
 				break
 			}


### PR DESCRIPTION
This ensures that Kubernetes agents created via the v20170831 API use ManagedDisks.