### PR TITLE
fix reference to old k8sRelease

### DIFF
--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -97,14 +97,14 @@ func Test_KubernetesConfig_Validate(t *testing.T) {
 		c = KubernetesConfig{
 			NonMasqueradeCidr: "10.120.1.0/24",
 		}
-		if err := c.Validate(k8sRelease); err != nil {
+		if err := c.Validate(k8sVersion); err != nil {
 			t.Error("should not error on valid NonMasqueradeCidr")
 		}
 
 		c = KubernetesConfig{
 			NonMasqueradeCidr: "10.120.1.0/invalid",
 		}
-		if err := c.Validate(k8sRelease); err == nil {
+		if err := c.Validate(k8sVersion); err == nil {
 			t.Error("should error on invalid NonMasqueradeCidr")
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
