### PR TITLE
change default value for fqdnEndpointSuffix to match public azure sce…

### DIFF
--- a/parts/masterparams.t
+++ b/parts/masterparams.t
@@ -109,7 +109,7 @@
       "type": "string"
     },
     "fqdnEndpointSuffix":{
-      "defaultValue": "%s.%s.cloudapp.azure.com",
+      "defaultValue": "cloudapp.azure.com",
       "metadata": {
         "description": "Endpoint of FQDN."
       },


### PR DESCRIPTION
…nario

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
The default value cause classicMode failure. The default value get introduced in #499
I want to make the default value conform with public azure, and let sovereignty cloud to override based on their use cases.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
