### PR TITLE
feat(test/e2e/dcos): Add a wait condition for node health when provisioning dcos clusters

### DIFF
--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -104,6 +104,11 @@ func main() {
 			teardown()
 			log.Fatalf("Error trying to install dcos client:%s\n", err)
 		}
+		ready := cluster.WaitForNodes(eng.NodeCount(), 10*time.Second, cfg.Timeout)
+		if ready == false {
+			teardown()
+			log.Fatal("Error: Not all nodes in healthy state!")
+		}
 	}
 
 	runGinkgo(cfg.Orchestrator)


### PR DESCRIPTION
This should help with the dcos e2e flakiness we are seeing with the ginkgo suite