### PR TITLE
add ManagedClusterAccessProfile type to expose AccessProfile as a separate Get request for HCP

### DIFF
--- a/pkg/api/agentPoolOnlyApi/v20170831/types.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/types.go
@@ -40,6 +40,19 @@ type Properties struct {
 	AccessProfiles          map[string]AccessProfile `json:"accessProfiles,omitempty"`
 }
 
+// ManagedClusterAccessProfile represents the access profile definition for managed cluster
+// The Id captures the Role Name e.g. clusterAdmin, clusterUser
+type ManagedClusterAccessProfile struct {
+	ID       string                `json:"id,omitempty"`
+	Location string                `json:"location,omitempty" validate:"required"`
+	Name     string                `json:"name,omitempty"`
+	Plan     *ResourcePurchasePlan `json:"plan,omitempty"`
+	Tags     map[string]string     `json:"tags,omitempty"`
+	Type     string                `json:"type,omitempty"`
+
+	Properties *AccessProfile `json:"properties"`
+}
+
 // ServicePrincipalProfile contains the client and secret used by the cluster for Azure Resource CRUD
 // The 'Secret' parameter could be either a plain text, or referenced to a secret in a keyvault.
 // In the latter case, the format of the parameter's value should be

--- a/pkg/api/agentPoolOnlyApi/v20170831/types.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/types.go
@@ -43,12 +43,10 @@ type Properties struct {
 // ManagedClusterAccessProfile represents the access profile definition for managed cluster
 // The Id captures the Role Name e.g. clusterAdmin, clusterUser
 type ManagedClusterAccessProfile struct {
-	ID       string                `json:"id,omitempty"`
-	Location string                `json:"location,omitempty" validate:"required"`
-	Name     string                `json:"name,omitempty"`
-	Plan     *ResourcePurchasePlan `json:"plan,omitempty"`
-	Tags     map[string]string     `json:"tags,omitempty"`
-	Type     string                `json:"type,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Location string `json:"location,omitempty" validate:"required"`
+	Name     string `json:"name,omitempty"`
+	Type     string `json:"type,omitempty"`
 
 	Properties *AccessProfile `json:"properties"`
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
provide API for users to fetch clusterUser accessProfile

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #Feature #1432464

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
