### PR TITLE
removing unneeded valdiation that is failing update calls. This valid…

### DIFF
--- a/pkg/api/agentPoolOnlyApi/v20170831/types.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/types.go
@@ -52,7 +52,7 @@ type Properties struct {
 //    <VERSION> (optional) is the version of the secret (default: the latest version)
 type ServicePrincipalProfile struct {
 	ClientID string `json:"clientId,omitempty" validate:"required"`
-	Secret   string `json:"secret,omitempty" validate:"required"`
+	Secret   string `json:"secret,omitempty"`
 }
 
 // LinuxProfile represents the Linux configuration passed to the cluster
@@ -72,7 +72,7 @@ type PublicKey struct {
 // WindowsProfile represents the Windows configuration passed to the cluster
 type WindowsProfile struct {
 	AdminUsername string `json:"adminUsername,omitempty" validate:"required"`
-	AdminPassword string `json:"adminPassword,omitempty" validate:"required"`
+	AdminPassword string `json:"adminPassword,omitempty"`
 }
 
 // ProvisioningState represents the current state of container service resource.

--- a/pkg/api/agentPoolOnlyApi/v20170831/validate.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/validate.go
@@ -78,19 +78,6 @@ func (a *Properties) Validate() error {
 		return e
 	}
 
-	for _, agentPoolProfile := range a.AgentPoolProfiles {
-		if agentPoolProfile.OSType == Windows {
-			if a.WindowsProfile == nil {
-				return fmt.Errorf("WindowsProfile must not be empty since agent pool '%s' specifies windows", agentPoolProfile.Name)
-			}
-			if len(a.WindowsProfile.AdminUsername) == 0 {
-				return fmt.Errorf("WindowsProfile.AdminUsername must not be empty since agent pool '%s' specifies windows", agentPoolProfile.Name)
-			}
-			if len(a.WindowsProfile.AdminPassword) == 0 {
-				return fmt.Errorf("WindowsProfile.AdminPassword must not be empty since  agent pool '%s' specifies windows", agentPoolProfile.Name)
-			}
-		}
-	}
 	if e := a.LinuxProfile.Validate(); e != nil {
 		return e
 	}

--- a/pkg/api/agentPoolOnlyApi/v20170831/validate.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/validate.go
@@ -78,10 +78,6 @@ func (a *Properties) Validate() error {
 		return e
 	}
 
-	if a.ServicePrincipalProfile == nil {
-		return fmt.Errorf("missing ServicePrincipalProfile")
-	}
-
 	for _, agentPoolProfile := range a.AgentPoolProfiles {
 		if agentPoolProfile.OSType == Windows {
 			if a.WindowsProfile == nil {

--- a/pkg/api/agentPoolOnlyApi/vlabs/types.go
+++ b/pkg/api/agentPoolOnlyApi/vlabs/types.go
@@ -53,7 +53,7 @@ type Properties struct {
 //    <VERSION> (optional) is the version of the secret (default: the latest version)
 type ServicePrincipalProfile struct {
 	ClientID string `json:"clientId,omitempty" validate:"required"`
-	Secret   string `json:"secret,omitempty" validate:"required"`
+	Secret   string `json:"secret,omitempty"`
 }
 
 // CertificateProfile contains cert material for the Kubernetes cluster
@@ -93,7 +93,7 @@ type PublicKey struct {
 // WindowsProfile represents the Windows configuration passed to the cluster
 type WindowsProfile struct {
 	AdminUsername string `json:"adminUsername,omitempty" validate:"required"`
-	AdminPassword string `json:"adminPassword,omitempty" validate:"required"`
+	AdminPassword string `json:"adminPassword,omitempty"`
 	ImageVersion  string `json:"imageVersion,omitempty"`
 }
 

--- a/pkg/api/agentPoolOnlyApi/vlabs/validate.go
+++ b/pkg/api/agentPoolOnlyApi/vlabs/validate.go
@@ -78,19 +78,6 @@ func (a *Properties) Validate() error {
 		return e
 	}
 
-	for _, agentPoolProfile := range a.AgentPoolProfiles {
-		if agentPoolProfile.OSType == Windows {
-			if a.WindowsProfile == nil {
-				return fmt.Errorf("WindowsProfile must not be empty since agent pool '%s' specifies windows", agentPoolProfile.Name)
-			}
-			if len(a.WindowsProfile.AdminUsername) == 0 {
-				return fmt.Errorf("WindowsProfile.AdminUsername must not be empty since agent pool '%s' specifies windows", agentPoolProfile.Name)
-			}
-			if len(a.WindowsProfile.AdminPassword) == 0 {
-				return fmt.Errorf("WindowsProfile.AdminPassword must not be empty since  agent pool '%s' specifies windows", agentPoolProfile.Name)
-			}
-		}
-	}
 	if e := a.LinuxProfile.Validate(); e != nil {
 		return e
 	}

--- a/pkg/api/agentPoolOnlyApi/vlabs/validate.go
+++ b/pkg/api/agentPoolOnlyApi/vlabs/validate.go
@@ -78,10 +78,6 @@ func (a *Properties) Validate() error {
 		return e
 	}
 
-	if a.ServicePrincipalProfile == nil {
-		return fmt.Errorf("missing ServicePrincipalProfile")
-	}
-
 	for _, agentPoolProfile := range a.AgentPoolProfiles {
 		if agentPoolProfile.OSType == Windows {
 			if a.WindowsProfile == nil {


### PR DESCRIPTION
…ation is done better in the service code and these types can only be created through the service

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Service is failing to do a get then update as the serviceprincipal isn't returned fully in get. Allowing it to be empty