### PR TITLE
fix 1.6 under new image

### DIFF
--- a/parts/kubernetesagentcustomdata.yml
+++ b/parts/kubernetesagentcustomdata.yml
@@ -119,6 +119,11 @@ write_files:
 {{if IsKubernetesVersionGe "1.6.0"}}
     KUBELET_NON_MASQUERADE_CIDR=--non-masquerade-cidr={{WrapAsVariable "kubernetesNonMasqueradeCidr"}}
     KUBELET_FEATURE_GATES=--feature-gates=Accelerators=true
+  {{if IsKubernetesVersionTilde "1.6.x"}}
+    KUBELET_FIX_43704_1=--cgroups-per-qos=false
+    KUBELET_FIX_43704_2=--enforce-node-allocatable=
+    KUBELET_FIX_43704_3=""
+  {{end}}
 {{end}}
 
 - path: "/etc/systemd/system/kubelet.service"

--- a/parts/kuberneteskubelet.service
+++ b/parts/kuberneteskubelet.service
@@ -37,6 +37,8 @@ ExecStart=/usr/bin/docker run \
         --pod-infra-container-image="${KUBELET_POD_INFRA_CONTAINER_IMAGE}" \
         --address=0.0.0.0 \
         --allow-privileged=true \
+        ${KUBELET_FIX_43704_1} \
+        ${KUBELET_FIX_43704_2}${KUBELET_FIX_43704_3} \
         --enable-server \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster-dns=${KUBELET_CLUSTER_DNS} \

--- a/parts/kubernetesmastercustomdata.yml
+++ b/parts/kubernetesmastercustomdata.yml
@@ -215,9 +215,15 @@ write_files:
     KUBELET_REGISTER_NODE=--register-node=true
     KUBELET_REGISTER_WITH_TAINTS=--register-with-taints={{WrapAsVariable "registerWithTaints"}}
   {{end}}
+  {{if IsKubernetesVersionTilde "1.6.x"}}
+    KUBELET_FIX_43704_1=--cgroups-per-qos=false
+    KUBELET_FIX_43704_2=--enforce-node-allocatable=
+    KUBELET_FIX_43704_3=""
+  {{end}}
 {{else}}
     KUBELET_REGISTER_SCHEDULABLE={{WrapAsVariable "registerSchedulable"}}
 {{end}}
+
 - path: "/etc/systemd/system/kubelet.service"
   permissions: "0644"
   encoding: gzip

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -732,6 +732,14 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			constraint, _ := semver.NewConstraint(">=" + version)
 			return cs.Properties.OrchestratorProfile.OrchestratorType == api.Kubernetes && constraint.Check(orchestratorVersion)
 		},
+		"IsKubernetesVersionTilde": func(version string) bool {
+			// examples include
+			// ~2.3 is equivalent to >= 2.3, < 2.4
+			// ~1.2.x is equivalent to >= 1.2.0, < 1.3.0
+			orchestratorVersion, _ := semver.NewVersion(cs.Properties.OrchestratorProfile.OrchestratorVersion)
+			constraint, _ := semver.NewConstraint("~" + version)
+			return cs.Properties.OrchestratorProfile.OrchestratorType == api.Kubernetes && constraint.Check(orchestratorVersion)
+		},
 		"GetKubernetesLabels": func(profile *api.AgentPoolProfile) string {
 			var buf bytes.Buffer
 			buf.WriteString(fmt.Sprintf("kubernetes.io/role=agent,agentpool=%s", profile.Name))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Kubernetes 1.6 does not start under the new Ubuntu October image.  This is discussed in https://github.com/kubernetes/kubernetes/issues/43704.  This PR applies the mitigation for 1.6.
