### PR TITLE
adding test that cluster ip works which should fill gap in our c…

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -129,7 +129,6 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 			s, err := service.Get("kubernetes-dashboard", "kube-system")
 			Expect(err).NotTo(HaveOccurred())
-
 			port := s.GetNodePort(80)
 
 			master := fmt.Sprintf("azureuser@%s", kubeConfig.GetServerName())


### PR DESCRIPTION
…urrent validation for vnets

**What this PR does / why we need it**:
Custom vnets are broken and our validation isn't catching it currently. This should catch the gap then I can use it to identify which PR broke us.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: should help with investigations into #1603 #1595 

