### PR TITLE
Convert all Kubernetes VM prefix names to lowercase, and add validation to agent pools only models

### DIFF
--- a/pkg/api/agentPoolOnlyApi/v20170831/validate.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/validate.go
@@ -78,6 +78,12 @@ func (a *Properties) Validate() error {
 		return e
 	}
 
+	for _, agentPoolProfile := range a.AgentPoolProfiles {
+		if e := agentPoolProfile.Validate(); e != nil {
+			return e
+		}
+	}
+
 	if e := a.LinuxProfile.Validate(); e != nil {
 		return e
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:  Kubernetes Agent Pool names cause VM names to be uppercase.  However, kubernetes cannot handle mixed case VM names, because the cloud provider makes them lowercase.  This PR ensure VM names end up as lowercase by adding validation to agent pool only configuration.

