### PR TITLE
Doc update: attach route table to VNET

### DIFF
--- a/docs/custom-vnet.md
+++ b/docs/custom-vnet.md
@@ -174,7 +174,7 @@ For Kubernetes clusters, we need to update the VNET to attach to the route table
 
 ```
 #!/bin/bash
-rt=$(az network route-table list -g acs-custom-vnet | jq -r '.[].name')
+rt=$(az network route-table list -g acs-custom-vnet | jq -r '.[].id')
 az network vnet subnet update -n KubernetesSubnet -g acs-custom-vnet --vnet-name KubernetesCustomVNET --route-table $rt
 ```
 

--- a/docs/custom-vnet.md
+++ b/docs/custom-vnet.md
@@ -168,5 +168,17 @@ az group deployment create -g acs-custom-vnet --name "ClusterDeployment" --templ
 
 Depending on the number of agent you have asked for the deployment can take a while.
 
+## Post-Deployment: Attach Cluster Route Table to VNET
+
+For Kubernetes clusters, we need to update the VNET to attach to the route table created by the above `az group deployment create` command. An example in bash form:
+
+```
+#!/bin/bash
+rt=$(az network route-table list -g acs-custom-vnet | jq -r '.[].name')
+az network vnet subnet update -n KubernetesSubnet -g acs-custom-vnet --vnet-name KubernetesCustomVNET --route-table $rt
+```
+
+... where `KubernetesSubnet` is the name of the vnet subnet, and `KubernetesCustomVNET` is the name of the custom VNET itself.
+
 ## Connect to your new cluster
 Once the deployment is completed, you can follow [this documentation](https://docs.microsoft.com/en-us/azure/container-service/container-service-connect) to connect to your new Azure Container Service cluster.

--- a/examples/vnet/k8s-vnet-postdeploy.sh
+++ b/examples/vnet/k8s-vnet-postdeploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-rt=$(az network route-table list -g ${RESOURCE_GROUP} | jq -r '.[].name')
+rt=$(az network route-table list -g ${RESOURCE_GROUP} | jq -r '.[].id')
 
 az network vnet subnet update -n KubernetesSubnet -g ${RESOURCE_GROUP} --vnet-name KubernetesCustomVNET --route-table $rt


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: In our custom VNET docs it doesn't mention the need to attach the created cluster's route table to the custom VNET

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
