### PR TITLE
Reduce size of Kube master customData

### DIFF
--- a/parts/kubernetesmastercustomdata.yml
+++ b/parts/kubernetesmastercustomdata.yml
@@ -165,7 +165,7 @@ write_files:
   encoding: gzip
   owner: "root"
   content: !!binary |
-    MASTER_ADDON_CALICO_DAEMONSET_B64_GZIP_STR
+    {{WrapAsVariable "masterAddonCalicoDaemonset"}}
 {{end}}
 
 - path: "/etc/systemd/system/kubectl-extract.service"

--- a/parts/kubernetesmastervars.t
+++ b/parts/kubernetesmastervars.t
@@ -277,3 +277,6 @@
     "singleQuote": "'",
     "windowsCustomScriptSuffix": " $inputFile = '%SYSTEMDRIVE%\\AzureData\\CustomData.bin' ; $outputFile = '%SYSTEMDRIVE%\\AzureData\\CustomDataSetupScript.ps1' ; Copy-Item $inputFile $outputFile ; Invoke-Expression('{0} {1}' -f $outputFile, $arguments) ; "
 {{end}}
+{{if eq .OrchestratorProfile.KubernetesConfig.NetworkPolicy "calico"}}
+    ,"masterAddonCalicoDaemonset": "{{GetKubernetesMasterCalicoCustomData .}}"
+{{end}}

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -132,9 +132,9 @@ var kubernetesAddonYamls15 = map[string]string{
 	"MASTER_ADDON_TILLER_DEPLOYMENT_B64_GZIP_STR":               "kubernetesmasteraddons-tiller-deployment1.5.yaml",
 }
 
-var calicoAddonYaml string = "kubernetesmasteraddons-calico-daemonset.yaml"
+var calicoAddonYaml = "kubernetesmasteraddons-calico-daemonset.yaml"
 
-var calicoAddonYaml15 string = "kubernetesmasteraddons-calico-daemonset1.5.yaml"
+var calicoAddonYaml15 = "kubernetesmasteraddons-calico-daemonset1.5.yaml"
 
 var commonTemplateFiles = []string{agentOutputs, agentParams, classicParams, masterOutputs, iaasOutputs, masterParams, windowsParams}
 var dcosTemplateFiles = []string{dcosBaseFile, dcosAgentResourcesVMAS, dcosAgentResourcesVMSS, dcosAgentVars, dcosMasterResources, dcosMasterVars, dcosParams, dcosWindowsAgentResourcesVMAS, dcosWindowsAgentResourcesVMSS}

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -915,14 +915,12 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 				str = strings.Replace(str, placeholder, addonTextContents, -1)
 			}
 
-
-
 			// return the custom data
 			return fmt.Sprintf("\"customData\": \"[base64(concat('%s'))]\",", str)
 		},
 		"GetKubernetesMasterCalicoCustomData": func(profile *api.Properties) string {
 			var calicoAddon string
-			
+
 			// add calico manifests
 			if profile.OrchestratorProfile.KubernetesConfig.NetworkPolicy == "calico" {
 				if profile.OrchestratorProfile.OrchestratorVersion == api.KubernetesVersion1Dot5Dot8 ||
@@ -930,8 +928,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 					calicoAddonYaml = calicoAddonYaml15
 				}
 				calicoAddon = getBase64CustomScript(calicoAddonYaml)
-			}	
-			return calicoAddon 
+			}
+			return calicoAddon
 		},
 		"GetKubernetesAgentCustomData": func(profile *api.AgentPoolProfile) string {
 			str, e := t.getSingleLineForTemplate(kubernetesAgentCustomDataYaml, cs, profile)


### PR DESCRIPTION
Fix for Issue #1637, reducing the size of Kubernetes master customData.
Suggesting a way to move out Base64 data to ARM variable to reduce ARM
limits

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
The Kubernetes customData is very close to the limit, even with  #1579, it reduces the size by 250 bytes.  This PR reduces the size of the customData by about 3k, and suggests a way to use ARM variables within customData, placing the Base64 parts in the ARM variables defintion.

**Which issue this PR fixes** *(optional, in `fixes #1637


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
