### PR TITLE
Kubernetes v1.8.2

### DIFF
--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -97,8 +97,8 @@ const (
 
 // KubeConfigs represents Docker images used for Kubernetes components based on Kubernetes versions (major.minor.patch)
 var KubeConfigs = map[string]map[string]string{
-	api.KubernetesVersion1Dot8Dot1: {
-		"hyperkube":       "hyperkube-amd64:v1.8.1",
+	api.KubernetesVersion1Dot8Dot2: {
+		"hyperkube":       "hyperkube-amd64:v1.8.2",
 		"dashboard":       "kubernetes-dashboard-amd64:v1.7.0",
 		"exechealthz":     "exechealthz-amd64:1.2",
 		"addonresizer":    "addon-resizer:1.7",
@@ -108,7 +108,7 @@ var KubeConfigs = map[string]map[string]string{
 		"dnsmasq":         "k8s-dns-dnsmasq-nanny-amd64:1.14.5",
 		"pause":           "pause-amd64:3.0",
 		"tiller":          DefaultTillerImage,
-		"windowszip":      "v1.8.1-1intwinnat.zip",
+		"windowszip":      "v1.8.1-1intwinnat.zip", // TODO build Windows 1.8.2 image
 		"nodestatusfreq":  DefaultKubernetesNodeStatusUpdateFrequency,
 		"nodegraceperiod": DefaultKubernetesCtrlMgrNodeMonitorGracePeriod,
 		"podeviction":     DefaultKubernetesCtrlMgrPodEvictionTimeout,

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -108,7 +108,7 @@ var KubeConfigs = map[string]map[string]string{
 		"dnsmasq":         "k8s-dns-dnsmasq-nanny-amd64:1.14.5",
 		"pause":           "pause-amd64:3.0",
 		"tiller":          DefaultTillerImage,
-		"windowszip":      "v1.8.1-1intwinnat.zip", // TODO build Windows 1.8.2 image
+		"windowszip":      "v1.8.2-1intwinnat.zip",
 		"nodestatusfreq":  DefaultKubernetesNodeStatusUpdateFrequency,
 		"nodegraceperiod": DefaultKubernetesCtrlMgrNodeMonitorGracePeriod,
 		"podeviction":     DefaultKubernetesCtrlMgrPodEvictionTimeout,

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -53,8 +53,8 @@ const (
 )
 
 const (
-	// KubernetesVersion1Dot8Dot1 is the major.minor.patch string for 1.8.1 versions of kubernetes
-	KubernetesVersion1Dot8Dot1 string = "1.8.1"
+	// KubernetesVersion1Dot8Dot2 is the major.minor.patch string for 1.8.2 versions of kubernetes
+	KubernetesVersion1Dot8Dot2 string = "1.8.2"
 	// KubernetesVersion1Dot7Dot7 is the major.minor.patch string for 1.7.9 versions of kubernetes
 	KubernetesVersion1Dot7Dot7 string = "1.7.9"
 	// KubernetesVersion1Dot6Dot11 is the major.minor.patch string for 1.6.11 versions of kubernetes
@@ -67,7 +67,7 @@ const (
 
 // AllKubernetesSupportedVersions maintain a list of available k8s versions in acs-engine
 var AllKubernetesSupportedVersions = []string{
-	KubernetesVersion1Dot8Dot1,
+	KubernetesVersion1Dot8Dot2,
 	KubernetesVersion1Dot7Dot7,
 	KubernetesVersion1Dot6Dot11,
 	KubernetesVersion1Dot5Dot8,

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -68,8 +68,8 @@ const (
 )
 
 const (
-	// KubernetesVersion1Dot8Dot1 is the major.minor.patch string for 1.8.1 versions of kubernetes
-	KubernetesVersion1Dot8Dot1 string = "1.8.1"
+	// KubernetesVersion1Dot8Dot2 is the major.minor.patch string for 1.8.2 versions of kubernetes
+	KubernetesVersion1Dot8Dot2 string = "1.8.2"
 	// KubernetesVersion1Dot7Dot7 is the major.minor.patch string for 1.7.9 versions of kubernetes
 	KubernetesVersion1Dot7Dot7 string = "1.7.9"
 	// KubernetesVersion1Dot6Dot11 is the major.minor.patch string for 1.6.11 versions of kubernetes

--- a/pkg/api/convertertoagentpoolonlyapi.go
+++ b/pkg/api/convertertoagentpoolonlyapi.go
@@ -191,7 +191,7 @@ func convertV20170831AgentPoolOnlyOrchestratorProfile(kubernetesVersion string) 
 	}
 
 	switch kubernetesVersion {
-	case KubernetesVersion1Dot8Dot1, KubernetesVersion1Dot7Dot7, KubernetesVersion1Dot6Dot11, KubernetesVersion1Dot5Dot8:
+	case KubernetesVersion1Dot8Dot2, KubernetesVersion1Dot7Dot7, KubernetesVersion1Dot6Dot11, KubernetesVersion1Dot5Dot8:
 		orchestratorProfile.OrchestratorVersion = kubernetesVersion
 	default:
 		orchestratorProfile.OrchestratorVersion = KubernetesDefaultVersion
@@ -205,7 +205,7 @@ func convertVLabsAgentPoolOnlyOrchestratorProfile(kubernetesVersion string) *Orc
 	}
 
 	switch kubernetesVersion {
-	case KubernetesVersion1Dot8Dot1, KubernetesVersion1Dot7Dot7, KubernetesVersion1Dot6Dot11, KubernetesVersion1Dot5Dot8:
+	case KubernetesVersion1Dot8Dot2, KubernetesVersion1Dot7Dot7, KubernetesVersion1Dot6Dot11, KubernetesVersion1Dot5Dot8:
 		orchestratorProfile.OrchestratorVersion = kubernetesVersion
 	default:
 		orchestratorProfile.OrchestratorVersion = KubernetesDefaultVersion

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -543,7 +543,7 @@ func convertV20170701OrchestratorProfile(v20170701cs *v20170701.OrchestratorProf
 	switch api.OrchestratorType {
 	case Kubernetes:
 		switch v20170701cs.OrchestratorVersion {
-		case KubernetesVersion1Dot8Dot1, KubernetesVersion1Dot7Dot7, KubernetesVersion1Dot6Dot11, KubernetesVersion1Dot5Dot8:
+		case KubernetesVersion1Dot8Dot2, KubernetesVersion1Dot7Dot7, KubernetesVersion1Dot6Dot11, KubernetesVersion1Dot5Dot8:
 			api.OrchestratorVersion = v20170701cs.OrchestratorVersion
 		default:
 			api.OrchestratorVersion = KubernetesDefaultVersion

--- a/pkg/api/orchestrators.go
+++ b/pkg/api/orchestrators.go
@@ -184,11 +184,11 @@ func kubernetesUpgrades(csOrch *OrchestratorProfile) ([]*OrchestratorProfile, er
 		// add next version
 		ret = append(ret, &OrchestratorProfile{
 			OrchestratorType:    Kubernetes,
-			OrchestratorVersion: common.KubernetesVersion1Dot8Dot1,
+			OrchestratorVersion: common.KubernetesVersion1Dot8Dot2,
 		})
 	case strings.HasPrefix(csOrch.OrchestratorVersion, "1.8"):
 		// check for patch upgrade
-		if ret, err = addPatchUpgrade(ret, csOrch.OrchestratorVersion, common.KubernetesVersion1Dot8Dot1); err != nil {
+		if ret, err = addPatchUpgrade(ret, csOrch.OrchestratorVersion, common.KubernetesVersion1Dot8Dot2); err != nil {
 			return ret, err
 		}
 	}

--- a/pkg/api/orchestrators_test.go
+++ b/pkg/api/orchestrators_test.go
@@ -92,10 +92,10 @@ func TestOrchestratorUpgradeInfo(t *testing.T) {
 	Expect(len(orch.Upgrades)).To(Equal(1))
 	Expect(orch.Upgrades[0].OrchestratorVersion).To(Equal(common.KubernetesVersion1Dot8Dot1))
 
-	// 1.8.1 is not upgradable
+	// 1.8.2 is not upgradable
 	csOrch = &OrchestratorProfile{
 		OrchestratorType:    Kubernetes,
-		OrchestratorVersion: KubernetesVersion1Dot8Dot1,
+		OrchestratorVersion: KubernetesVersion1Dot8Dot2,
 	}
 	orch, e = GetOrchestratorVersionProfile(csOrch)
 	Expect(e).To(BeNil())

--- a/pkg/api/orchestrators_test.go
+++ b/pkg/api/orchestrators_test.go
@@ -80,7 +80,7 @@ func TestOrchestratorUpgradeInfo(t *testing.T) {
 	Expect(e).To(BeNil())
 	Expect(len(orch.Upgrades)).To(Equal(2))
 	Expect(orch.Upgrades[0].OrchestratorVersion).To(Equal(common.KubernetesVersion1Dot7Dot7))
-	Expect(orch.Upgrades[1].OrchestratorVersion).To(Equal(common.KubernetesVersion1Dot8Dot1))
+	Expect(orch.Upgrades[1].OrchestratorVersion).To(Equal(common.KubernetesVersion1Dot8Dot2))
 
 	// 1.7.9 is upgradable to 1.8.x
 	csOrch = &OrchestratorProfile{
@@ -90,7 +90,7 @@ func TestOrchestratorUpgradeInfo(t *testing.T) {
 	orch, e = GetOrchestratorVersionProfile(csOrch)
 	Expect(e).To(BeNil())
 	Expect(len(orch.Upgrades)).To(Equal(1))
-	Expect(orch.Upgrades[0].OrchestratorVersion).To(Equal(common.KubernetesVersion1Dot8Dot1))
+	Expect(orch.Upgrades[0].OrchestratorVersion).To(Equal(common.KubernetesVersion1Dot8Dot2))
 
 	// 1.8.2 is not upgradable
 	csOrch = &OrchestratorProfile{

--- a/pkg/api/v20170701/validate.go
+++ b/pkg/api/v20170701/validate.go
@@ -38,7 +38,7 @@ func (o *OrchestratorProfile) Validate() error {
 	case DockerCE:
 	case Kubernetes:
 		switch o.OrchestratorVersion {
-		case common.KubernetesVersion1Dot8Dot1:
+		case common.KubernetesVersion1Dot8Dot2:
 		case common.KubernetesVersion1Dot7Dot7:
 		case common.KubernetesVersion1Dot6Dot11:
 		case common.KubernetesVersion1Dot5Dot8:

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -388,7 +388,7 @@ func (a *KubernetesConfig) Validate(k8sVersion string) error {
 	const minKubeletRetries = 4
 	// k8s versions that have cloudprovider backoff enabled
 	var backoffEnabledVersions = map[string]bool{
-		common.KubernetesVersion1Dot8Dot1:  true,
+		common.KubernetesVersion1Dot8Dot2:  true,
 		common.KubernetesVersion1Dot7Dot7:  true,
 		common.KubernetesVersion1Dot6Dot11: true,
 	}

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -53,7 +53,7 @@ func Test_OrchestratorProfile_Validate(t *testing.T) {
 
 func Test_KubernetesConfig_Validate(t *testing.T) {
 	// Tests that should pass across all versions
-	for _, k8sVersion := range []string{common.KubernetesVersion1Dot5Dot8, common.KubernetesVersion1Dot6Dot11, common.KubernetesVersion1Dot7Dot7, common.KubernetesVersion1Dot8Dot1} {
+	for _, k8sVersion := range []string{common.KubernetesVersion1Dot5Dot8, common.KubernetesVersion1Dot6Dot11, common.KubernetesVersion1Dot7Dot7, common.KubernetesVersion1Dot8Dot2} {
 		c := KubernetesConfig{}
 		if err := c.Validate(k8sVersion); err != nil {
 			t.Errorf("should not error on empty KubernetesConfig: %v, version %s", err, k8sVersion)
@@ -226,7 +226,7 @@ func Test_KubernetesConfig_Validate(t *testing.T) {
 	}
 
 	// Tests that apply to 1.6 and later releases
-	for _, k8sVersion := range []string{common.KubernetesVersion1Dot6Dot11, common.KubernetesVersion1Dot7Dot7, common.KubernetesVersion1Dot8Dot1} {
+	for _, k8sVersion := range []string{common.KubernetesVersion1Dot6Dot11, common.KubernetesVersion1Dot7Dot7, common.KubernetesVersion1Dot8Dot2} {
 		c := KubernetesConfig{
 			CloudProviderBackoff:   true,
 			CloudProviderRateLimit: true,

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -86,7 +86,7 @@ func (uc *UpgradeCluster) UpgradeCluster(subscriptionID uuid.UUID, kubeConfig, r
 		upgrader17.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig)
 		upgrader = upgrader17
 
-	case api.KubernetesVersion1Dot8Dot1:
+	case api.KubernetesVersion1Dot8Dot2:
 		upgrader18 := &Kubernetes18upgrader{}
 		upgrader18.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig)
 		upgrader = upgrader18


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Adds support for the latest Kubernetes 1.8 release: `v1.8.2`

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Upgrade Kubernetes 1.8 release channel to 1.8.2
```