### PR TITLE
added 1.8 k8s release example

### DIFF
--- a/examples/kubernetes-releases/kubernetes1.8.json
+++ b/examples/kubernetes-releases/kubernetes1.8.json
@@ -1,0 +1,36 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "1.8"
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    }
+  }
+}

--- a/test/acse-conf/acse-regression.json
+++ b/test/acse-conf/acse-regression.json
@@ -62,6 +62,14 @@
       "category": "version"
     },
     {
+      "cluster_definition": "kubernetes-releases/kubernetes1.6.json",
+      "category": "version"
+    },
+    {
+      "cluster_definition": "kubernetes-releases/kubernetes1.8.json",
+      "category": "version"
+    },
+    {
       "cluster_definition": "networkpolicy/kubernetes-calico.json",
       "category": "network"
     },

--- a/test/acse-conf/acse-regression.json
+++ b/test/acse-conf/acse-regression.json
@@ -58,10 +58,6 @@
       "location": "westus"
     },
     {
-      "cluster_definition": "kubernetes-releases/kubernetes1.5.json",
-      "category": "version"
-    },
-    {
       "cluster_definition": "kubernetes-releases/kubernetes1.6.json",
       "category": "version"
     },


### PR DESCRIPTION
added 1.6 and 1.8 to regression suite

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Adds 1.6 and 1.8 k8s releases to regression test suite

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
