### PR TITLE
acsengine: fix agent extensions

### DIFF
--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -1238,7 +1238,7 @@ func makeAgentExtensionScriptCommands(cs *api.ContainerService, profile *api.Age
 	if profile.IsAvailabilitySets() {
 		copyIndex = fmt.Sprintf("',copyIndex(variables('%sOffset')),'", profile.Name)
 	}
-	return makeExtensionScriptCommands(cs.Properties.MasterProfile.PreprovisionExtension,
+	return makeExtensionScriptCommands(profile.PreprovisionExtension,
 		cs.Properties.ExtensionProfiles, copyIndex)
 }
 


### PR DESCRIPTION
Fixes a bug where it was looking at the master profile not the agent.