### PR TITLE
Add support to build official Docker image from release binaries.

### DIFF
--- a/releases/Dockerfile.linux
+++ b/releases/Dockerfile.linux
@@ -1,0 +1,31 @@
+FROM alpine:3.6
+
+ARG ACSENGINE_VERSION
+ARG BUILD_DATE
+
+# Metadata as defined at http://label-schema.org
+LABEL maintainer="Microsoft" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name="Azure Container Service Engine (acs-engine)" \
+      org.label-schema.version=$ACSENGINE_VERSION \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="The Azure Container Service Engine (acs-engine) generates ARM (Azure Resource Manager) templates for Docker enabled clusters on Microsoft Azure with your choice of DCOS, Kubernetes, or Swarm orchestrators." \
+      org.label-schema.url="https://github.com/Azure/acs-engine" \
+      org.label-schema.usage="https://github.com/Azure/acs-engine/blob/master/docs/acsengine.md" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/Azure/acs-engine.git" \
+      org.label-schema.docker.cmd="docker run -v \${PWD}:/acs-engine/workspace -it --rm microsoft/acs-engine:$ACSENGINE_VERSION"
+
+RUN apk add --update bash curl && \
+    rm -rf /var/cache/apk/* 
+     
+RUN curl -L "https://github.com/Azure/acs-engine/releases/download/v${ACSENGINE_VERSION}/acs-engine-v${ACSENGINE_VERSION}-linux-amd64.tar.gz" | tar xvz -C ~ && \
+    chown -R root:root ~/acs-engine-v${ACSENGINE_VERSION}-linux-amd64 && \
+    ln -s ~/acs-engine-v${ACSENGINE_VERSION}-linux-amd64/acs-engine /usr/local/bin/acs-engine && \
+    chmod +x /usr/local/bin/acs-engine && \
+    echo 'PS1="acs-engine# "' > ~/.bashrc
+
+WORKDIR /acs-engine/workspace
+
+CMD bash

--- a/releases/README.Dockerfile.md
+++ b/releases/README.Dockerfile.md
@@ -1,0 +1,58 @@
+# Build Docker image
+
+**Bash**
+```bash
+$ VERSION=0.8.0
+$ docker build --no-cache --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg ACSENGINE_VERSION="$VERSION" -t microsoft/acs-engine:$VERSION --file ./Dockerfile.linux .
+```
+**PowerShell**
+```powershell
+PS> $VERSION="0.8.0"
+PS> docker build --no-cache --build-arg BUILD_DATE=$(Get-Date((Get-Date).ToUniversalTime()) -UFormat "%Y-%m-%dT%H:%M:%SZ") --build-arg ACSENGINE_VERSION="$VERSION" -t microsoft/acs-engine:$VERSION --file .\Dockerfile.linux .
+```
+
+# Inspect Docker image metadata
+
+**Bash**
+```bash
+$ docker image inspect microsoft/acs-engine:0.8.0 --format "{{json .Config.Labels}}" | jq
+{
+  "maintainer": "Microsoft",
+  "org.label-schema.build-date": "2017-10-25T04:35:06Z",
+  "org.label-schema.description": "The Azure Container Service Engine (acs-engine) generates ARM (Azure Resource Manager) templates for Docker enabled clusters on Microsoft Azure with your choice of DCOS, Kubernetes, or Swarm orchestrators.",
+  "org.label-schema.docker.cmd": "docker run -v ${PWD}:/acs-engine/workspace -it --rm microsoft/acs-engine:0.8.0",
+  "org.label-schema.license": "MIT",
+  "org.label-schema.name": "Azure Container Service Engine (acs-engine)",
+  "org.label-schema.schema-version": "1.0",
+  "org.label-schema.url": "https://github.com/Azure/acs-engine",
+  "org.label-schema.usage": "https://github.com/Azure/acs-engine/blob/master/docs/acsengine.md",
+  "org.label-schema.vcs-url": "https://github.com/Azure/acs-engine.git",
+  "org.label-schema.vendor": "Microsoft",
+  "org.label-schema.version": "0.8.0"
+}
+```
+
+**PowerShell**
+```powershell
+PS> docker image inspect microsoft/acs-engine:0.8.0 --format "{{json .Config.Labels}}" | ConvertFrom-Json | ConvertTo-Json
+{
+    "maintainer":  "Microsoft",
+    "org.label-schema.build-date":  "2017-10-25T04:35:06Z",
+    "org.label-schema.description":  "The Azure Container Service Engine (acs-engine) generates ARM (Azure Resource Manager) templates for Docker enabled clusters on Microsoft Azure with your choice of DCOS, Kubernetes, or Swarm orchestrators.",
+    "org.label-schema.docker.cmd":  "docker run -v ${PWD}:/acs-engine/workspace -it --rm microsoft/acs-engine:0.8.0",
+    "org.label-schema.license":  "MIT",
+    "org.label-schema.name":  "Azure Container Service Engine (acs-engine)",
+    "org.label-schema.schema-version":  "1.0",
+    "org.label-schema.url":  "https://github.com/Azure/acs-engine",
+    "org.label-schema.usage":  "https://github.com/Azure/acs-engine/blob/master/docs/acsengine.md",
+    "org.label-schema.vcs-url":  "https://github.com/Azure/acs-engine.git",
+    "org.label-schema.vendor":  "Microsoft",
+    "org.label-schema.version":  "0.8.0"
+}
+```
+
+# Run Docker image
+
+```
+$ docker run -v ${PWD}:/acs-engine/workspace -it --rm microsoft/acs-engine:0.8.0
+```


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support to build the official microsoft/acs-engine Docker image from the release binaries. It also adds metadata support.

**Which issue this PR fixes** 

Related to #1604 

**Special notes for your reviewer**:

The `README.Dockerfile.md` file contains instructions on `build-args` to pass in to the `docker build` command.

```bash
$ VERSION=0.8.0
$ docker build --no-cache --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg ACSENGINE_VERSION="$VERSION" -t microsoft/acs-engine:$VERSION --file ./Dockerfile.linux .
```

The metadata added provides build, license, repo and usage information.

```bash
$ docker image inspect microsoft/acs-engine:0.8.0 --format "{{json .Config.Labels}}" | jq
{
  "maintainer": "Microsoft",
  "org.label-schema.build-date": "2017-10-25T04:35:06Z",
  "org.label-schema.description": "The Azure Container Service Engine (acs-engine) generates ARM (Azure Resource Manager) templates for Docker enabled clusters on Microsoft Azure with your choice of DCOS, Kubernetes, or Swarm orchestrators.",
  "org.label-schema.docker.cmd": "docker run -v ${PWD}:/acs-engine/workspace -it --rm microsoft/acs-engine:0.8.0",
  "org.label-schema.license": "MIT",
  "org.label-schema.name": "Azure Container Service Engine (acs-engine)",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.url": "https://github.com/Azure/acs-engine",
  "org.label-schema.usage": "https://github.com/Azure/acs-engine/blob/master/docs/acsengine.md",
  "org.label-schema.vcs-url": "https://github.com/Azure/acs-engine.git",
  "org.label-schema.vendor": "Microsoft",
  "org.label-schema.version": "0.8.0"
}
```

The usage example in the metadata shows how to map the current working directory to a workspace in the container, which is set as the working directory. This allows for the resulting `_output` folder to be accessed from the host.

```bash
$ docker run -v ${PWD}:/acs-engine/workspace -it --rm microsoft/acs-engine:0.8.0
acs-engine# acs-engine --help
ACS-Engine deploys and manages Kubernetes, Swarm Mode, and DC/OS clusters in Azure
Usage:
  acs-engine [command]
Available Commands:
  deploy        deploy an Azure Resource Manager template
  generate      Generate an Azure Resource Manager template
  help          Help about any command
  orchestrators provide info about supported orchestrators
  upgrade       upgrades an existing Kubernetes cluster
  version       Print the version of ACS-Engine
Flags:
      --debug   enable verbose debug logs
  -h, --help    help for acs-engine
Use "acs-engine [command] --help" for more information about a command.

acs-engine# acs-engine version
Version: v0.8.0
GitCommit: 79572455
GitTreeState: clean

acs-engine# 
```
