### PR TITLE
[WIP] Making omitted orchestrator versions act like patch on updates.

### DIFF
--- a/pkg/acsengine/testdata/v20170701/kubernetes-default-version.json
+++ b/pkg/acsengine/testdata/v20170701/kubernetes-default-version.json
@@ -2,8 +2,7 @@
   "apiVersion": "2017-07-01",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes",
-      "orchestratorVersion": "1.6.11"
+      "orchestratorType": "Kubernetes"
     },
     "masterProfile": {
       "count": 1,

--- a/pkg/acsengine/testdata/v20170701/kubernetes-default-version.json
+++ b/pkg/acsengine/testdata/v20170701/kubernetes-default-version.json
@@ -1,0 +1,49 @@
+{
+  "apiVersion": "2017-07-01",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorVersion": "1.6.11"
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "masterdns1",
+      "OSDiskSizeGB": 200,
+      "vmSize": "Standard_D2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 1,
+        "vmSize": "Standard_D2_v2",
+        "OSDiskSizeGB": 200,
+        "availabilityProfile": "AvailabilitySet"
+      },
+      {
+        "name": "agentpool2",
+        "count": 1,
+        "vmSize": "Standard_D3_v2",
+        "availabilityProfile": "AvailabilitySet",
+        "osType": "Windows"
+      }
+    ],
+    "windowsProfile": {
+      "adminUsername": "azureuser",
+      "adminPassword": "replacepassword1234$"
+    },
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": "ssh-rsa PUBLICKEY azureuser@linuxvm"
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "ServicePrincipalClientID",
+      "secret": "myServicePrincipalClientSecret"
+    }
+  }
+}

--- a/pkg/api/apiloader.go
+++ b/pkg/api/apiloader.go
@@ -61,8 +61,8 @@ func (a *Apiloader) LoadContainerService(
 	validate, isUpdate bool,
 	existingContainerService *ContainerService) (*ContainerService, error) {
 	var curOrchVersion string
-	haveExistingCS := existingContainerService != nil
-	if haveExistingCS {
+	hasExistingCS := existingContainerService != nil
+	if hasExistingCS {
 		curOrchVersion = existingContainerService.Properties.OrchestratorProfile.OrchestratorVersion
 	}
 	switch version {
@@ -71,7 +71,7 @@ func (a *Apiloader) LoadContainerService(
 		if e := json.Unmarshal(contents, &containerService); e != nil {
 			return nil, e
 		}
-		if haveExistingCS {
+		if hasExistingCS {
 			vecs := ConvertContainerServiceToV20160930(existingContainerService)
 			if e := containerService.Merge(vecs); e != nil {
 				return nil, e
@@ -91,7 +91,7 @@ func (a *Apiloader) LoadContainerService(
 		if e := json.Unmarshal(contents, &containerService); e != nil {
 			return nil, e
 		}
-		if haveExistingCS {
+		if hasExistingCS {
 			vecs := ConvertContainerServiceToV20160330(existingContainerService)
 			if e := containerService.Merge(vecs); e != nil {
 				return nil, e
@@ -112,7 +112,7 @@ func (a *Apiloader) LoadContainerService(
 		if e := json.Unmarshal(contents, &containerService); e != nil {
 			return nil, e
 		}
-		if haveExistingCS {
+		if hasExistingCS {
 			vecs := ConvertContainerServiceToV20170131(existingContainerService)
 			if e := containerService.Merge(vecs); e != nil {
 				return nil, e
@@ -133,7 +133,7 @@ func (a *Apiloader) LoadContainerService(
 		if e := json.Unmarshal(contents, &containerService); e != nil {
 			return nil, e
 		}
-		if haveExistingCS {
+		if hasExistingCS {
 			vecs := ConvertContainerServiceToV20170701(existingContainerService)
 			if e := containerService.Merge(vecs); e != nil {
 				return nil, e
@@ -158,7 +158,7 @@ func (a *Apiloader) LoadContainerService(
 		if e := checkJSONKeys(contents, reflect.TypeOf(*containerService), reflect.TypeOf(TypeMeta{})); e != nil {
 			return nil, e
 		}
-		if haveExistingCS {
+		if hasExistingCS {
 			vecs := ConvertContainerServiceToVLabs(existingContainerService)
 			if e := containerService.Merge(vecs); e != nil {
 				return nil, e

--- a/pkg/api/apiloader_test.go
+++ b/pkg/api/apiloader_test.go
@@ -34,7 +34,7 @@ func TestLoadContainerServiceFromFile(t *testing.T) {
 		t.Error(err.Error())
 	}
 	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesVersion1Dot6Dot9 {
-		t.Error("Failed to set orcherstator version when it is set in the json")
+		t.Errorf("Failed  set orcherstator version when it is not set in the json, got %s", containerService.Properties.OrchestratorProfile.OrchestratorVersion)
 	}
 
 	containerService, _, err = apiloader.LoadContainerServiceFromFile("../acsengine/testdata/v20170131/kubernetes.json", true, false, existingContainerService)
@@ -42,6 +42,38 @@ func TestLoadContainerServiceFromFile(t *testing.T) {
 		t.Error(err.Error())
 	}
 	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesVersion1Dot6Dot9 {
-		t.Error("Failed to set orcherstator version when it is set in the json")
+		t.Errorf("Failed  set orcherstator version when it is not set in the json, got %s", containerService.Properties.OrchestratorProfile.OrchestratorVersion)
+	}
+
+	containerService, _, err = apiloader.LoadContainerServiceFromFile("../acsengine/testdata/v20160930/kubernetes.json", true, false, existingContainerService)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesVersion1Dot6Dot9 {
+		t.Errorf("Failed  set orcherstator version when it is not set in the json, got %s", containerService.Properties.OrchestratorProfile.OrchestratorVersion)
+	}
+
+	containerService, _, err = apiloader.LoadContainerServiceFromFile("../acsengine/testdata/v20170701/kubernetes-default-version.json", true, false, nil)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesDefaultVersion {
+		t.Errorf("Failed  set orcherstator version when it is not set in the json, got %s", containerService.Properties.OrchestratorProfile.OrchestratorVersion)
+	}
+
+	containerService, _, err = apiloader.LoadContainerServiceFromFile("../acsengine/testdata/v20170131/kubernetes.json", true, false, nil)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesDefaultVersion {
+		t.Errorf("Failed  set orcherstator version when it is not set in the json, got %s", containerService.Properties.OrchestratorProfile.OrchestratorVersion)
+	}
+
+	containerService, _, err = apiloader.LoadContainerServiceFromFile("../acsengine/testdata/v20160930/kubernetes.json", true, false, nil)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesVersion1Dot5Dot8 {
+		t.Errorf("Failed  set orcherstator version when it is not set in the json, got %s", containerService.Properties.OrchestratorProfile.OrchestratorVersion)
 	}
 }

--- a/pkg/api/apiloader_test.go
+++ b/pkg/api/apiloader_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"github.com/Azure/acs-engine/pkg/api/common"
+	"github.com/Azure/acs-engine/pkg/i18n"
+	"github.com/leonelquinteros/gotext"
+
+	"path"
+	"testing"
+)
+
+func TestLoadContainerServiceFromFile(t *testing.T) {
+	existingContainerService := &ContainerService{Name: "test",
+		Properties: &Properties{OrchestratorProfile: &OrchestratorProfile{OrchestratorType: Kubernetes, OrchestratorVersion: common.KubernetesVersion1Dot6Dot9}}}
+
+	locale := gotext.NewLocale(path.Join("..", "..", "translations"), "en_US")
+	i18n.Initialize(locale)
+	apiloader := &Apiloader{
+		Translator: &i18n.Translator{
+			Locale: locale,
+		},
+	}
+
+	containerService, _, err := apiloader.LoadContainerServiceFromFile("../acsengine/testdata/v20170701/kubernetes.json", true, false, existingContainerService)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesVersion1Dot6Dot11 {
+		t.Error("Failed to set orcherstator version when it is set in the json")
+	}
+
+	containerService, _, err = apiloader.LoadContainerServiceFromFile("../acsengine/testdata/v20170701/kubernetes-default-version.json", true, false, existingContainerService)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesVersion1Dot6Dot9 {
+		t.Error("Failed to set orcherstator version when it is set in the json")
+	}
+
+	containerService, _, err = apiloader.LoadContainerServiceFromFile("../acsengine/testdata/v20170131/kubernetes.json", true, false, existingContainerService)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesVersion1Dot6Dot9 {
+		t.Error("Failed to set orcherstator version when it is set in the json")
+	}
+}


### PR DESCRIPTION

**What this PR does / why we need it**:
See title. Without this the service can't scale old clusters through the portal.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
related to https://github.com/Azure/ACS/issues/82
**Special notes for your reviewer**:
Looking for feedback on proper behavior for 2017-07-01 and vlabs as in those versions you can specify the version. i also need to add comments and unit tests.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Making omitted orchestrator versions act like patch on updates.
```
