### PR TITLE
Fix for NVIDIA driver install

### DIFF
--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -1332,7 +1332,9 @@ func getGPUDriversInstallScript(profile *api.AgentPoolProfile) string {
 - update-initramfs -u
 - sudo add-apt-repository -y ppa:graphics-drivers
 - sudo apt-get update
-- sudo apt-get install -y nvidia-%s`, dv)
+- sudo apt-get install -y nvidia-%s
+- sudo nvidia-smi
+- sudo systemctl restart kubelet`, dv)
 
 	// We don't have an agreement in place with NVIDIA to provide the drivers on every sku. For this VMs we simply log a warning message.
 	na := getGPUDriversNotInstalledWarningMessage(profile.VMSize)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Currently, NVIDIA drivers are automatically installed but needs `nvidia-smi` or system restart to work properly. Also, kubelet does not recognize GPUs (`alpha.kubernetes.io/nvidia-gpu`) unless it is restarted.
With this PR, immediately after driver installation finishes, GPU should be available in Kubernetes.

**Special notes for your reviewer**:
We didn't need this before since VMs were restarting after deployment, but they are not restarting anymore. Is it intended they are not restarting anymore?

/cc @wbuchwalter 
