### PR TITLE
changing deployment name

### DIFF
--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -69,10 +69,11 @@ func (kan *UpgradeAgentNode) CreateNode(poolName string, agentNo int) error {
 
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	deploymentSuffix := random.Int31()
+	deploymentName := fmt.Sprintf("agent-%s-%d", time.Now().Format("07-01-31"), deploymentSuffix),
 
 	_, err := kan.Client.DeployTemplate(
 		kan.ResourceGroup,
-		fmt.Sprintf("%s-%d", kan.ResourceGroup, deploymentSuffix),
+		deploymentName,
 		kan.TemplateMap,
 		kan.ParametersMap,
 		nil)

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -69,7 +69,7 @@ func (kan *UpgradeAgentNode) CreateNode(poolName string, agentNo int) error {
 
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	deploymentSuffix := random.Int31()
-	deploymentName := fmt.Sprintf("agent-%s-%d", time.Now().Format("07-01-31-13:20:00"), deploymentSuffix)
+	deploymentName := fmt.Sprintf("agent-%s-%d", time.Now().Format("06-01-02T15:04:05"), deploymentSuffix)
 
 	_, err := kan.Client.DeployTemplate(
 		kan.ResourceGroup,

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -69,7 +69,7 @@ func (kan *UpgradeAgentNode) CreateNode(poolName string, agentNo int) error {
 
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	deploymentSuffix := random.Int31()
-	deploymentName := fmt.Sprintf("agent-%s-%d", time.Now().Format("07-01-31"), deploymentSuffix),
+	deploymentName := fmt.Sprintf("agent-%s-%d", time.Now().Format("07-01-31"), deploymentSuffix)
 
 	_, err := kan.Client.DeployTemplate(
 		kan.ResourceGroup,

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -69,7 +69,7 @@ func (kan *UpgradeAgentNode) CreateNode(poolName string, agentNo int) error {
 
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	deploymentSuffix := random.Int31()
-	deploymentName := fmt.Sprintf("agent-%s-%d", time.Now().Format("07-01-31"), deploymentSuffix)
+	deploymentName := fmt.Sprintf("agent-%s-%d", time.Now().Format("07-01-31-13:20:00"), deploymentSuffix)
 
 	_, err := kan.Client.DeployTemplate(
 		kan.ResourceGroup,

--- a/pkg/operations/kubernetesupgrade/upgrademasternode.go
+++ b/pkg/operations/kubernetesupgrade/upgrademasternode.go
@@ -54,10 +54,11 @@ func (kmn *UpgradeMasterNode) CreateNode(poolName string, masterNo int) error {
 
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	deploymentSuffix := random.Int31()
+	deploymentName := fmt.Sprintf("master-%s-%d", time.Now().Format("07-01-31"), deploymentSuffix),
 
 	_, err := kmn.Client.DeployTemplate(
 		kmn.ResourceGroup,
-		fmt.Sprintf("%s-%d", kmn.ResourceGroup, deploymentSuffix),
+		deploymentName,
 		kmn.TemplateMap,
 		kmn.ParametersMap,
 		nil)

--- a/pkg/operations/kubernetesupgrade/upgrademasternode.go
+++ b/pkg/operations/kubernetesupgrade/upgrademasternode.go
@@ -54,7 +54,7 @@ func (kmn *UpgradeMasterNode) CreateNode(poolName string, masterNo int) error {
 
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	deploymentSuffix := random.Int31()
-	deploymentName := fmt.Sprintf("master-%s-%d", time.Now().Format("07-01-31-13:20:00"), deploymentSuffix)
+	deploymentName := fmt.Sprintf("master-%s-%d", time.Now().Format("06-01-02T15:04:05"), deploymentSuffix)
 
 	_, err := kmn.Client.DeployTemplate(
 		kmn.ResourceGroup,

--- a/pkg/operations/kubernetesupgrade/upgrademasternode.go
+++ b/pkg/operations/kubernetesupgrade/upgrademasternode.go
@@ -54,7 +54,7 @@ func (kmn *UpgradeMasterNode) CreateNode(poolName string, masterNo int) error {
 
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	deploymentSuffix := random.Int31()
-	deploymentName := fmt.Sprintf("master-%s-%d", time.Now().Format("07-01-31"), deploymentSuffix),
+	deploymentName := fmt.Sprintf("master-%s-%d", time.Now().Format("07-01-31-13:20:00"), deploymentSuffix)
 
 	_, err := kmn.Client.DeployTemplate(
 		kmn.ResourceGroup,

--- a/test/e2e/dcos/dcos.go
+++ b/test/e2e/dcos/dcos.go
@@ -235,6 +235,9 @@ func (c *Cluster) AppCount() (int, error) {
 // Version will return the node count for a dcos cluster
 func (c *Cluster) Version() (string, error) {
 	out, err := c.Connection.Execute("curl -s http://localhost:80/dcos-metadata/dcos-version.json")
+	if err != nil {
+		log.Printf("Error while executing connection:%s\n", err)
+	}
 	version := Version{}
 	err = json.Unmarshal(out, &version)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Changes the way deployment name is computed

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Currently ARM deployment names do not have a cap for 64 characters. Changing the way this name is computed. Making it a function of time/suffix.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
