### PR TITLE
adding a message when scaling command decides no action should be taken

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -203,6 +203,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 		currentNodeCount = len(indexes)
 
 		if currentNodeCount == sc.newDesiredAgentCount {
+			log.Info("Cluster is currently at the desired agent count. If some nodes aren't joining the cluster either debug them or delete them and try the scale command again")
 			return nil
 		}
 		highestUsedIndex = indexes[len(indexes)-1]

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -203,7 +203,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 		currentNodeCount = len(indexes)
 
 		if currentNodeCount == sc.newDesiredAgentCount {
-			log.Info("Cluster is currently at the desired agent count. If some nodes aren't joining the cluster either debug them or delete them and try the scale command again")
+			log.Info("Cluster is currently at the desired agent count.")
 			return nil
 		}
 		highestUsedIndex = indexes[len(indexes)-1]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Adding another log to make the scale command more usable.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
