### PR TITLE
Added an explicit reference to the heapster host.

### DIFF
--- a/parts/kubernetesmasteraddons-kubernetes-dashboard-deployment.yaml
+++ b/parts/kubernetesmasteraddons-kubernetes-dashboard-deployment.yaml
@@ -62,6 +62,7 @@ spec:
     spec:
       containers:
       - args: 
+        - --heapster-host=http://heapster.kube-system:80
         image: <kubernetesDashboardSpec>
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
This is to fix:

https://github.com/Azure/AKS/issues/16

(and likely similar issues in ACS)

The upstream reference for this change is here:
https://github.com/kubernetes/dashboard/pull/2181