### PR TITLE
removing route table for k8s scaling operations

### DIFF
--- a/pkg/acsengine/transformtestfiles/k8s_agent_upgrade_template.json
+++ b/pkg/acsengine/transformtestfiles/k8s_agent_upgrade_template.json
@@ -785,22 +785,6 @@
       },
       "type": "string"
     },
-    "generatorCode": {
-      "defaultValue": "acsengine",
-      "metadata": {
-        "description": "The generator code used to identify the generator"
-      },
-      "type": "string"
-    },
-    "orchestratorName": {
-      "defaultValue": "k8s",
-      "metadata": {
-        "description": "The orchestrator name used to identify the orchestrator.  This must be no more than 3 digits in length, otherwise it will exceed Windows Naming"
-      },
-      "minLength": 3,
-      "maxLength": 3,
-      "type": "string"
-    },
     "dockerBridgeCidr": {
       "defaultValue": "",
       "metadata": {
@@ -819,6 +803,13 @@
       "defaultValue": "10.240.255.5",
       "metadata": {
         "description": "Sets the static IP of the first master"
+      },
+      "type": "string"
+    },
+    "generatorCode": {
+      "defaultValue": "acsengine",
+      "metadata": {
+        "description": "The generator code used to identify the generator"
       },
       "type": "string"
     },
@@ -1106,6 +1097,15 @@
       "metadata": {
         "description": "The network policy enforcement to use (none|azure|calico)"
       },
+      "type": "string"
+    },
+    "orchestratorName": {
+      "defaultValue": "k8s",
+      "maxLength": 3,
+      "metadata": {
+        "description": "The orchestrator name used to identify the orchestrator.  This must be no more than 3 digits in length, otherwise it will exceed Windows Naming"
+      },
+      "minLength": 3,
       "type": "string"
     },
     "servicePrincipalClientId": {
@@ -1799,9 +1799,6 @@
     },
     {
       "apiVersion": "[variables('apiVersionDefault')]",
-      "dependsOn": [
-        "[concat('Microsoft.Network/routeTables/', variables('routeTableName'))]"
-      ],
       "location": "[variables('location')]",
       "name": "[variables('virtualNetworkName')]",
       "properties": {
@@ -1826,12 +1823,6 @@
         ]
       },
       "type": "Microsoft.Network/virtualNetworks"
-    },
-    {
-      "apiVersion": "[variables('apiVersionDefault')]",
-      "location": "[variables('location')]",
-      "name": "[variables('routeTableName')]",
-      "type": "Microsoft.Network/routeTables"
     },
     {
       "apiVersion": "[variables('apiVersionDefault')]",

--- a/pkg/acsengine/transformtestfiles/k8s_scale_template.json
+++ b/pkg/acsengine/transformtestfiles/k8s_scale_template.json
@@ -785,22 +785,6 @@
       },
       "type": "string"
     },
-    "generatorCode": {
-      "defaultValue": "acsengine",
-      "metadata": {
-        "description": "The generator code used to identify the generator"
-      },
-      "type": "string"
-    },
-    "orchestratorName": {
-      "defaultValue": "k8s",
-      "metadata": {
-        "description": "The orchestrator name used to identify the orchestrator.  This must be no more than 3 digits in length, otherwise it will exceed Windows Naming"
-      },
-      "minLength": 3,
-      "maxLength": 3,
-      "type": "string"
-    },
     "dockerBridgeCidr": {
       "defaultValue": "",
       "metadata": {
@@ -819,6 +803,13 @@
       "defaultValue": "10.240.255.5",
       "metadata": {
         "description": "Sets the static IP of the first master"
+      },
+      "type": "string"
+    },
+    "generatorCode": {
+      "defaultValue": "acsengine",
+      "metadata": {
+        "description": "The generator code used to identify the generator"
       },
       "type": "string"
     },
@@ -1106,6 +1097,15 @@
       "metadata": {
         "description": "The network policy enforcement to use (none|azure|calico)"
       },
+      "type": "string"
+    },
+    "orchestratorName": {
+      "defaultValue": "k8s",
+      "maxLength": 3,
+      "metadata": {
+        "description": "The orchestrator name used to identify the orchestrator.  This must be no more than 3 digits in length, otherwise it will exceed Windows Naming"
+      },
+      "minLength": 3,
       "type": "string"
     },
     "servicePrincipalClientId": {
@@ -1981,9 +1981,6 @@
     },
     {
       "apiVersion": "[variables('apiVersionDefault')]",
-      "dependsOn": [
-        "[concat('Microsoft.Network/routeTables/', variables('routeTableName'))]"
-      ],
       "location": "[variables('location')]",
       "name": "[variables('virtualNetworkName')]",
       "properties": {
@@ -2008,12 +2005,6 @@
         ]
       },
       "type": "Microsoft.Network/virtualNetworks"
-    },
-    {
-      "apiVersion": "[variables('apiVersionDefault')]",
-      "location": "[variables('location')]",
-      "name": "[variables('routeTableName')]",
-      "type": "Microsoft.Network/routeTables"
     },
     {
       "apiVersion": "[variables('apiVersionDefault')]",

--- a/pkg/acsengine/transformtestfiles/k8s_vnet_scale_template.json
+++ b/pkg/acsengine/transformtestfiles/k8s_vnet_scale_template.json
@@ -783,22 +783,6 @@
       },
       "type": "string"
     },
-    "generatorCode": {
-      "defaultValue": "acsengine",
-      "metadata": {
-        "description": "The generator code used to identify the generator"
-      },
-      "type": "string"
-    },
-    "orchestratorName": {
-      "defaultValue": "k8s",
-      "metadata": {
-        "description": "The orchestrator name used to identify the orchestrator.  This must be no more than 3 digits in length, otherwise it will exceed Windows Naming"
-      },
-      "minLength": 3,
-      "maxLength": 3,
-      "type": "string"
-    },
     "dockerBridgeCidr": {
       "defaultValue": "",
       "metadata": {
@@ -817,6 +801,13 @@
       "defaultValue": "10.239.255.239",
       "metadata": {
         "description": "Sets the static IP of the first master"
+      },
+      "type": "string"
+    },
+    "generatorCode": {
+      "defaultValue": "acsengine",
+      "metadata": {
+        "description": "The generator code used to identify the generator"
       },
       "type": "string"
     },
@@ -1103,6 +1094,15 @@
       "metadata": {
         "description": "The network policy enforcement to use (none|azure|calico)"
       },
+      "type": "string"
+    },
+    "orchestratorName": {
+      "defaultValue": "k8s",
+      "maxLength": 3,
+      "metadata": {
+        "description": "The orchestrator name used to identify the orchestrator.  This must be no more than 3 digits in length, otherwise it will exceed Windows Naming"
+      },
+      "minLength": 3,
       "type": "string"
     },
     "servicePrincipalClientId": {
@@ -1683,7 +1683,6 @@
         "count": "[sub(variables('agentpriCount'), variables('agentpriOffset'))]",
         "name": "loop"
       },
-      "dependsOn": [],
       "location": "[variables('location')]",
       "name": "[concat(variables('agentpriVMNamePrefix'), 'nic-', copyIndex(variables('agentpriOffset')))]",
       "properties": {
@@ -1826,7 +1825,6 @@
         "count": "[sub(variables('agentpri2Count'), variables('agentpri2Offset'))]",
         "name": "loop"
       },
-      "dependsOn": [],
       "location": "[variables('location')]",
       "name": "[concat(variables('agentpri2VMNamePrefix'), 'nic-', copyIndex(variables('agentpri2Offset')))]",
       "properties": {
@@ -1973,12 +1971,6 @@
         "platformUpdateDomainCount": "3"
       },
       "type": "Microsoft.Compute/availabilitySets"
-    },
-    {
-      "apiVersion": "[variables('apiVersionDefault')]",
-      "location": "[variables('location')]",
-      "name": "[variables('routeTableName')]",
-      "type": "Microsoft.Network/routeTables"
     },
     {
       "apiVersion": "[variables('apiVersionDefault')]",


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently on scale operations the route table is emptied. K8s normally fills it back in quickly, this does cause a short pod to pod communication outage. I've seen one case where k8s struggled to add the route back and the outage was longer.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
https://github.com/Azure/ACS/issues/82 has a new issue part way down where during a scale the routes in the route table were wiped out and failed to be readded. This fixes the routes being removed.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
removing route table for k8s scaling operation templates
```
