### PR TITLE
punt on azureconst.go change enforcement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,6 @@ jobs:
           name: Run linting rules
           command: make test-style
       - run:
-          name: Test Azure Constants
-          command: make test-azure-constants
-      - run:
           name: Build binaries
           command: make build-binary
       - run:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: skipping azureconst.go unit test enforcement until we figure this out

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
