### PR TITLE
added etcdDiskSizeGB to kubernetesConfig

### DIFF
--- a/examples/kubernetes-config/README.md
+++ b/examples/kubernetes-config/README.md
@@ -8,3 +8,4 @@ These cluster definition examples show how to create customized [Kubernetes](../
 2. [**kubernetes-maxpods.json**](kubernetes-maxpods.json) - Configuring a custom maximum limit on the number of pods per node.
 3. [**kubernetes-dockerbridgesubnet.json**](kubernetes-dockerbridgesubnet.json) - Configuring a custom IP subnet used for allocating IP addresses for the docker bridge network on nodes.
 4. [**kubernetes-gc.json**](kubernetes-gc.json) - Configuring custom image garbage collection values.
+4. [**kubernetes-etcd-storage-size.json**](kubernetes-etcd-storage-size.json) - Configuring a custom size for the etcd disk volume.

--- a/examples/kubernetes-config/kubernetes-etcd-storage-size.json
+++ b/examples/kubernetes-config/kubernetes-etcd-storage-size.json
@@ -1,0 +1,38 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "kubernetesConfig": {
+        "etcdDiskSizeGB": "1000"
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureUser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    }
+  }
+}

--- a/examples/kubernetes-config/kubernetes-etcd-storage-size.json
+++ b/examples/kubernetes-config/kubernetes-etcd-storage-size.json
@@ -4,7 +4,7 @@
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
-        "etcdDiskSizeGB": "1000"
+        "etcdDiskSizeGB": "256"
       }
     },
     "masterProfile": {

--- a/parts/kubernetesmasterresources.t
+++ b/parts/kubernetesmasterresources.t
@@ -434,7 +434,7 @@
           "dataDisks": [
             {
               "createOption": "Empty"
-              ,"diskSizeGB": "128"
+              ,"diskSizeGB": "[variables('etcdDiskSizeGB')]"
               ,"lun": 0
               ,"name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-etcddisk')]"
           {{if .MasterProfile.IsStorageAccount}}

--- a/parts/kubernetesmastervars.t
+++ b/parts/kubernetesmastervars.t
@@ -1,3 +1,4 @@
+    "etcdDiskSizeGB": "[parameters('etcdDiskSizeGB')]",
     "maxVMsPerPool": 100,
     "apiServerCertificate": "[parameters('apiServerCertificate')]",
 {{ if not IsHostedMaster }}

--- a/parts/kubernetesparams.t
+++ b/parts/kubernetesparams.t
@@ -388,4 +388,11 @@
         "description": "The offset into the master pool where to start creating master VMs.  This value can be from 0 to 4, but must be less than masterCount."
       },
       "type": "int"
+    },
+    "etcdDiskSizeGB": {
+      {{PopulateClassicModeDefaultValue "etcdDiskSizeGB"}}
+      "metadata": {
+        "description": "Size in GB to allocate for etcd volume"
+      },
+      "type": "string"
     }

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -86,6 +86,8 @@ const (
 	DefaultGeneratorCode = "acsengine"
 	// DefaultOrchestratorName specifies the 3 character orchestrator code of the cluster template and affects resource naming.
 	DefaultOrchestratorName = "k8s"
+	// DefaultEtcdDiskSize specifies the default size for Kubernetes master etcd disk volumes in GB
+	DefaultEtcdDiskSize = "128"
 )
 
 const (

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -291,6 +291,11 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 			a.OrchestratorProfile.KubernetesConfig.TillerMemoryLimit = DefaultTillerMemoryLimit
 		}
 
+		if a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB == "" {
+			fmt.Println("didn't find EtcdDiskSizeGB")
+			a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB = DefaultEtcdDiskSize
+		}
+
 	} else if o.OrchestratorType == api.DCOS {
 		if o.DcosConfig == nil {
 			o.DcosConfig = &api.DcosConfig{}

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -584,6 +584,7 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 		addValue(parametersMap, "maxPods", properties.OrchestratorProfile.KubernetesConfig.MaxPods)
 		addValue(parametersMap, "gchighthreshold", properties.OrchestratorProfile.KubernetesConfig.GCHighThreshold)
 		addValue(parametersMap, "gclowthreshold", properties.OrchestratorProfile.KubernetesConfig.GCLowThreshold)
+		addValue(parametersMap, "etcdDiskSizeGB", cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB)
 
 		if properties.OrchestratorProfile.KubernetesConfig == nil ||
 			!properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity {
@@ -1214,6 +1215,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 					val = DefaultGeneratorCode
 				case "orchestratorName":
 					val = DefaultOrchestratorName
+				case "etcdDiskSizeGB":
+					val = cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB
 				default:
 					val = ""
 				}

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -674,6 +674,7 @@ func convertKubernetesConfigToVLabs(api *KubernetesConfig, vlabs *vlabs.Kubernet
 	vlabs.TillerCPULimit = api.TillerCPULimit
 	vlabs.TillerMemoryRequests = api.TillerMemoryRequests
 	vlabs.TillerMemoryLimit = api.TillerMemoryLimit
+	vlabs.EtcdDiskSizeGB = api.EtcdDiskSizeGB
 }
 
 func convertMasterProfileToV20160930(api *MasterProfile, v20160930 *v20160930.MasterProfile) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -616,6 +616,7 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 	api.TillerCPULimit = vlabs.TillerCPULimit
 	api.TillerMemoryRequests = vlabs.TillerMemoryRequests
 	api.TillerMemoryLimit = vlabs.TillerMemoryLimit
+	api.EtcdDiskSizeGB = vlabs.EtcdDiskSizeGB
 }
 
 func convertV20160930MasterProfile(v20160930 *v20160930.MasterProfile, api *MasterProfile) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -191,6 +191,7 @@ type KubernetesConfig struct {
 	TillerCPULimit                   string  `json:"tillerCPULimit,omitempty"`
 	TillerMemoryRequests             string  `json:"tillerMemoryRequests,omitempty"`
 	TillerMemoryLimit                string  `json:"tillerMemoryLimit,omitempty"`
+	EtcdDiskSizeGB                   string  `json:"etcdDiskSizeGB,omitempty"`
 }
 
 // DcosConfig Configuration for DC/OS

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -209,6 +209,7 @@ type KubernetesConfig struct {
 	TillerCPULimit                   string  `json:"tillerCPULimit,omitempty"`
 	TillerMemoryRequests             string  `json:"tillerMemoryRequests,omitempty"`
 	TillerMemoryLimit                string  `json:"tillerMemoryLimit,omitempty"`
+	EtcdDiskSizeGB                   string  `json:"etcdDiskSizeGB,omitempty"`
 }
 
 // DcosConfig Configuration for DC/OS


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: enables custom configuration of etcd disk volume size

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1749

**Special notes for your reviewer**: TODO: example api model and documentation

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
custom etcd volume size
```