### PR TITLE
keeping track of provision.sh runs

### DIFF
--- a/parts/kubernetesmastercustomscript.sh
+++ b/parts/kubernetesmastercustomscript.sh
@@ -428,4 +428,6 @@ if $REBOOTREQUIRED; then
   /bin/bash -c "shutdown -r 1 &"
 fi
 
-echo `date`,`hostname`, endscript>>/opt/m 
+echo `date`,`hostname`, endscript>>/opt/m
+
+mkdir -p /opt/azure/containers && touch /opt/azure/containers/provision.complete

--- a/parts/kubernetesmasterresources.t
+++ b/parts/kubernetesmasterresources.t
@@ -530,7 +530,7 @@
         "autoUpgradeMinorVersion": true,
         "settings": {},
         "protectedSettings": {
-          "commandToExecute": "[concat(variables('provisionScriptParametersCommon'),' ',variables('provisionScriptParametersMaster'),' /usr/bin/nohup /bin/bash -c \"/bin/bash /opt/azure/containers/provision.sh >> /var/log/azure/cluster-provision.log 2>&1\"')]"
+          "commandToExecute": "[concat(variables('provisionScriptParametersCommon'),' ',variables('provisionScriptParametersMaster'),' /usr/bin/nohup /bin/bash -c \"stat /opt/azure/containers/provision.complete || /bin/bash /opt/azure/containers/provision.sh >> /var/log/azure/cluster-provision.log 2>&1\"')]"
         }
       }
     }{{WriteLinkedTemplatesForExtensions}}


### PR DESCRIPTION
and only executing provision.sh if we haven’t already

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: ensures that provision script only runs once

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1752 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
only execute provision script once
```
