### PR TITLE
enabled instance metadata service by default

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -41,6 +41,7 @@ Here are the valid values for the orchestrator types:
 |maxPods|no|The maximum number of pods per node. The minimum valid value, necessary for running kube-system pods, is 5. Default value is 30 when networkPolicy equals azure, 110 otherwise.|
 |gcHighThreshold|no|Sets the --image-gc-high-threshold value on the kublet configuration. Default is 85. [See kubelet Garbage Collection](https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/) |
 |gcLowThreshold|no|Sets the --image-gc-low-threshold value on the kublet configuration. Default is 80. [See kubelet Garbage Collection](https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/) |
+|useInstanceMetadata|no|Use the Azure cloudprovider instance metadata service for appropriate resource discovery operations. Default is `true`.|
 |disabledAddons.dashboard|no|Disable dashboard addon (boolean - default == false, i.e. not disabled)|
 
 ### masterProfile

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -788,7 +788,12 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity
 		},
 		"UseInstanceMetadata": func() bool {
-			return cs.Properties.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata
+			if cs.Properties.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata == nil {
+				return true
+			} else if *cs.Properties.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata {
+				return true
+			}
+			return false
 		},
 		"GetVNETSubnetDependencies": func() string {
 			return getVNETSubnetDependencies(cs.Properties)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -186,7 +186,7 @@ type KubernetesConfig struct {
 	CloudProviderRateLimitBucket     int            `json:"cloudProviderRateLimitBucket,omitempty"`
 	UseManagedIdentity               bool           `json:"useManagedIdentity,omitempty"`
 	CustomHyperkubeImage             string         `json:"customHyperkubeImage,omitempty"`
-	UseInstanceMetadata              bool           `json:"useInstanceMetadata,omitempty"`
+	UseInstanceMetadata              *bool          `json:"useInstanceMetadata,omitempty"`
 	EnableRbac                       bool           `json:"enableRbac,omitempty"`
 	EnableAggregatedAPIs             bool           `json:"enableAggregatedAPIs,omitempty"`
 	GCHighThreshold                  int            `json:"gchighthreshold,omitempty"`

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -204,7 +204,7 @@ type KubernetesConfig struct {
 	CloudProviderRateLimitBucket     int            `json:"cloudProviderRateLimitBucket,omitempty"`
 	UseManagedIdentity               bool           `json:"useManagedIdentity,omitempty"`
 	CustomHyperkubeImage             string         `json:"customHyperkubeImage,omitempty"`
-	UseInstanceMetadata              bool           `json:"useInstanceMetadata,omitempty"`
+	UseInstanceMetadata              *bool          `json:"useInstanceMetadata,omitempty"`
 	EnableRbac                       bool           `json:"enableRbac,omitempty"`
 	EnableAggregatedAPIs             bool           `json:"enableAggregatedAPIs,omitempty"`
 	GCHighThreshold                  int            `json:"gchighthreshold,omitempty"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Enables instance metadata in Azure cloudprovider by default

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1734 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Enabled default support for Azure cloudprovider instance metadata service
```
