### PR TITLE
adding 'cordon and drain' for agent pool upgrades

### DIFF
--- a/examples/k8s-upgrade/v1.7.9-hybrid.json
+++ b/examples/k8s-upgrade/v1.7.9-hybrid.json
@@ -6,7 +6,7 @@
       "orchestratorVersion": "1.7.9"
     },
     "masterProfile": {
-      "count": 3,
+      "count": 1,
       "dnsPrefix": "",
       "vmSize": "Standard_D2_v2",
       "storageProfile" : "ManagedDisks"

--- a/examples/k8s-upgrade/v1.7.9-win.json
+++ b/examples/k8s-upgrade/v1.7.9-win.json
@@ -6,7 +6,7 @@
       "orchestratorVersion": "1.7.9"
     },
     "masterProfile": {
-      "count": 3,
+      "count": 1,
       "dnsPrefix": "",
       "vmSize": "Standard_D2_v2",
       "storageProfile" : "ManagedDisks"

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -61,7 +61,9 @@ func (mkc *MockKubernetesClient) GetNode(name string) (*v1.Node, error) {
 	if mkc.FailGetNode {
 		return nil, fmt.Errorf("GetNode failed")
 	}
-	return &v1.Node{}, nil
+	node := &v1.Node{}
+	node.Status.Conditions = append(node.Status.Conditions, v1.NodeCondition{Type: v1.NodeReady, Status: v1.ConditionTrue})
+	return node, nil
 }
 
 //UpdateNode updates the node in the api server with the passed in info

--- a/pkg/armhelpers/util.go
+++ b/pkg/armhelpers/util.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Azure/acs-engine/pkg/api"
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	log "github.com/sirupsen/logrus"
 )
@@ -138,4 +139,19 @@ func GetVMNameIndex(osType compute.OperatingSystemTypes, vmName string) (int, er
 	}
 
 	return agentIndex, nil
+}
+
+// GetK8sVMName reconstructs VM name
+func GetK8sVMName(osType api.OSType, isAKS bool, nameSuffix, agentPoolName string, agentPoolIndex, agentIndex int) (string, error) {
+	prefix := "k8s"
+	if isAKS {
+		prefix = "aks"
+	}
+	if osType == api.Linux {
+		return fmt.Sprintf("%s-%s-%s-%d", prefix, agentPoolName, nameSuffix, agentIndex), nil
+	}
+	if osType == api.Windows {
+		return fmt.Sprintf("%s%s90%d%d", nameSuffix[:5], prefix, 900+agentPoolIndex, agentIndex), nil
+	}
+	return "", fmt.Errorf("Failed to reconstruct VM Name")
 }

--- a/pkg/armhelpers/util.go
+++ b/pkg/armhelpers/util.go
@@ -151,7 +151,7 @@ func GetK8sVMName(osType api.OSType, isAKS bool, nameSuffix, agentPoolName strin
 		return fmt.Sprintf("%s-%s-%s-%d", prefix, agentPoolName, nameSuffix, agentIndex), nil
 	}
 	if osType == api.Windows {
-		return fmt.Sprintf("%s%s90%d%d", nameSuffix[:5], prefix, 900+agentPoolIndex, agentIndex), nil
+		return fmt.Sprintf("%s%s%d%d", nameSuffix[:5], prefix, 900+agentPoolIndex, agentIndex), nil
 	}
 	return "", fmt.Errorf("Failed to reconstruct VM Name")
 }

--- a/pkg/armhelpers/util_test.go
+++ b/pkg/armhelpers/util_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/acs-engine/pkg/api"
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 )
 
@@ -125,5 +126,27 @@ func Test_GetVMNameIndexWindows(t *testing.T) {
 	}
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func Test_GetK8sVMName(t *testing.T) {
+
+	for _, s := range []struct {
+		osType                     api.OSType
+		isAKS                      bool
+		nameSuffix, agentPoolName  string
+		agentPoolIndex, agentIndex int
+		expected                   string
+	}{
+		{api.Linux, true, "35953384", "agentpool1", 0, 2, "aks-agentpool1-35953384-2"},
+		{api.Windows, false, "35953384", "agentpool1", 0, 2, "35953k8s9002"},
+	} {
+		vmName, err := GetK8sVMName(s.osType, s.isAKS, s.nameSuffix, s.agentPoolName, s.agentPoolIndex, s.agentIndex)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if vmName != s.expected {
+			t.Fatalf("vmName %s, expected %s", vmName, s.expected)
+		}
 	}
 }

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -38,13 +38,19 @@ type UpgradeAgentNode struct {
 // backs up/preserves state as needed by a specific version of Kubernetes and then deletes
 // the node
 func (kan *UpgradeAgentNode) DeleteNode(vmName *string) error {
+	var kubeAPIServerURL string
 
-	// Currently in a single node cluster the api server will not be running when this point is reached on the first node so it will always fail.
-	// err := operations.SafelyDrainNode(kan.Client, log.New().WithField("operation", "upgrade"), kubeAPIServerURL, kan.kubeConfig, *vm.Name)
-	// if err != nil {
-	// 	log.Infoln(fmt.Sprintf("Error draining agent VM: %s", *vm.Name))
-	// 	return err
-	// }
+	if kan.UpgradeContainerService.Properties.HostedMasterProfile != nil {
+		kubeAPIServerURL = kan.UpgradeContainerService.Properties.HostedMasterProfile.FQDN
+	} else {
+		kubeAPIServerURL = kan.UpgradeContainerService.Properties.MasterProfile.FQDN
+	}
+
+	err := operations.SafelyDrainNode(kan.Client, logrus.New().WithField("operation", "upgrade"), kubeAPIServerURL, kan.kubeConfig, *vmName, time.Minute)
+	if err != nil {
+		kan.logger.Errorf(fmt.Sprintf("Error draining agent VM: %s", *vmName))
+		return err
+	}
 
 	if err := operations.CleanDeleteVirtualMachine(kan.Client, kan.logger, kan.ResourceGroup, *vmName); err != nil {
 		return err
@@ -85,10 +91,10 @@ func (kan *UpgradeAgentNode) CreateNode(poolName string, agentNo int) error {
 	return nil
 }
 
-// Validate will verify the that master/agent node has been upgraded as expected.
+// Validate will verify that agent node has been upgraded as expected.
 func (kan *UpgradeAgentNode) Validate(vmName *string) error {
 	if vmName == nil || *vmName == "" {
-		kan.logger.Warningf(fmt.Sprintf("VM name was empty. Skipping node condition check"))
+		kan.logger.Warningf("VM name was empty. Skipping node condition check")
 		return nil
 	}
 
@@ -113,13 +119,13 @@ func (kan *UpgradeAgentNode) Validate(vmName *string) error {
 		for {
 			agentNode, err := client.GetNode(*vmName)
 			if err != nil {
-				kan.logger.Infof(fmt.Sprintf("Agent VM: %s status error: %v\n", *vmName, err))
+				kan.logger.Infof("Agent VM: %s status error: %v\n", *vmName, err)
 				time.Sleep(time.Second * 5)
 			} else if node.IsNodeReady(agentNode) {
-				kan.logger.Infof(fmt.Sprintf("Agent VM: %s is ready", *vmName))
+				kan.logger.Infof("Agent VM: %s is ready", *vmName)
 				ch <- struct{}{}
 			} else {
-				kan.logger.Infof(fmt.Sprintf("Agent VM: %s not ready yet...", *vmName))
+				kan.logger.Infof("Agent VM: %s not ready yet...", *vmName)
 				time.Sleep(time.Second * 5)
 			}
 		}
@@ -130,7 +136,7 @@ func (kan *UpgradeAgentNode) Validate(vmName *string) error {
 		case <-ch:
 			return nil
 		case <-time.After(timeout):
-			kan.logger.Errorf(fmt.Sprintf("Node was not ready within %v", timeout))
+			kan.logger.Errorf("Node was not ready within %v", timeout)
 			return fmt.Errorf("Node was not ready within %v", timeout)
 		}
 	}

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -105,10 +105,6 @@ func (kan *UpgradeAgentNode) Validate(vmName *string) error {
 		masterURL = kan.UpgradeContainerService.Properties.MasterProfile.FQDN
 	}
 
-	if masterURL == "" {
-		return kan.Translator.Errorf("Control plane FQDN was not set.")
-	}
-
 	client, err := kan.Client.GetKubernetesClient(masterURL, kan.kubeConfig, interval, timeout)
 	if err != nil {
 		return err

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -106,7 +106,7 @@ func (kan *UpgradeAgentNode) Validate(vmName *string) error {
 	}
 
 	if masterURL == "" {
-		kan.Translator.Errorf("Control plane FQDN was not set.")
+		return kan.Translator.Errorf("Control plane FQDN was not set.")
 	}
 
 	client, err := kan.Client.GetKubernetesClient(masterURL, kan.kubeConfig, interval, timeout)

--- a/pkg/operations/kubernetesupgrade/upgrademasternode.go
+++ b/pkg/operations/kubernetesupgrade/upgrademasternode.go
@@ -87,10 +87,6 @@ func (kmn *UpgradeMasterNode) Validate(vmName *string) error {
 
 	masterURL := kmn.UpgradeContainerService.Properties.MasterProfile.FQDN
 
-	if masterURL == "" {
-		return kmn.Translator.Errorf("Control plane FQDN was not set.")
-	}
-
 	client, err := kmn.Client.GetKubernetesClient(masterURL, kmn.kubeConfig, interval, timeout)
 	if err != nil {
 		return err

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -282,9 +282,9 @@ func (ku *Upgrader) upgradeAgentPools() error {
 					ku.logger.Infof("Error validating upgraded agent VM: %s, err: %v\n", vm.Name, err)
 					return err
 				}
-				upgradedCount++
 				vm.Upgraded = true
 			}
+			upgradedCount++
 		}
 
 		agentsToCreate := agentCount - upgradedCount

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -231,14 +231,11 @@ func (ku *Upgrader) upgradeAgentPools() error {
 			upgradeVMs[agentIndex] = &UpgradeVM{*vm.Name, false}
 		}
 
-		// Create an auxiliary node if hasn't been created yet.
-		// This node is used to take on the load from deleting nodes
-		addedNode := false
+		// Create an auxiliary node if hasn't been created yet. This node is used to take on the load from deleting nodes.
 		// In a normal mode of operation the actual number of VMs in the pool [len(upgradeVMs)] is equal to agentCount.
 		// However, if the upgrade failed in the middle, the actual number of VMs might be agentCount+1 to include auxiliary node.
 		// In the later case we don't create an extra node.
 		if agentCount > 0 && len(upgradeVMs) == agentCount {
-			addedNode = true
 			agentIndex := getAvailableIndex(upgradeVMs)
 			ku.logger.Infof("Adding auxiliary agent node with index %d", agentIndex)
 
@@ -267,7 +264,7 @@ func (ku *Upgrader) upgradeAgentPools() error {
 			}
 
 			// do not create last node in favor of auxiliary node
-			if addedNode && upgradedCount == toBeUpgraded-1 {
+			if upgradedCount == toBeUpgraded-1 {
 				ku.logger.Infof("Skipping creation of VM %s (indx %d) in favor of auxiliary node", vm.Name, agentIndex)
 				delete(upgradeVMs, agentIndex)
 			} else {

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -241,24 +241,24 @@ func (ku *Upgrader) upgradeAgentPools() error {
 		// However, if the upgrade failed in the middle, the actual number of VMs might be less than that.
 		for agentCount > 0 && len(upgradeVMs) <= agentCount {
 			agentIndex := getAvailableIndex(upgradeVMs)
-			ku.logger.Infof("Adding auxiliary agent node with index %d", agentIndex)
 
 			vmName, err := armhelpers.GetK8sVMName(agentOsType, ku.DataModel.Properties.HostedMasterProfile != nil,
 				ku.NameSuffix, agentPoolName, agentPoolIndex, agentIndex)
 			if err != nil {
-				ku.logger.Infof("Error reconstructing VM name\n")
+				ku.logger.Infof("Error reconstructing agent VM name with index %d\n", agentIndex)
 				return err
 			}
+			ku.logger.Infof("Adding agent node %s (index %d)", vmName, agentIndex)
 
 			err = upgradeAgentNode.CreateNode(*agentPool.Name, agentIndex)
 			if err != nil {
-				ku.logger.Infof("Error creating agent VM[%d] %s: %v\n", agentIndex, vmName, err)
+				ku.logger.Infof("Error creating agent node %s (index %d): %v\n", vmName, agentIndex, err)
 				return err
 			}
 
 			err = upgradeAgentNode.Validate(&vmName)
 			if err != nil {
-				ku.logger.Infof("Error validating agent VM[%d] %s: %v\n", agentIndex, vmName, err)
+				ku.logger.Infof("Error validating agent node %s (index %d): %v\n", vmName, agentIndex, err)
 				return err
 			}
 

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -19,6 +19,12 @@ type Upgrader struct {
 	kubeConfig string
 }
 
+// UpgradeVM holds VM name and upgrade status
+type UpgradeVM struct {
+	Name     string
+	Upgraded bool
+}
+
 // Init initializes an upgrader struct
 func (ku *Upgrader) Init(translator *i18n.Translator, logger *logrus.Entry, clusterTopology ClusterTopology, client armhelpers.ACSEngineClient, kubeConfig string) {
 	ku.Translator = translator
@@ -76,6 +82,7 @@ func (ku *Upgrader) upgradeMasterNodes() error {
 	upgradeMasterNode.UpgradeContainerService = ku.ClusterTopology.DataModel
 	upgradeMasterNode.ResourceGroup = ku.ClusterTopology.ResourceGroup
 	upgradeMasterNode.Client = ku.Client
+	upgradeMasterNode.kubeConfig = ku.kubeConfig
 
 	expectedMasterCount := ku.ClusterTopology.DataModel.Properties.MasterProfile.Count
 	mastersUpgradedCount := len(*ku.ClusterTopology.UpgradedMasterVMs)
@@ -167,14 +174,6 @@ func (ku *Upgrader) upgradeMasterNodes() error {
 }
 
 func (ku *Upgrader) upgradeAgentPools() error {
-	// Unused until safely drain node is being called
-	// var kubeAPIServerURL string
-	// if ku.DataModel.Properties.MasterProfile != nil {
-	// 	kubeAPIServerURL = ku.DataModel.Properties.MasterProfile.FQDN
-	// }
-	// if ku.DataModel.Properties.HostedMasterProfile != nil {
-	// 	kubeAPIServerURL = ku.DataModel.Properties.HostedMasterProfile.FQDN
-	// }
 	for _, agentPool := range ku.ClusterTopology.AgentPools {
 		// Upgrade Agent VMs
 		templateMap, parametersMap, err := ku.generateUpgradeTemplate(ku.ClusterTopology.DataModel)
@@ -216,51 +215,86 @@ func (ku *Upgrader) upgradeAgentPools() error {
 		upgradeAgentNode.Client = ku.Client
 		upgradeAgentNode.kubeConfig = ku.kubeConfig
 
-		upgradedAgentsIndex := make(map[int]bool)
+		upgradeVMs := make(map[int]*UpgradeVM)
 
 		for _, vm := range *agentPool.UpgradedAgentVMs {
 			ku.logger.Infof("Agent VM: %s, pool name: %s on expected orchestrator version\n", *vm.Name, *agentPool.Name)
 			agentIndex, _ := armhelpers.GetVMNameIndex(vm.StorageProfile.OsDisk.OsType, *vm.Name)
-			upgradedAgentsIndex[agentIndex] = true
+			upgradeVMs[agentIndex] = &UpgradeVM{*vm.Name, true}
 		}
 
 		ku.logger.Infof("Starting upgrade of agent nodes in pool identifier: %s, name: %s...\n",
 			*agentPool.Identifier, *agentPool.Name)
 
 		for _, vm := range *agentPool.AgentVMs {
-			ku.logger.Infof("Upgrading Agent VM: %s, pool name: %s\n", *vm.Name, *agentPool.Name)
-
 			agentIndex, _ := armhelpers.GetVMNameIndex(vm.StorageProfile.OsDisk.OsType, *vm.Name)
+			upgradeVMs[agentIndex] = &UpgradeVM{*vm.Name, false}
+		}
 
-			err := upgradeAgentNode.DeleteNode(vm.Name)
-			if err != nil {
-				ku.logger.Infof("Error deleting agent VM: %s\n", *vm.Name)
-				return err
-			}
+		// Create an auxiliary node if hasn't been created yet.
+		// This node is used to take on the load from deleting nodes
+		addedNode := false
+		// In a normal mode of operation the actual number of VMs in the pool [len(upgradeVMs)] is equal to agentCount.
+		// However, if the upgrade failed in the middle, the actual number of VMs might be agentCount+1 to include auxiliary node.
+		// In the later case we don't create an extra node.
+		if agentCount > 0 && len(upgradeVMs) == agentCount {
+			addedNode = true
+			agentIndex := getAvailableIndex(upgradeVMs)
+			ku.logger.Infof("Adding auxiliary agent node with index %d", agentIndex)
 
 			err = upgradeAgentNode.CreateNode(*agentPool.Name, agentIndex)
 			if err != nil {
-				ku.logger.Infof("Error creating upgraded agent VM: %s\n", *vm.Name)
+				ku.logger.Infof("Error creating auxiliary node\n")
 				return err
 			}
-
-			err = upgradeAgentNode.Validate(vm.Name)
-			if err != nil {
-				ku.logger.Infof("Error validating upgraded agent VM: %s, err: %v\n", *vm.Name, err)
-				return err
-			}
-
-			upgradedAgentsIndex[agentIndex] = true
+			// It is possible to reconstruct VM name, but we don't have to.
+			// The VM name is need for nodes that require upgrade. However this node already has desired orchestrator version.
+			upgradeVMs[agentIndex] = &UpgradeVM{"", true}
 		}
 
-		agentsToCreate := agentCount - len(upgradedAgentsIndex)
+		// Upgrade nodes in agent pool
+		upgradedCount, toBeUpgraded := 0, len(*agentPool.AgentVMs)
+		for agentIndex, vm := range upgradeVMs {
+			if vm.Upgraded {
+				continue
+			}
+			ku.logger.Infof("Upgrading Agent VM: %s, pool name: %s\n", vm.Name, *agentPool.Name)
+
+			err := upgradeAgentNode.DeleteNode(&vm.Name)
+			if err != nil {
+				ku.logger.Infof("Error deleting agent VM: %s\n", vm.Name)
+				return err
+			}
+
+			// do not create last node in favor of auxiliary node
+			if addedNode && upgradedCount == toBeUpgraded-1 {
+				ku.logger.Infof("Skipping creation of VM %s (indx %d) in favor of auxiliary node", vm.Name, agentIndex)
+				delete(upgradeVMs, agentIndex)
+			} else {
+				err = upgradeAgentNode.CreateNode(*agentPool.Name, agentIndex)
+				if err != nil {
+					ku.logger.Infof("Error creating upgraded agent VM: %s\n", vm.Name)
+					return err
+				}
+
+				err = upgradeAgentNode.Validate(&vm.Name)
+				if err != nil {
+					ku.logger.Infof("Error validating upgraded agent VM: %s, err: %v\n", vm.Name, err)
+					return err
+				}
+				upgradedCount++
+				vm.Upgraded = true
+			}
+		}
+
+		agentsToCreate := agentCount - upgradedCount
 		ku.logger.Infof("Expected agent count in the pool: %d, Creating %d more agents\n", agentCount, agentsToCreate)
 
 		// NOTE: this is NOT completely idempotent because it assumes that
 		// the OS disk has been deleted
 		for i := 0; i < agentsToCreate; i++ {
 			agentIndexToCreate := 0
-			for upgradedAgentsIndex[agentIndexToCreate] == true {
+			for upgradeVMs[agentIndexToCreate].Upgraded == true {
 				agentIndexToCreate++
 			}
 
@@ -279,7 +313,7 @@ func (ku *Upgrader) upgradeAgentPools() error {
 				return err
 			}
 
-			upgradedAgentsIndex[agentIndexToCreate] = true
+			upgradeVMs[agentIndexToCreate].Upgraded = true
 		}
 	}
 
@@ -310,4 +344,23 @@ func (ku *Upgrader) generateUpgradeTemplate(upgradeContainerService *api.Contain
 	parametersMap := parameters.(map[string]interface{})
 
 	return templateMap, parametersMap, nil
+}
+
+// return unused index within the range of agent indices, or subsequent index
+func getAvailableIndex(vms map[int]*UpgradeVM) int {
+	maxIndex := 0
+
+	for indx := range vms {
+		if indx > maxIndex {
+			maxIndex = indx
+		}
+	}
+
+	for indx := 0; indx < maxIndex; indx++ {
+		if _, found := vms[indx]; !found {
+			return indx
+		}
+	}
+
+	return maxIndex + 1
 }


### PR DESCRIPTION
- adding 'cordon and drain' for agent pool upgrades
- creating a new agent node prior to starting deleting and recreating existing agent nodes
- waiting for master nodes to become ready after upgrade prior to proceeding with agent pool upgrades