### PR TITLE
fix(docs): use release-1.5 for influxdb/grafana install

### DIFF
--- a/docs/kubernetes/monitoring.md
+++ b/docs/kubernetes/monitoring.md
@@ -73,15 +73,14 @@ Another option to see stats is via Grafana and Influx DB. Grafana is a powerful 
 
 To set up Grafana, we will need to deploy Grafana and InfluxDB. We will also need to configure Heapster to use InfluxDB as its storage backend. 
 
-1. `git clone https://github.com/kubernetes/Heapster.git $HOME/heapster`
-1. `cd $HOME/heapster`
-1. `git checkout release-1.4`
-1. `git cherry-pick c674a16f74782b326f02345486b5f9520891f395` (This works around the [open issue](https://github.com/kubernetes/Heapster/issues/1783) with Grafana deployments currently)
-1. `kubectl create -f deploy/kube-config/influxdb/influxdb.yaml`
-1. `kubectl create -f deploy/kube-config/influxdb/grafana.yaml`
+1. `wget https://raw.githubusercontent.com/kubernetes/heapster/release-1.5/deploy/kube-config/influxdb/influxdb.yaml`
+1. `wget https://raw.githubusercontent.com/kubernetes/heapster/release-1.5/deploy/kube-config/influxdb/grafana.yaml`
+1. `kubectl create -f influxdb.yaml`
+1. `kubectl create -f grafana.yaml`
 1. `kubectl get pods --namespace=kube-system` Ensure that Heapster, Grafana and InfluxDB are in the `Running` state
 1. `kubectl edit deployment/heapster --namespace=kube-system`
-1. We need to configure Heapster to use InfluxDB as the the data store. To do that under the spec > containers > command property change the command field from:
+    
+    We need to configure Heapster to use InfluxDB as the the data store. To do that under the spec > containers > command property change the command field from:
    ``` yaml
    - command:
      - /heapster


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Update influxdb/grafana instructions to use `release-1.5` which greatly simplifies the overall install as it includes the fix to  https://github.com/kubernetes/Heapster/issues/1783

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: N/A

**Special notes for your reviewer**:
Tested on a v1.8.3 cluster deployed through `acs-engine` and it works. Can see pretty graphs in grafana.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
