### PR TITLE
fixes azure networkPolicy regression

### DIFF
--- a/examples/networkpolicy/kubernetes-azure.json
+++ b/examples/networkpolicy/kubernetes-azure.json
@@ -1,0 +1,44 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "kubernetesConfig": {
+        "networkPolicy": "azure"
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      },
+      {
+        "name": "agentpool2",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    }
+  }
+}

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -10,11 +10,6 @@ import (
 )
 
 const (
-	// CniPluginVer specifies version of CNI plugin, mirrored from
-	// https://github.com/containernetworking/cni/releases/download/${CNI_PLUGIN_VER}/cni-amd64-${CNI_PLUGIN_VER}.tgz
-	// to https://acs-mirror.azureedge.net/cni/
-	CniPluginVer = "v0.6.0"
-
 	// AzureCniPluginVer specifies version of Azure CNI plugin, which has been mirrored from
 	// https://github.com/Azure/azure-container-networking/releases/download/${AZURE_PLUGIN_VER}/azure-vnet-cni-linux-amd64-${AZURE_PLUGIN_VER}.tgz
 	// to https://acs-mirror.azureedge.net/cni/
@@ -29,7 +24,7 @@ var (
 		EtcdDownloadURLBase:              "https://acs-mirror.azureedge.net/github-coreos",
 		KubeBinariesSASURLBase:           "https://acs-mirror.azureedge.net/wink8s/",
 		WindowsTelemetryGUID:             "fb801154-36b9-41bc-89c2-f4d4f05472b0",
-		CNIPluginsDownloadURL:            "https://acs-mirror.azureedge.net/cni/cni-amd64-" + CniPluginVer + ".tgz",
+		CNIPluginsDownloadURL:            "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-latest.tgz",
 		VnetCNILinuxPluginsDownloadURL:   "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-" + AzureCniPluginVer + ".tgz",
 		VnetCNIWindowsPluginsDownloadURL: "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-" + AzureCniPluginVer + ".zip",
 	}

--- a/test/acse-conf/acse-regression.json
+++ b/test/acse-conf/acse-regression.json
@@ -70,6 +70,10 @@
       "category": "network"
     },
     {
+      "cluster_definition": "networkpolicy/kubernetes-azure.json",
+      "category": "network"
+    },
+    {
       "cluster_definition": "kubernetes-config/kubernetes-clustersubnet.json",
       "category": "network"
     },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Reverts a change to the download URL for azure CNI. Also adds E2E coverage for `"networkPolicy": "azure"` cluster scenarios.

Fixes #1775 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```