### PR TITLE
WIP: orchestrator version support across cluster contexts

### DIFF
--- a/pkg/api/apiloader_test.go
+++ b/pkg/api/apiloader_test.go
@@ -57,7 +57,7 @@ func TestLoadContainerServiceFromFile(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesDefaultVersion {
+	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesDefaultVersions[common.ACSContext] {
 		t.Errorf("Failed  set orcherstator version when it is not set in the json, got %s", containerService.Properties.OrchestratorProfile.OrchestratorVersion)
 	}
 
@@ -65,7 +65,7 @@ func TestLoadContainerServiceFromFile(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesDefaultVersion {
+	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesDefaultVersions[common.ACSContext] {
 		t.Errorf("Failed  set orcherstator version when it is not set in the json, got %s", containerService.Properties.OrchestratorProfile.OrchestratorVersion)
 	}
 

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -1,5 +1,7 @@
 package common
 
+type ClusterContext string
+
 // the orchestrators supported
 const (
 	// Mesos is the string constant for MESOS orchestrator type
@@ -91,6 +93,22 @@ const (
 	KubernetesDefaultVersion string = KubernetesVersion1Dot7Dot9
 )
 
+const (
+	// AKSContext is a managed cluster context
+	AKSContext ClusterContext = "aks"
+	// ACSContext is traditional ACS RP context
+	ACSContext ClusterContext = "acs"
+	// VlabsContext is non-SLA context, e.g., CLI
+	VlabsContext ClusterContext = "vlabs"
+)
+
+// KubernetesDefaultVersions returns default Kubernetes cluster versions for each cluster context
+var KubernetesDefaultVersions = map[ClusterContext]string{
+	AKSContext:   KubernetesVersion1Dot7Dot9,
+	ACSContext:   KubernetesVersion1Dot7Dot9,
+	VlabsContext: KubernetesVersion1Dot7Dot9,
+}
+
 // AllKubernetesSupportedVersions is a whitelist map of supported Kubernetes version strings
 var AllKubernetesSupportedVersions = map[string]bool{
 	KubernetesVersion1Dot5Dot7:  true,
@@ -112,18 +130,66 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	KubernetesVersion1Dot8Dot2:  true,
 }
 
+// GetSupportedOrchestratorVersions returns a hash table of orchestrator support by cluster context
+func GetSupportedOrchestratorVersions(c ClusterContext) map[string]map[string]bool {
+	switch c {
+	case ACSContext:
+		return map[string]map[string]bool{
+			Kubernetes: {
+				KubernetesVersion1Dot6Dot9:  true,
+				KubernetesVersion1Dot6Dot11: true,
+				KubernetesVersion1Dot7Dot7:  true,
+				KubernetesVersion1Dot7Dot9:  true,
+				KubernetesVersion1Dot8Dot1:  true,
+				KubernetesVersion1Dot8Dot2:  true,
+			},
+			DCOS: {
+				DCOSVersion1Dot8Dot8:  true,
+				DCOSVersion1Dot9Dot0:  true,
+				DCOSVersion1Dot10Dot0: true,
+			},
+			Swarm:     {},
+			SwarmMode: {},
+		}
+	case AKSContext:
+		return map[string]map[string]bool{
+			Kubernetes: {
+				KubernetesVersion1Dot7Dot7: true,
+				KubernetesVersion1Dot7Dot9: true,
+				KubernetesVersion1Dot8Dot1: true,
+				KubernetesVersion1Dot8Dot2: true,
+			},
+		}
+	case VlabsContext:
+		return map[string]map[string]bool{
+			Kubernetes: AllKubernetesSupportedVersions,
+			DCOS:       AllDCOSSupportedVersions,
+		}
+	}
+	return nil
+}
+
 // GetSupportedKubernetesVersion verifies that a passed-in version string is supported, or returns a default version string if not
-func GetSupportedKubernetesVersion(version string) string {
+func GetSupportedKubernetesVersion(version string, c ClusterContext) string {
 	if k8sVersion := version; AllKubernetesSupportedVersions[k8sVersion] {
 		return k8sVersion
 	}
-	return KubernetesDefaultVersion
+	return KubernetesDefaultVersions[c]
 }
 
 // GetAllSupportedKubernetesVersions returns a slice of all supported Kubernetes versions
 func GetAllSupportedKubernetesVersions() []string {
 	versions := make([]string, 0, len(AllKubernetesSupportedVersions))
 	for k := range AllKubernetesSupportedVersions {
+		versions = append(versions, k)
+	}
+	return versions
+}
+
+// GetAllSupportedDCOSVersions returns a slice of all supported DCOS versions
+func GetAllSupportedDCOSVersions() []string {
+	versions := make([]string, 0, len(AllDCOSSupportedVersions))
+	for k := range AllDCOSSupportedVersions {
 		versions = append(versions, k)
 	}
 	return versions
@@ -153,9 +219,9 @@ const (
 	DCOSDefaultVersion string = DCOSVersion1Dot9Dot0
 )
 
-// AllDCOSSupportedVersions maintain a list of available dcos versions in acs-engine
-var AllDCOSSupportedVersions = []string{
-	DCOSVersion1Dot10Dot0,
-	DCOSVersion1Dot9Dot0,
-	DCOSVersion1Dot8Dot8,
+// AllDCOSSupportedVersions is a whitelist map of supported DCOS version strings
+var AllDCOSSupportedVersions = map[string]bool{
+	DCOSVersion1Dot10Dot0: true,
+	DCOSVersion1Dot9Dot0:  true,
+	DCOSVersion1Dot8Dot8:  true,
 }

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -1,5 +1,6 @@
 package common
 
+// ClusterContext e.g., "acs", "aks", or "vlabs"
 type ClusterContext string
 
 // the orchestrators supported

--- a/pkg/api/common/const_test.go
+++ b/pkg/api/common/const_test.go
@@ -25,14 +25,14 @@ func Test_GetAllSupportedKubernetesVersions(t *testing.T) {
 func Test_GetSupportedKubernetesVersion(t *testing.T) {
 	versions := GetAllSupportedKubernetesVersions()
 	for _, version := range versions {
-		supportedVersion := GetSupportedKubernetesVersion(version)
+		supportedVersion := GetSupportedKubernetesVersion(version, ACSContext)
 		if supportedVersion != version {
-			t.Errorf("GetSupportedKubernetesVersion(%s) should return the same passed-in string, instead returned %s", version, supportedVersion)
+			t.Errorf("GetSupportedKubernetesVersion(%s, %s) should return the same passed-in string, instead returned %s", version, ACSContext, supportedVersion)
 		}
 	}
 
-	defaultVersion := GetSupportedKubernetesVersion("")
-	if defaultVersion != KubernetesDefaultVersion {
-		t.Errorf("GetSupportedKubernetesVersion(\"\") should return the default version %s, instead returned %s", KubernetesDefaultVersion, defaultVersion)
+	defaultVersion := GetSupportedKubernetesVersion("", ACSContext)
+	if defaultVersion != KubernetesDefaultVersions[ACSContext] {
+		t.Errorf("GetSupportedKubernetesVersion(\"\", %s) should return the default version %s, instead returned %s", KubernetesDefaultVersions[ACSContext], ACSContext, defaultVersion)
 	}
 }

--- a/pkg/api/common/helper.go
+++ b/pkg/api/common/helper.go
@@ -55,12 +55,12 @@ func HandleValidationErrors(e validator.ValidationErrors) error {
 }
 
 // GetSupportedVersions get supported version list for a certain orchestrator
-func GetSupportedVersions(orchType string) (versions []string, defaultVersion string) {
+func GetSupportedVersions(orchType string, c ClusterContext) (versions []string, defaultVersion string) {
 	switch orchType {
 	case Kubernetes:
-		return GetAllSupportedKubernetesVersions(), string(KubernetesDefaultVersion)
+		return GetAllSupportedKubernetesVersions(), KubernetesDefaultVersions[c]
 	case DCOS:
-		return AllDCOSSupportedVersions, DCOSDefaultVersion
+		return GetAllSupportedDCOSVersions(), DCOSDefaultVersion
 	default:
 		return nil, ""
 	}
@@ -95,7 +95,7 @@ func GetValidPatchVersion(orchType, orchVer string) string {
 
 // RationalizeReleaseAndVersion return a version when it can be rationalized from the input, otherwise ""
 func RationalizeReleaseAndVersion(orchType, orchRel, orchVer string) (version string) {
-	supportedVersions, defaultVersion := GetSupportedVersions(orchType)
+	supportedVersions, defaultVersion := GetSupportedVersions(orchType, ACSContext)
 	if supportedVersions == nil {
 		return ""
 	}

--- a/pkg/api/common/helper_test.go
+++ b/pkg/api/common/helper_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func Test_GetValidPatchVersion(t *testing.T) {
 	version := GetValidPatchVersion(Kubernetes, "")
-	if version != KubernetesDefaultVersion {
+	if version != KubernetesDefaultVersions[ACSContext] {
 		t.Errorf("It is not the default Kubernetes version")
 	}
 
@@ -26,7 +26,7 @@ func Test_GetValidPatchVersion(t *testing.T) {
 
 func Test_RationalizeReleaseAndVersion(t *testing.T) {
 	version := RationalizeReleaseAndVersion(Kubernetes, "", "")
-	if version != KubernetesDefaultVersion {
+	if version != KubernetesDefaultVersions[ACSContext] {
 		t.Errorf("It is not the default Kubernetes version")
 	}
 

--- a/pkg/api/convertertoagentpoolonlyapi.go
+++ b/pkg/api/convertertoagentpoolonlyapi.go
@@ -189,14 +189,14 @@ func convertVLabsAgentPoolOnlyWindowsProfile(vlabs *vlabs.WindowsProfile, api *W
 func convertV20170831AgentPoolOnlyOrchestratorProfile(kubernetesVersion string) *OrchestratorProfile {
 	return &OrchestratorProfile{
 		OrchestratorType:    Kubernetes,
-		OrchestratorVersion: common.GetSupportedKubernetesVersion(kubernetesVersion),
+		OrchestratorVersion: common.GetSupportedKubernetesVersion(kubernetesVersion, common.ACSContext),
 	}
 }
 
 func convertVLabsAgentPoolOnlyOrchestratorProfile(kubernetesVersion string) *OrchestratorProfile {
 	return &OrchestratorProfile{
 		OrchestratorType:    Kubernetes,
-		OrchestratorVersion: common.GetSupportedKubernetesVersion(kubernetesVersion),
+		OrchestratorVersion: common.GetSupportedKubernetesVersion(kubernetesVersion, common.ACSContext),
 	}
 }
 

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -527,7 +527,7 @@ func convertV20160330OrchestratorProfile(v20160330 *v20160330.OrchestratorProfil
 func convertV20170131OrchestratorProfile(v20170131 *v20170131.OrchestratorProfile, api *OrchestratorProfile) {
 	api.OrchestratorType = v20170131.OrchestratorType
 	if api.OrchestratorType == Kubernetes {
-		api.OrchestratorVersion = common.KubernetesDefaultVersion
+		api.OrchestratorVersion = common.KubernetesDefaultVersions[common.ACSContext]
 	} else if api.OrchestratorType == DCOS {
 		api.OrchestratorVersion = DCOSVersion1Dot9Dot0
 	}
@@ -542,7 +542,7 @@ func convertV20170701OrchestratorProfile(v20170701cs *v20170701.OrchestratorProf
 
 	switch api.OrchestratorType {
 	case Kubernetes:
-		api.OrchestratorVersion = common.GetSupportedKubernetesVersion(v20170701cs.OrchestratorVersion)
+		api.OrchestratorVersion = common.GetSupportedKubernetesVersion(v20170701cs.OrchestratorVersion, common.ACSContext)
 	case DCOS:
 		switch v20170701cs.OrchestratorVersion {
 		case DCOSVersion1Dot10Dot0, DCOSVersion1Dot9Dot0, DCOSVersion1Dot8Dot8:

--- a/pkg/api/convertertoapi_test.go
+++ b/pkg/api/convertertoapi_test.go
@@ -86,7 +86,7 @@ func TestOrchestratorVersion(t *testing.T) {
 		},
 	}
 	cs := ConvertV20170701ContainerService(v20170701cs)
-	if cs.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesDefaultVersion {
+	if cs.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesDefaultVersions[common.ACSContext] {
 		t.Fatalf("incorrect OrchestratorVersion '%s'", cs.Properties.OrchestratorProfile.OrchestratorVersion)
 	}
 
@@ -111,7 +111,7 @@ func TestOrchestratorVersion(t *testing.T) {
 		},
 	}
 	cs = ConvertVLabsContainerService(vlabscs)
-	if cs.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesDefaultVersion {
+	if cs.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesDefaultVersions[common.ACSContext] {
 		t.Fatalf("incorrect OrchestratorVersion '%s'", cs.Properties.OrchestratorProfile.OrchestratorVersion)
 	}
 

--- a/pkg/api/orchestrators.go
+++ b/pkg/api/orchestrators.go
@@ -127,7 +127,7 @@ func kubernetesInfo(csOrch *OrchestratorProfile) ([]*OrchestratorVersionProfile,
 						OrchestratorType:    Kubernetes,
 						OrchestratorVersion: ver,
 					},
-					Default:  ver == common.KubernetesDefaultVersion,
+					Default:  ver == common.KubernetesDefaultVersions[common.ACSContext],
 					Upgrades: upgrades,
 				})
 		}
@@ -148,7 +148,7 @@ func kubernetesInfo(csOrch *OrchestratorProfile) ([]*OrchestratorVersionProfile,
 					OrchestratorType:    Kubernetes,
 					OrchestratorVersion: csOrch.OrchestratorVersion,
 				},
-				Default:  csOrch.OrchestratorVersion == common.KubernetesDefaultVersion,
+				Default:  csOrch.OrchestratorVersion == common.KubernetesDefaultVersions[common.ACSContext],
 				Upgrades: upgrades,
 			})
 	}
@@ -206,7 +206,7 @@ func dcosInfo(csOrch *OrchestratorProfile) ([]*OrchestratorVersionProfile, error
 	orchs := []*OrchestratorVersionProfile{}
 	if csOrch.OrchestratorVersion == "" {
 		// get info for all supported versions
-		for _, ver := range common.AllDCOSSupportedVersions {
+		for _, ver := range common.GetAllSupportedDCOSVersions() {
 			orchs = append(orchs,
 				&OrchestratorVersionProfile{
 					OrchestratorProfile: OrchestratorProfile{

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorVersion != "" {
 				Expect(version).To(MatchRegexp("v" + eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorVersion))
 			} else {
-				Expect(version).To(Equal("v" + common.KubernetesDefaultVersion))
+				Expect(version).To(Equal("v" + common.KubernetesDefaultVersions[common.ACSContext]))
 			}
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This PR aims to centralize and clarify the way acs-engine enforces version support across the following contexts:

- which orchestrator? (e.g., Kubernetes, DC/OS)
- which cluster context (e.g., acs-engine CLI, ACS portal)

Fixes #1800

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
standardize version support across cluster contexts
```
