### PR TITLE
renamed IsVNETIntegrated to IsAzureCNI

### DIFF
--- a/parts/kubernetesagentcustomdata.yml
+++ b/parts/kubernetesagentcustomdata.yml
@@ -142,7 +142,7 @@ write_files:
   content: |
     #!/bin/bash
 
-{{if IsVNETIntegrated}}
+{{if IsAzureCNI}}
     # SNAT outbound traffic from pods to destinations outside of VNET.
     iptables -t nat -A POSTROUTING -m iprange ! --dst-range 168.63.129.16 -m addrtype ! --dst-type local ! -d {{WrapAsVariable "vnetCidr"}} -j MASQUERADE
 {{end}}

--- a/parts/kubernetesagentresourcesvmas.t
+++ b/parts/kubernetesagentresourcesvmas.t
@@ -36,7 +36,7 @@
           {{if lt $seq $.IPAddressCount}},{{end}}
           {{end}}
         ]
-{{if not IsVNETIntegrated}}
+{{if not IsAzureCNI}}
         ,
         "enableIPForwarding": true
 {{end}}

--- a/parts/kubernetesbase.t
+++ b/parts/kubernetesbase.t
@@ -59,7 +59,7 @@
       "apiVersion": "[variables('apiVersionDefault')]",
       "dependsOn": [
         "[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgName'))]"
-    {{if not IsVNETIntegrated}}
+    {{if not IsAzureCNI}}
         ,
         "[concat('Microsoft.Network/routeTables/', variables('routeTableName'))]"
     {{end}}
@@ -80,7 +80,7 @@
               "networkSecurityGroup": {
                 "id": "[variables('nsgID')]"
               }
-    {{if not IsVNETIntegrated}}
+    {{if not IsAzureCNI}}
               ,
               "routeTable": {
                 "id": "[variables('routeTableID')]"
@@ -92,7 +92,7 @@
       },
       "type": "Microsoft.Network/virtualNetworks"
     },
-    {{if not IsVNETIntegrated}}
+    {{if not IsAzureCNI}}
     {
       "apiVersion": "[variables('apiVersionDefault')]",
       "location": "[variables('location')]",

--- a/parts/kubernetesmastercustomdata.yml
+++ b/parts/kubernetesmastercustomdata.yml
@@ -264,7 +264,7 @@ write_files:
     iptables -t nat -A PREROUTING -p tcp --dport 4443 -j REDIRECT --to-port 443
 {{end}}
 
-{{if IsVNETIntegrated}}
+{{if IsAzureCNI}}
     # SNAT outbound traffic from pods to destinations outside of VNET.
     iptables -t nat -A POSTROUTING -m iprange ! --dst-range 168.63.129.16 -m addrtype ! --dst-type local ! -d {{WrapAsVariable "vnetCidr"}} -j MASQUERADE
 {{end}}

--- a/parts/kubernetesmasterresources.t
+++ b/parts/kubernetesmasterresources.t
@@ -37,7 +37,7 @@
       "apiVersion": "[variables('apiVersionDefault')]",
       "dependsOn": [
         "[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgName'))]"
-{{if not IsVNETIntegrated}}
+{{if not IsAzureCNI}}
         ,
         "[concat('Microsoft.Network/routeTables/', variables('routeTableName'))]"
 {{end}}
@@ -58,7 +58,7 @@
               "networkSecurityGroup": {
                 "id": "[variables('nsgID')]"
               }
-{{if not IsVNETIntegrated}}
+{{if not IsAzureCNI}}
               ,
               "routeTable": {
                 "id": "[variables('routeTableID')]"
@@ -125,7 +125,7 @@
       },
       "type": "Microsoft.Network/networkSecurityGroups"
     },
-{{if not IsVNETIntegrated}}
+{{if not IsAzureCNI}}
     {
       "apiVersion": "[variables('apiVersionDefault')]",
       "location": "[variables('location')]",
@@ -337,7 +337,7 @@
               }
             }
           }
-{{if IsVNETIntegrated}}
+{{if IsAzureCNI}}
           {{range $seq := loop 2 .MasterProfile.IPAddressCount}}
           ,
           {
@@ -353,7 +353,7 @@
           {{end}}
 {{end}}
         ]
-{{if not IsVNETIntegrated}}
+{{if not IsAzureCNI}}
         ,
         "enableIPForwarding": true
 {{end}}

--- a/parts/kubernetesmastervars.t
+++ b/parts/kubernetesmastervars.t
@@ -143,7 +143,7 @@
 {{end}}
     "generateProxyCertsScript": "{{GetKubernetesB64GenerateProxyCerts}}",
     "orchestratorNameVersionTag": "{{.OrchestratorProfile.OrchestratorType}}:{{.OrchestratorProfile.OrchestratorVersion}}",
-{{if IsVNETIntegrated}}
+{{if IsAzureCNI}}
     "allocateNodeCidrs": false,
 {{else}}
     "allocateNodeCidrs": true,

--- a/parts/kuberneteswinagentresourcesvmas.t
+++ b/parts/kuberneteswinagentresourcesvmas.t
@@ -36,7 +36,7 @@
           {{if lt $seq $.IPAddressCount}},{{end}}
           {{end}}
         ]
-{{if not IsVNETIntegrated}}
+{{if not IsAzureCNI}}
         ,
         "enableIPForwarding": true
 {{end}}

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -281,7 +281,7 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 			o.KubernetesConfig.NetworkPolicy = DefaultNetworkPolicy
 		}
 		if o.KubernetesConfig.ClusterSubnet == "" {
-			if o.IsVNETIntegrated() {
+			if o.IsAzureCNI() {
 				// When VNET integration is enabled, all masters, agents and pods share the same large subnet.
 				o.KubernetesConfig.ClusterSubnet = DefaultKubernetesSubnet
 			} else {
@@ -289,7 +289,7 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 			}
 		}
 		if o.KubernetesConfig.MaxPods == 0 {
-			if o.IsVNETIntegrated() {
+			if o.IsAzureCNI() {
 				o.KubernetesConfig.MaxPods = DefaultKubernetesMaxPodsVNETIntegrated
 			} else {
 				o.KubernetesConfig.MaxPods = DefaultKubernetesMaxPods
@@ -418,7 +418,7 @@ func setMasterNetworkDefaults(a *api.Properties) {
 
 	if !a.MasterProfile.IsCustomVNET() {
 		if a.OrchestratorProfile.OrchestratorType == api.Kubernetes {
-			if a.OrchestratorProfile.IsVNETIntegrated() {
+			if a.OrchestratorProfile.IsAzureCNI() {
 				// When VNET integration is enabled, all masters, agents and pods share the same large subnet.
 				a.MasterProfile.Subnet = a.OrchestratorProfile.KubernetesConfig.ClusterSubnet
 				a.MasterProfile.FirstConsecutiveStaticIP = getFirstConsecutiveStaticIPAddress(a.MasterProfile.Subnet)
@@ -441,7 +441,7 @@ func setMasterNetworkDefaults(a *api.Properties) {
 		a.MasterProfile.IPAddressCount = 1
 
 		// Allocate IP addresses for pods if VNET integration is enabled.
-		if a.OrchestratorProfile.IsVNETIntegrated() {
+		if a.OrchestratorProfile.IsAzureCNI() {
 			if a.OrchestratorProfile.OrchestratorType == api.Kubernetes {
 				a.MasterProfile.IPAddressCount += a.OrchestratorProfile.KubernetesConfig.MaxPods
 			}
@@ -485,7 +485,7 @@ func setAgentNetworkDefaults(a *api.Properties) {
 			profile.IPAddressCount = 1
 
 			// Allocate IP addresses for pods if VNET integration is enabled.
-			if a.OrchestratorProfile.IsVNETIntegrated() {
+			if a.OrchestratorProfile.IsAzureCNI() {
 				if a.OrchestratorProfile.OrchestratorType == api.Kubernetes {
 					profile.IPAddressCount += a.OrchestratorProfile.KubernetesConfig.MaxPods
 				}

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -836,8 +836,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"IsPublic": func(ports []int) bool {
 			return len(ports) > 0
 		},
-		"IsVNETIntegrated": func() bool {
-			return cs.Properties.OrchestratorProfile.IsVNETIntegrated()
+		"IsAzureCNI": func() bool {
+			return cs.Properties.OrchestratorProfile.IsAzureCNI()
 		},
 		"UseManagedIdentity": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -558,8 +558,8 @@ func (o *OrchestratorProfile) IsDCOS() bool {
 	return o.OrchestratorType == DCOS
 }
 
-// IsVNETIntegrated returns true if Azure VNET integration is enabled
-func (o *OrchestratorProfile) IsVNETIntegrated() bool {
+// IsAzureCNI returns true if Azure VNET integration is enabled
+func (o *OrchestratorProfile) IsAzureCNI() bool {
 	switch o.OrchestratorType {
 	case Kubernetes:
 		return o.KubernetesConfig.NetworkPolicy == "azure"


### PR DESCRIPTION
because what we’re actually determining is if azure CNI is enabled

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: we have a convenience function `IsVNETIntegrated` that determines if the api model we're processing specifies Azure CNI. The name `IsAzureCNI` better reflects what that function is doing, and renaming it improves readability given all the subtle wrinkles around VNETs and CNI (there are a lot of permutations).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
