### PR TITLE
make 'cordon and drain' conditional in upgrade

### DIFF
--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -50,8 +50,8 @@ func (kan *UpgradeAgentNode) DeleteNode(vmName *string, drain bool) error {
 
 		err := operations.SafelyDrainNode(kan.Client, logrus.New().WithField("operation", "upgrade"), kubeAPIServerURL, kan.kubeConfig, *vmName, time.Minute)
 		if err != nil {
-			kan.logger.Errorf(fmt.Sprintf("Error draining agent VM %s: %v", *vmName, err))
-			return err
+			kan.logger.Warningf("Error draining agent VM %s. Proceeding with deletion. Error: %v", *vmName, err)
+			// Proceed with deletion anyways
 		}
 	}
 	if err := operations.CleanDeleteVirtualMachine(kan.Client, kan.logger, kan.ResourceGroup, *vmName); err != nil {

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -48,7 +48,7 @@ func (kan *UpgradeAgentNode) DeleteNode(vmName *string, drain bool) error {
 			kubeAPIServerURL = kan.UpgradeContainerService.Properties.MasterProfile.FQDN
 		}
 
-		err := operations.SafelyDrainNode(kan.Client, logrus.New().WithField("operation", "upgrade"), kubeAPIServerURL, kan.kubeConfig, *vmName, time.Minute)
+		err := operations.SafelyDrainNode(kan.Client, kan.logger, kubeAPIServerURL, kan.kubeConfig, *vmName, time.Minute)
 		if err != nil {
 			kan.logger.Warningf("Error draining agent VM %s. Proceeding with deletion. Error: %v", *vmName, err)
 			// Proceed with deletion anyways

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -37,7 +37,7 @@ type UpgradeAgentNode struct {
 // DeleteNode takes state/resources of the master/agent node from ListNodeResources
 // backs up/preserves state as needed by a specific version of Kubernetes and then deletes
 // the node
-func (kan *UpgradeAgentNode) DeleteNode(vmName *string) error {
+func (kan *UpgradeAgentNode) DeleteNode(vmName *string, drain bool) error {
 	var kubeAPIServerURL string
 
 	if kan.UpgradeContainerService.Properties.HostedMasterProfile != nil {
@@ -48,7 +48,7 @@ func (kan *UpgradeAgentNode) DeleteNode(vmName *string) error {
 
 	err := operations.SafelyDrainNode(kan.Client, logrus.New().WithField("operation", "upgrade"), kubeAPIServerURL, kan.kubeConfig, *vmName, time.Minute)
 	if err != nil {
-		kan.logger.Errorf(fmt.Sprintf("Error draining agent VM: %s", *vmName))
+		kan.logger.Errorf(fmt.Sprintf("Error draining agent VM %s: %v", *vmName, err))
 		return err
 	}
 

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -37,21 +37,23 @@ type UpgradeAgentNode struct {
 // DeleteNode takes state/resources of the master/agent node from ListNodeResources
 // backs up/preserves state as needed by a specific version of Kubernetes and then deletes
 // the node
+// The 'drain' flag is used to invoke 'cordon and drain' flow.
 func (kan *UpgradeAgentNode) DeleteNode(vmName *string, drain bool) error {
-	var kubeAPIServerURL string
+	if drain {
+		var kubeAPIServerURL string
 
-	if kan.UpgradeContainerService.Properties.HostedMasterProfile != nil {
-		kubeAPIServerURL = kan.UpgradeContainerService.Properties.HostedMasterProfile.FQDN
-	} else {
-		kubeAPIServerURL = kan.UpgradeContainerService.Properties.MasterProfile.FQDN
+		if kan.UpgradeContainerService.Properties.HostedMasterProfile != nil {
+			kubeAPIServerURL = kan.UpgradeContainerService.Properties.HostedMasterProfile.FQDN
+		} else {
+			kubeAPIServerURL = kan.UpgradeContainerService.Properties.MasterProfile.FQDN
+		}
+
+		err := operations.SafelyDrainNode(kan.Client, logrus.New().WithField("operation", "upgrade"), kubeAPIServerURL, kan.kubeConfig, *vmName, time.Minute)
+		if err != nil {
+			kan.logger.Errorf(fmt.Sprintf("Error draining agent VM %s: %v", *vmName, err))
+			return err
+		}
 	}
-
-	err := operations.SafelyDrainNode(kan.Client, logrus.New().WithField("operation", "upgrade"), kubeAPIServerURL, kan.kubeConfig, *vmName, time.Minute)
-	if err != nil {
-		kan.logger.Errorf(fmt.Sprintf("Error draining agent VM %s: %v", *vmName, err))
-		return err
-	}
-
 	if err := operations.CleanDeleteVirtualMachine(kan.Client, kan.logger, kan.ResourceGroup, *vmName); err != nil {
 		return err
 	}

--- a/pkg/operations/kubernetesupgrade/upgrademasternode.go
+++ b/pkg/operations/kubernetesupgrade/upgrademasternode.go
@@ -32,7 +32,7 @@ type UpgradeMasterNode struct {
 // DeleteNode takes state/resources of the master/agent node from ListNodeResources
 // backs up/preserves state as needed by a specific version of Kubernetes and then deletes
 // the node
-func (kmn *UpgradeMasterNode) DeleteNode(vmName *string) error {
+func (kmn *UpgradeMasterNode) DeleteNode(vmName *string, dummy bool) error {
 	if err := operations.CleanDeleteVirtualMachine(kmn.Client, kmn.logger, kmn.ResourceGroup, *vmName); err != nil {
 		return err
 	}

--- a/pkg/operations/kubernetesupgrade/upgrademasternode.go
+++ b/pkg/operations/kubernetesupgrade/upgrademasternode.go
@@ -31,8 +31,9 @@ type UpgradeMasterNode struct {
 
 // DeleteNode takes state/resources of the master/agent node from ListNodeResources
 // backs up/preserves state as needed by a specific version of Kubernetes and then deletes
-// the node
-func (kmn *UpgradeMasterNode) DeleteNode(vmName *string, dummy bool) error {
+// the node.
+// The 'drain' flag is not used for deleting master nodes.
+func (kmn *UpgradeMasterNode) DeleteNode(vmName *string, drain bool) error {
 	if err := operations.CleanDeleteVirtualMachine(kmn.Client, kmn.logger, kmn.ResourceGroup, *vmName); err != nil {
 		return err
 	}

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -113,7 +113,7 @@ func (ku *Upgrader) upgradeMasterNodes() error {
 
 		masterIndex, _ := armhelpers.GetVMNameIndex(vm.StorageProfile.OsDisk.OsType, *vm.Name)
 
-		err := upgradeMasterNode.DeleteNode(vm.Name)
+		err := upgradeMasterNode.DeleteNode(vm.Name, false)
 		if err != nil {
 			ku.logger.Infof("Error deleting master VM: %s, err: %v\n", *vm.Name, err)
 			return err
@@ -234,7 +234,7 @@ func (ku *Upgrader) upgradeAgentPools() error {
 
 			if vmProvisioningState != string(api.Succeeded) {
 				ku.logger.Infof("Deleting agent VM %s in provisioning state %s\n", *vm.Name, vmProvisioningState)
-				err := upgradeAgentNode.DeleteNode(vm.Name)
+				err := upgradeAgentNode.DeleteNode(vm.Name, false)
 				if err != nil {
 					ku.logger.Errorf("Error deleting agent VM %s: %v\n", *vm.Name, err)
 					return err
@@ -290,7 +290,7 @@ func (ku *Upgrader) upgradeAgentPools() error {
 			}
 			ku.logger.Infof("Upgrading Agent VM: %s, pool name: %s\n", vm.Name, *agentPool.Name)
 
-			err := upgradeAgentNode.DeleteNode(&vm.Name)
+			err := upgradeAgentNode.DeleteNode(&vm.Name, true)
 			if err != nil {
 				ku.logger.Errorf("Error deleting agent VM %s: %v\n", vm.Name, err)
 				return err

--- a/pkg/operations/kubernetesupgrade/upgradeworkflow.go
+++ b/pkg/operations/kubernetesupgrade/upgradeworkflow.go
@@ -15,7 +15,8 @@ type UpgradeWorkFlow interface {
 type UpgradeNode interface {
 	// DeleteNode takes state/resources of the master/agent node from ListNodeResources
 	// backs up/preserves state as needed by a specific version of Kubernetes and then deletes
-	// the node
+	// the node.
+	// the second argument is a flag to invoke 'cordon and drain' flow.
 	DeleteNode(*string, bool) error
 
 	// CreateNode creates a new master/agent node with the targeted version of Kubernetes

--- a/pkg/operations/kubernetesupgrade/upgradeworkflow.go
+++ b/pkg/operations/kubernetesupgrade/upgradeworkflow.go
@@ -16,7 +16,7 @@ type UpgradeNode interface {
 	// DeleteNode takes state/resources of the master/agent node from ListNodeResources
 	// backs up/preserves state as needed by a specific version of Kubernetes and then deletes
 	// the node
-	DeleteNode(*string) error
+	DeleteNode(*string, bool) error
 
 	// CreateNode creates a new master/agent node with the targeted version of Kubernetes
 	CreateNode(string, int) error


### PR DESCRIPTION
During upgrade operation do not invoke 'cordon and drain' for unhealthy nodes.