### PR TITLE
Adding Prometheus and Grafana

### DIFF
--- a/examples/extensions/prometheus-grafana-k8s.json
+++ b/examples/extensions/prometheus-grafana-k8s.json
@@ -1,0 +1,47 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes"
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_DS2_v2",
+      "extensions": [
+        { 
+          "name": "prometheus-grafana-k8s"
+        }
+      ]
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 3,
+        "vmSize": "Standard_DS2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "extensionProfiles": [
+      { 
+        "name": "prometheus-grafana-k8s", 
+        "version": "v1",
+        "rootURL": "https://raw.githubusercontent.com/ritazh/acs-engine/feat-monitor/"
+      }
+    ],
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    }
+  }
+}

--- a/extensions/prometheus-grafana-k8s/README.md
+++ b/extensions/prometheus-grafana-k8s/README.md
@@ -89,9 +89,11 @@ $ kubectl port-forward $GF_POD_NAME 3000:3000 &
 |extensionParameters|no||
 |rootURL|optional||
 
+_Note_: specify a string for `extensionParameters` for a non-default namespace in the Kubernetes cluster
+
 # Example
 ``` javascript
-{ "name": "prometheus-grafana-k8s", "version": "v1" }
+{ "name": "prometheus-grafana-k8s", "version": "v1", "extensionParameters": "monitoring" }
 ```
 
 # Supported Orchestrators

--- a/extensions/prometheus-grafana-k8s/README.md
+++ b/extensions/prometheus-grafana-k8s/README.md
@@ -1,0 +1,30 @@
+# prometheus-grafana Extension
+
+
+Sample prometheus-grafana extension.  Runs the following on the master:
+
+```
+ 
+```
+
+You can validate that the extension was run by running:
+```
+kubectl get pods --show-all
+
+```
+
+# Configuration
+|Name|Required|Acceptable Value|
+|---|---|---|
+|name|yes|prometheus-grafana-k8s|
+|version|yes|v1|
+|extensionParameters|no||
+|rootURL|optional||
+
+# Example
+``` javascript
+{ "name": "prometheus-grafana-k8s", "version": "v1" }
+```
+
+# Supported Orchestrators
+Kubernetes

--- a/extensions/prometheus-grafana-k8s/README.md
+++ b/extensions/prometheus-grafana-k8s/README.md
@@ -1,7 +1,7 @@
 # prometheus-grafana Extension
 
 
-This is the prometheus-grafana extension.  Add this extension to your json file as shown below to automatically enable prometheus and grafana in your new Kubernetes cluster.
+This is the prometheus-grafana extension.  Add this extension to the api model you pass as input into acs-engine as shown below to automatically enable prometheus and grafana in your new Kubernetes cluster.
 
 ```
 {

--- a/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
@@ -218,11 +218,11 @@ install_grafana $NAMESPACE
 sleep 5
 
 echo $(date) " - Creating the Prometheus datasource in Grafana"
-GF_USER_NAME=$(kubectl get secret $K8S_SECRET_NAME -o jsonpath="{.data.grafana-admin-user}" | base64 --decode)
+GF_USER_NAME=$(kubectl get secret -n $NAMESPACE $K8S_SECRET_NAME -o jsonpath="{.data.grafana-admin-user}" | base64 --decode)
 echo $GF_USER_NAME
-GF_PASSWORD=$(kubectl get secret $K8S_SECRET_NAME -o jsonpath="{.data.grafana-admin-password}" | base64 --decode)
+GF_PASSWORD=$(kubectl get secret -n $NAMESPACE $K8S_SECRET_NAME -o jsonpath="{.data.grafana-admin-password}" | base64 --decode)
 echo $GF_PASSWORD
-GF_URL=$(kubectl get svc -l "app=dashboard-grafana,component=grafana" -o jsonpath="{.items[0].spec.clusterIP}")
+GF_URL=$(kubectl get svc -n $NAMESPACE -l "app=dashboard-grafana,component=grafana" -o jsonpath="{.items[0].spec.clusterIP}")
 echo $GF_URL
 
 echo retrieving current data sources...

--- a/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
@@ -166,6 +166,18 @@ install_grafana() {
     done
 }
 
+ensure_k8s_namespace() {
+    NAMESPACE_TO_EXIST="$1"
+
+    kubectl get ns $NAMESPACE_TO_EXIST > /dev/null 2> /dev/null
+    if [[ $? -ne 0 ]]; then
+        echo $(date) " - Creating namespace $NAMESPACE_TO_EXIST"
+        kubectl create ns $NAMESPACE_TO_EXIST
+    else
+        echo $(date) " - Namespace $NAMESPACE_TO_EXIST already exists"
+    fi
+}
+
 # this extension should only run on a single node
 # the logic to decide whether or not this current node
 # should run the extension is to alphabetically determine
@@ -179,7 +191,11 @@ fi
 
 # Deploy container
 
-NAMESPACE=default
+if [[ -n "$1" ]]; then
+    NAMESPACE=$1
+else
+    NAMESPACE=default
+fi
 K8S_SECRET_NAME=dashboard-grafana
 DS_TYPE=prometheus
 DS_NAME=prometheus1

--- a/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
@@ -1,0 +1,64 @@
+# Script file to install prometheus and grafana
+
+#!/bin/bash
+
+set -e
+
+echo $(date) " - Starting Script"
+
+echo $(date) " - Waiting for API Server to start"
+kubernetesStarted=1
+for i in {1..600}; do
+    if [ -e /usr/local/bin/kubectl ]
+    then
+        /usr/local/bin/kubectl cluster-info
+        if [ "$?" = "0" ]
+        then
+            echo "kubernetes started"
+            kubernetesStarted=0
+            break
+        fi
+    else
+        /usr/bin/docker ps | grep apiserver
+        if [ "$?" = "0" ]
+        then
+            echo "kubernetes started"
+            kubernetesStarted=0
+            break
+        fi
+    fi
+    sleep 1
+done
+if [ $kubernetesStarted -ne 0 ]
+then
+    echo "kubernetes did not start"
+    exit 1
+fi
+
+# Deploy container
+echo $(date) " - Downloading helm"
+
+curl https://storage.googleapis.com/kubernetes-helm/helm-v2.6.2-linux-amd64.tar.gz > helm-v2.6.2-linux-amd64.tar.gz
+tar -zxvf helm-v2.6.2-linux-amd64.tar.gz
+mv linux-amd64/helm /usr/local/bin/helm
+echo $(date) " - Downloading prometheus values"
+curl https://raw.githubusercontent.com/ritazh/acs-engine/feat-monitor/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml > prometheus_values.yaml 
+pwd
+
+sleep 120
+
+echo $(date) " - helm version"
+helm version
+helm init
+
+echo $(date) " - helm installed"
+
+echo $(date) " - Deploying prometheus chart"
+helm install --name monitoring -f prometheus_values.yaml stable/prometheus
+
+echo $(date) " - Deploying grafana chart"
+
+helm install --name dashboard stable/grafana
+
+echo $(date) " - installed grafana chart"
+echo $(date) " - Script complete"

--- a/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -x
 
-echo "$1" > /tmp/extensionParameters
-
 echo $(date) " - Starting Script"
 
 echo $(date) " - Waiting for API Server to start"

--- a/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -x
 
+echo "$1" > /tmp/extensionParameters
+
 echo $(date) " - Starting Script"
 
 echo $(date) " - Waiting for API Server to start"

--- a/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
@@ -42,16 +42,25 @@ curl https://storage.googleapis.com/kubernetes-helm/helm-v2.6.2-linux-amd64.tar.
 tar -zxvf helm-v2.6.2-linux-amd64.tar.gz
 mv linux-amd64/helm /usr/local/bin/helm
 echo $(date) " - Downloading prometheus values"
+
+# TODO: replace this
 curl https://raw.githubusercontent.com/ritazh/acs-engine/feat-monitor/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml > prometheus_values.yaml 
 pwd
 
-sleep 120
+sleep 60
 
 echo $(date) " - helm version"
 helm version
 helm init
 
 echo $(date) " - helm installed"
+
+NAMESPACE=default
+K8S_SECRET_NAME=dashboard-grafana
+DS_TYPE=prometheus
+DS_NAME=prometheus1
+
+PROM_URL=http://monitoring-prometheus-server
 
 echo $(date) " - Deploying prometheus chart"
 helm install --name monitoring -f prometheus_values.yaml stable/prometheus
@@ -60,5 +69,75 @@ echo $(date) " - Deploying grafana chart"
 
 helm install --name dashboard stable/grafana
 
-echo $(date) " - installed grafana chart"
+echo $(date) " - Installed grafana chart"
+
+sleep 5
+
+echo $(date) " - Creating the Prometheus datasource in Grafana"
+GF_USER_NAME=$(kubectl get secret $K8S_SECRET_NAME -o jsonpath="{.data.grafana-admin-user}" | base64 --decode)
+echo $GF_USER_NAME
+GF_PASSWORD=$(kubectl get secret $K8S_SECRET_NAME -o jsonpath="{.data.grafana-admin-password}" | base64 --decode)
+echo $GF_PASSWORD
+GF_URL=$(kubectl get svc -l "app=dashboard-grafana,component=grafana" -o jsonpath="{.items[0].spec.clusterIP}")
+echo $GF_URL
+
+echo retrieving current data sources...
+CURRENT_DS_LIST=$(curl -s --user "$GF_USER_NAME:$GF_PASSWORD" "$GF_URL/api/datasources")
+echo $CURRENT_DS_LIST | grep -q "\"name\":\"$DS_NAME\""
+if [[ $? -eq 0 ]]; then
+    echo data source $DS_NAME already exists
+    echo $CURRENT_DS_LIST | python -m json.tool
+    exit 0
+fi
+
+echo data source $DS_NAME does not exist, creating...
+DS_RAW=$(cat << EOF
+{
+    "name": "$DS_NAME",
+    "type": "$DS_TYPE",
+    "url": "$PROM_URL",
+    "access": "proxy"
+}
+EOF
+)
+
+curl \
+    -X POST \
+    --user "$GF_USER_NAME:$GF_PASSWORD" \
+    -H "Content-Type: application/json" \
+    -d "$DS_RAW" \
+    "$GF_URL/api/datasources"
+
+echo $(date) " - Creating the Kubernetes dashboard in Grafana"
+
+cat << EOF > sanitize_dashboard.py
+#!/usr/bin/python3
+
+import fileinput
+import json
+
+dashboard = json.loads(''.join(fileinput.input()))
+dashboard.pop('__inputs')
+dashboard.pop('__requires')
+print(json.dumps(dashboard).replace('${DS_PROMETHEUS}', 'prometheus1'))
+
+EOF
+
+chmod u+x sanitize_dashboard.py
+
+DB_RAW=$(cat << EOF
+{
+    "dashboard": $(curl -sL "https://grafana.com/api/dashboards/315/revisions/3/download" | ./sanitize_dashboard.py),
+    "overwrite": false
+}
+EOF
+)
+
+curl \
+    -X POST \
+    --user "$GF_USER_NAME:$GF_PASSWORD" \
+    -H "Content-Type: application/json" \
+    -d "$DB_RAW" \
+    "$GF_URL/api/dashboards/db"
+
 echo $(date) " - Script complete"

--- a/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
@@ -76,7 +76,7 @@ install_prometheus() {
     PROM_POD_PREFIX="$PROM_RELEASE_NAME-prometheus-server"
     DESIRED_POD_STATE=Running
 
-    ATTEMPTS=30
+    ATTEMPTS=90
     SLEEP_TIME=10
 
     ITERATION=0
@@ -108,7 +108,7 @@ install_grafana() {
     GF_POD_PREFIX="$GF_RELEASE_NAME-grafana"
     DESIRED_POD_STATE=Running
 
-    ATTEMPTS=30
+    ATTEMPTS=90
     SLEEP_TIME=10
 
     ITERATION=0
@@ -176,7 +176,7 @@ EOF
 
 
 
-ATTEMPTS=30
+ATTEMPTS=90
 SLEEP_TIME=10
 
 ITERATION=0

--- a/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
@@ -166,7 +166,7 @@ install_grafana() {
     done
 }
 
-ensure_k8s_namespace() {
+ensure_k8s_namespace_exists() {
     NAMESPACE_TO_EXIST="$1"
 
     kubectl get ns $NAMESPACE_TO_EXIST > /dev/null 2> /dev/null
@@ -191,11 +191,16 @@ fi
 
 # Deploy container
 
+# the user can pass a non-default namespace through
+# extensionParameters as a string. we need to create
+# this namespace if it doesn't already exist
 if [[ -n "$1" ]]; then
     NAMESPACE=$1
 else
     NAMESPACE=default
 fi
+ensure_k8s_namespace_exists $NAMESPACE
+
 K8S_SECRET_NAME=dashboard-grafana
 DS_TYPE=prometheus
 DS_NAME=prometheus1

--- a/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml
@@ -1,0 +1,638 @@
+rbac:
+  create: false
+
+alertmanager:
+  ## If false, alertmanager will not be installed
+  ##
+  enabled: false
+
+  # Defines the serviceAccountName to use when `rbac.create=false`
+  serviceAccountName: default
+
+  ## alertmanager container name
+  ##
+  name: alertmanager
+
+  ## alertmanager container image
+  ##
+  image:
+    repository: prom/alertmanager
+    tag: v0.9.1
+    pullPolicy: IfNotPresent
+
+  ## Additional alertmanager container arguments
+  ##
+  extraArgs: {}
+
+  ## The URL prefix at which the container can be accessed. Useful in the case the '-web.external-url' includes a slug
+  ## so that the various internal URLs are still able to access as they are in the default case.
+  ## (Optional)
+  baseURL: ""
+
+  ## Additional alertmanager container environment variable
+  ## For instance to add a http_proxy
+  ##
+  extraEnv: {}
+
+  ## ConfigMap override where fullname is {{.Release.Name}}-{{.Values.alertmanager.configMapOverrideName}}
+  ## Defining configMapOverrideName will cause templates/alertmanager-configmap.yaml
+  ## to NOT generate a ConfigMap resource
+  ##
+  configMapOverrideName: ""
+
+  ingress:
+    ## If true, alertmanager Ingress will be created
+    ##
+    enabled: false
+
+    ## alertmanager Ingress annotations
+    ##
+    annotations: {}
+    #   kubernetes.io/ingress.class: nginx
+    #   kubernetes.io/tls-acme: 'true'
+
+    ## alertmanager Ingress hostnames
+    ## Must be provided if Ingress is enabled
+    ##
+    hosts: []
+    #   - alertmanager.domain.com
+
+    ## alertmanager Ingress TLS configuration
+    ## Secrets must be manually created in the namespace
+    ##
+    tls: []
+    #   - secretName: prometheus-alerts-tls
+    #     hosts:
+    #       - alertmanager.domain.com
+
+  ## Alertmanager Deployment Strategy type
+  # strategy:
+  #   type: Recreate
+
+  ## Node labels for alertmanager pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  persistentVolume:
+    ## If true, alertmanager will create/use a Persistent Volume Claim
+    ## If false, use emptyDir
+    ##
+    enabled: true
+
+    ## alertmanager data Persistent Volume access modes
+    ## Must match those of existing PV or dynamic provisioner
+    ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    accessModes:
+      - ReadWriteOnce
+
+    ## alertmanager data Persistent Volume Claim annotations
+    ##
+    annotations: {}
+
+    ## alertmanager data Persistent Volume existing claim name
+    ## Requires alertmanager.persistentVolume.enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    existingClaim: ""
+
+    ## alertmanager data Persistent Volume mount root path
+    ##
+    mountPath: /data
+
+    ## alertmanager data Persistent Volume size
+    ##
+    size: 2Gi
+
+    ## alertmanager data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: managed-standard
+
+    ## Subdirectory of alertmanager data Persistent Volume to mount
+    ## Useful if the volume's root directory is not empty
+    ##
+    subPath: ""
+
+  ## Annotations to be added to alertmanager pods
+  ##
+  podAnnotations: {}
+
+  replicaCount: 1
+
+  ## alertmanager resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+    # limits:
+    #   cpu: 10m
+    #   memory: 32Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 32Mi
+
+  service:
+    annotations: {}
+    labels: {}
+    clusterIP: ""
+
+    ## List of IP addresses at which the alertmanager service is available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    servicePort: 80
+    # nodePort: 30000
+    type: ClusterIP
+
+## Monitors ConfigMap changes and POSTs to a URL
+## Ref: https://github.com/jimmidyson/configmap-reload
+##
+configmapReload:
+  ## configmap-reload container name
+  ##
+  name: configmap-reload
+
+  ## configmap-reload container image
+  ##
+  image:
+    repository: jimmidyson/configmap-reload
+    tag: v0.1
+    pullPolicy: IfNotPresent
+
+  ## configmap-reload resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+
+kubeStateMetrics:
+  ## If false, kube-state-metrics will not be installed
+  ##
+  enabled: true
+
+  # Defines the serviceAccountName to use when `rbac.create=false`
+  serviceAccountName: default
+
+  ## kube-state-metrics container name
+  ##
+  name: kube-state-metrics
+
+  ## kube-state-metrics container image
+  ##
+  image:
+    repository: gcr.io/google_containers/kube-state-metrics
+    tag: v1.1.0-rc.0
+    pullPolicy: IfNotPresent
+
+  ## Node labels for kube-state-metrics pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Annotations to be added to kube-state-metrics pods
+  ##
+  podAnnotations: {}
+
+  replicaCount: 1
+
+  ## kube-state-metrics resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+    # limits:
+    #   cpu: 10m
+    #   memory: 16Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 16Mi
+
+  service:
+    annotations:
+      prometheus.io/scrape: "true"
+    labels: {}
+
+    clusterIP: None
+
+    ## List of IP addresses at which the kube-state-metrics service is available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    servicePort: 80
+    type: ClusterIP
+
+nodeExporter:
+  ## If false, node-exporter will not be installed
+  ##
+  enabled: true
+
+  # Defines the serviceAccountName to use when `rbac.create=false`
+  serviceAccountName: default
+
+  ## node-exporter container name
+  ##
+  name: node-exporter
+
+  ## node-exporter container image
+  ##
+  image:
+    repository: prom/node-exporter
+    tag: v0.15.0
+    pullPolicy: IfNotPresent
+
+  ## Custom Update Strategy
+  ##
+  updateStrategy:
+    type: OnDelete
+
+  ## Additional node-exporter container arguments
+  ##
+  extraArgs: {}
+
+  ## Additional node-exporter hostPath mounts
+  ##
+  extraHostPathMounts: []
+    # - name: textfile-dir
+    #   mountPath: /srv/txt_collector
+    #   hostPath: /var/lib/node-exporter
+    #   readOnly: true
+
+  ## Node tolerations for node-exporter scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+    # - key: "key"
+    #   operator: "Equal|Exists"
+    #   value: "value"
+    #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  ## Node labels for node-exporter pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Annotations to be added to node-exporter pods
+  ##
+  podAnnotations: {}
+
+  ## node-exporter resource limits & requests
+  ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+    # limits:
+    #   cpu: 200m
+    #   memory: 50Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 30Mi
+
+  service:
+    annotations:
+      prometheus.io/scrape: "true"
+    labels: {}
+
+    clusterIP: None
+
+    ## List of IP addresses at which the node-exporter service is available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+
+    hostPort: 9100
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    servicePort: 9100
+    type: ClusterIP
+
+server:
+  ## Prometheus server container name
+  ##
+  name: server
+
+  # Defines the serviceAccountName to use when `rbac.create=false`
+  serviceAccountName: default
+
+  ## Prometheus server container image
+  ##
+  image:
+    repository: prom/prometheus
+    tag: v1.8.1
+    pullPolicy: IfNotPresent
+
+  ## (optional) alertmanager URL
+  ## only used if alertmanager.enabled = false
+  alertmanagerURL: ""
+
+  ## The URL prefix at which the container can be accessed. Useful in the case the '-web.external-url' includes a slug
+  ## so that the various internal URLs are still able to access as they are in the default case.
+  ## (Optional)
+  baseURL: ""
+
+  ## Additional Prometheus server container arguments
+  ##
+  extraArgs: {}
+
+  ## Additional Prometheus server hostPath mounts
+  ##
+  extraHostPathMounts: []
+    # - name: certs-dir
+    #   mountPath: /etc/kubernetes/certs
+    #   hostPath: /etc/kubernetes/certs
+    #   readOnly: true
+
+  ## ConfigMap override where fullname is {{.Release.Name}}-{{.Values.server.configMapOverrideName}}
+  ## Defining configMapOverrideName will cause templates/server-configmap.yaml
+  ## to NOT generate a ConfigMap resource
+  ##
+  configMapOverrideName: ""
+
+  ingress:
+    ## If true, Prometheus server Ingress will be created
+    ##
+    enabled: false
+
+    ## Prometheus server Ingress annotations
+    ##
+    annotations: {}
+    #   kubernetes.io/ingress.class: nginx
+    #   kubernetes.io/tls-acme: 'true'
+
+    ## Prometheus server Ingress hostnames
+    ## Must be provided if Ingress is enabled
+    ##
+    hosts: []
+    #   - prometheus.domain.com
+
+    ## Prometheus server Ingress TLS configuration
+    ## Secrets must be manually created in the namespace
+    ##
+    tls: []
+    #   - secretName: prometheus-server-tls
+    #     hosts:
+    #       - prometheus.domain.com
+
+  ## Server Deployment Strategy type
+  # strategy:
+  #   type: Recreate
+
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+    # - key: "key"
+    #   operator: "Equal|Exists"
+    #   value: "value"
+    #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  ## Node labels for Prometheus server pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  nodeSelector: {}
+
+  persistentVolume:
+    ## If true, Prometheus server will create/use a Persistent Volume Claim
+    ## If false, use emptyDir
+    ##
+    enabled: true
+
+    ## Prometheus server data Persistent Volume access modes
+    ## Must match those of existing PV or dynamic provisioner
+    ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    accessModes:
+      - ReadWriteOnce
+
+    ## Prometheus server data Persistent Volume annotations
+    ##
+    annotations: {}
+
+    ## Prometheus server data Persistent Volume existing claim name
+    ## Requires server.persistentVolume.enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    existingClaim: ""
+
+    ## Prometheus server data Persistent Volume mount root path
+    ##
+    mountPath: /data
+
+    ## Prometheus server data Persistent Volume size
+    ##
+    size: 8Gi
+
+    ## Prometheus server data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: managed-standard
+
+    ## Subdirectory of Prometheus server data Persistent Volume to mount
+    ## Useful if the volume's root directory is not empty
+    ##
+    subPath: ""
+
+  ## Annotations to be added to Prometheus server pods
+  ##
+  podAnnotations: {}
+    # iam.amazonaws.com/role: prometheus
+
+  replicaCount: 1
+
+  ## Prometheus server resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 500m
+    #   memory: 512Mi
+
+  service:
+    annotations: {}
+    labels: {}
+    clusterIP: ""
+
+    ## List of IP addresses at which the Prometheus server service is available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    servicePort: 80
+    type: ClusterIP
+
+  ## Prometheus server pod termination grace period
+  ##
+  terminationGracePeriodSeconds: 300
+
+  ## Prometheus data retention period (i.e 360h)
+  ##
+  retention: ""
+
+pushgateway:
+  ## If false, pushgateway will not be installed
+  ##
+  enabled: true
+
+  ## pushgateway container name
+  ##
+  name: pushgateway
+
+  ## pushgateway container image
+  ##
+  image:
+    repository: prom/pushgateway
+    tag: v0.4.0
+    pullPolicy: IfNotPresent
+
+  ## Additional pushgateway container arguments
+  ##
+  extraArgs: {}
+
+  ingress:
+    ## If true, pushgateway Ingress will be created
+    ##
+    enabled: false
+
+    ## pushgateway Ingress annotations
+    ##
+    annotations:
+    #   kubernetes.io/ingress.class: nginx
+    #   kubernetes.io/tls-acme: 'true'
+
+    ## pushgateway Ingress hostnames
+    ## Must be provided if Ingress is enabled
+    ##
+    hosts: []
+    #   - pushgateway.domain.com
+
+    ## pushgateway Ingress TLS configuration
+    ## Secrets must be manually created in the namespace
+    ##
+    tls: []
+    #   - secretName: prometheus-alerts-tls
+    #     hosts:
+    #       - pushgateway.domain.com
+
+  ## Node labels for pushgateway pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Annotations to be added to pushgateway pods
+  ##
+  podAnnotations: {}
+
+  replicaCount: 1
+
+  ## pushgateway resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+    # limits:
+    #   cpu: 10m
+    #   memory: 32Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 32Mi
+
+  service:
+    annotations:
+      prometheus.io/probe: pushgateway
+    labels: {}
+    clusterIP: ""
+
+    ## List of IP addresses at which the pushgateway service is available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    servicePort: 9091
+    type: ClusterIP
+
+## alertmanager ConfigMap entries
+##
+alertmanagerFiles:
+  alertmanager.yml: |-
+    global:
+      # slack_api_url: ''
+
+    receivers:
+      - name: default-receiver
+        # slack_configs:
+        #  - channel: '@you'
+        #    send_resolved: true
+
+    route:
+      group_wait: 10s
+      group_interval: 5m
+      receiver: default-receiver
+      repeat_interval: 3h
+
+## Prometheus server ConfigMap entries
+##
+serverFiles:
+  alerts: ""
+  rules: ""
+
+  prometheus.yml: |-
+    rule_files:
+      - /etc/config/rules
+      - /etc/config/alerts
+
+    scrape_configs:
+      - job_name: prometheus
+        static_configs:
+          - targets:
+            - localhost:9090
+
+      - job_name: kubernetes-nodes-cadvisor
+        scrape_interval: 10s
+        scrape_timeout: 10s
+        scheme: https  # remove if you want to scrape metrics on insecure port
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          # Only for Kubernetes ^1.7.3.
+          # See: https://github.com/prometheus/prometheus/issues/2916
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+        metric_relabel_configs:
+          - action: replace
+            source_labels: [id]
+            regex: '^/machine\.slice/machine-rkt\\x2d([^\\]+)\\.+/([^/]+)\.service$'
+            target_label: rkt_container_name
+            replacement: '${2}-${1}'
+          - action: replace
+            source_labels: [id]
+            regex: '^/system\.slice/(.+)\.service$'
+            target_label: systemd_service_name
+            replacement: '${1}'
+
+networkPolicy:
+  ## Enable creation of NetworkPolicy resources.
+  ##
+  enabled: false

--- a/extensions/prometheus-grafana-k8s/v1/supported-orchestrators.json
+++ b/extensions/prometheus-grafana-k8s/v1/supported-orchestrators.json
@@ -1,0 +1,1 @@
+["Kubernetes"]

--- a/extensions/prometheus-grafana-k8s/v1/template-link.json
+++ b/extensions/prometheus-grafana-k8s/v1/template-link.json
@@ -1,0 +1,36 @@
+{
+    "name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'PrometheusGrafanaK8s')]",
+    "type": "Microsoft.Resources/deployments",
+    "apiVersion": "[variables('apiVersionLinkDefault')]",
+    "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', copyIndex(EXTENSION_LOOP_OFFSET))]"
+    ],
+    "copy": {
+        "count": "EXTENSION_LOOP_COUNT",
+        "name": "prometheusgrafanaExtensionLoop"
+    },
+    "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+            "uri": "EXTENSION_URL_REPLACEextensions/prometheus-grafana-k8s/v1/template.json",
+            "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+            "artifactsLocation": {
+                "value": "EXTENSION_URL_REPLACE"
+            },
+            "apiVersionCompute": {
+                "value": "[variables('apiVersionDefault')]"
+            },
+            "targetVMName": {
+                "value": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET))]"
+            },
+            "extensionParameters": {
+                "value": "EXTENSION_PARAMETERS_REPLACE"
+            },
+            "vmIndex":{
+                "value": "[copyIndex(EXTENSION_LOOP_OFFSET)]"
+            }
+        }
+    }
+}

--- a/extensions/prometheus-grafana-k8s/v1/template.json
+++ b/extensions/prometheus-grafana-k8s/v1/template.json
@@ -1,0 +1,68 @@
+{
+   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {  
+		"artifactsLocation": {
+			"type": "string",
+			"minLength": 1,
+			"metadata": {
+				"description": "Artifacts Location - URL"
+			}
+        },
+		"apiVersionCompute": {
+			"type": "string",
+			"minLength": 1,
+			"metadata": {
+				"description": "Compute API Version"
+			}
+		},
+		"targetVMName":{
+			"type": "string",
+			"minLength": 1,
+			"metadata": {
+				"description": "Name of the vm to run the "
+			}
+		},
+		"extensionParameters": {
+			"type": "securestring",
+			"minLength": 0,
+			"metadata": {
+				"description": "Custom Parameter for Extension - for prometheus-grafana-k8s, this is empty"
+			}
+		},
+		"vmIndex": {
+			"type": "int",
+			"metadata": {
+				"description": "index in the pool of the current agent, used so that we can get the extension name right"
+			}
+		}
+   },
+   "variables": {  
+		"singleQuote": "'",
+		"initScriptUrl": "[concat(parameters('artifactsLocation'), 'extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh')]"
+   },
+   "resources": [  
+	{
+      "apiVersion": "[parameters('apiVersionCompute')]",
+      "dependsOn": [],
+      "location": "[resourceGroup().location]",
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+	  "name": "[concat(parameters('targetVMName'),'/cse', parameters('vmIndex'))]",
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+			"fileUris": [ 
+			   "[variables('initScriptUrl')]" 
+			 ]
+		},
+        "protectedSettings": {
+			"commandToExecute": "[concat('/bin/bash -c \"/bin/bash ./prometheus-grafana-k8s.sh ', variables('singleQuote'), parameters('extensionParameters'), variables('singleQuote'), ' >> /var/log/azure/prometheus-grafana-k8s.log 2>&1 &\" &')]"
+        }
+      }
+    }
+	],
+   "outputs": {  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Adding Prometheus and Grafana to acs-engine to enable out of the box k8s monitoring experience

**Special notes for your reviewer**:
We have decided to create a new extension for this purpose to fully utilize the existing Prometheus and Grafana helm charts to manage releases and updates of existing charts. The new `prometheus-grafana-k8s` extension installs the helm cli and installs the Prometheus and Grafana charts.

cc @tstringer