### PR TITLE
Mitigate windows outbound connection test failure due to known random…

### DIFF
--- a/test/cluster-tests/kubernetes/k8s-utils.sh
+++ b/test/cluster-tests/kubernetes/k8s-utils.sh
@@ -161,7 +161,8 @@ function test_windows_deployment() {
     log "curl failed, retrying..."
     ipconfig=$(kubectl exec $winpodname -- powershell ipconfig /all)
     log "$ipconfig"
-    sleep 10; count=$((count-1))
+    # TODO: reduce sleep time when outbound connection delay is fixed
+    sleep 100; count=$((count-1))
   done
   set -e
   if [[ "${success}" != "y" ]]; then


### PR DESCRIPTION
… delay

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Mitigate windows outbound connection test failure due to known random delay.
