### PR TITLE
Add Upgrading provisioning state to facilitate conversion

### DIFF
--- a/pkg/api/agentPoolOnlyApi/v20170831/types.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/types.go
@@ -103,6 +103,8 @@ const (
 	// Migrating means resource is being migrated from one subscription or
 	// resource group to another
 	Migrating ProvisioningState = "Migrating"
+	// Upgrading means an existing resource is being upgraded
+	Upgrading ProvisioningState = "Upgrading"
 )
 
 // PoolUpgradeProfile contains pool properties:

--- a/pkg/api/agentPoolOnlyApi/vlabs/types.go
+++ b/pkg/api/agentPoolOnlyApi/vlabs/types.go
@@ -114,6 +114,8 @@ const (
 	// Migrating means resource is being migrated from one subscription or
 	// resource group to another
 	Migrating ProvisioningState = "Migrating"
+	// Upgrading means an existing resource is being upgraded
+	Upgrading ProvisioningState = "Upgrading"
 )
 
 // AgentPoolProfile represents configuration of VMs running agent


### PR DESCRIPTION
Add Upgrading provisioning state

**What this PR does / why we need it**:
Versioned API model of MangedCluster resource type is missing `Upgrading` provisioning state. This leads to `Upgrading` state not being set and also gets lost when converting unversioned model back to versioned model.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Add `Upgrading` provisioning state to versioned API model