### PR TITLE
pin docker version swarm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,6 +331,12 @@ workflows:
           filters:
             branches:
               ignore: master
+      - swarm-e2e:
+          requires:
+            - pr-e2e-hold
+          filters:
+            branches:
+              ignore: master
       - swarmmode-e2e:
           requires:
             - pr-e2e-hold
@@ -386,6 +392,12 @@ workflows:
             branches:
               only: master
       - k8s-hybrid-1.8-release-e2e:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master
+      - swarm-e2e:
           requires:
             - test
           filters:

--- a/parts/configure-swarm-cluster.sh
+++ b/parts/configure-swarm-cluster.sh
@@ -20,6 +20,7 @@ POSTINSTALLSCRIPTURI=${7}
 BASESUBNET=${8}
 DOCKERENGINEDOWNLOADREPO=${9}
 DOCKERCOMPOSEDOWNLOADURL=${10}
+DOCKER_CE_VERSION=17.03.*
 VMNAME=`hostname`
 VMNUMBER=`echo $VMNAME | sed 's/.*[^0-9]\([0-9]\+\)*$/\1/'`
 VMPREFIX=`echo $VMNAME | sed 's/\(.*[^0-9]\)*[0-9]\+$/\1/'`
@@ -167,7 +168,9 @@ retrycmd_if_failure() { for i in 1 2 3 4 5; do $@; [ $? -eq 0  ] && break || sle
 installDocker()
 {
   for i in {1..10}; do
-    wget --tries 4 --retry-connrefused --waitretry=15 -qO- https://get.docker.com | sh
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    apt-get update
+    apt-get install -y docker-ce=${DOCKER_CE_VERSION}
     if [ $? -eq 0 ]
     then
       # hostname has been found continue

--- a/parts/configure-swarm-cluster.sh
+++ b/parts/configure-swarm-cluster.sh
@@ -168,6 +168,8 @@ retrycmd_if_failure() { for i in 1 2 3 4 5; do $@; [ $? -eq 0  ] && break || sle
 installDocker()
 {
   for i in {1..10}; do
+    apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+    curl --max-time 60 -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - 
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
     apt-get update
     apt-get install -y docker-ce=${DOCKER_CE_VERSION}

--- a/test/acse-conf/acse-regression.json
+++ b/test/acse-conf/acse-regression.json
@@ -28,6 +28,10 @@
       "cluster_definition": "disks-managed/kubernetes-vmas.json",
       "category": "managed-disk"
     },
+    { 
+      "cluster_definition": "disks-managed/swarm-preAttachedDisks-vmss.json", 
+      "category": "managed-disk" 
+    },
     {
       "cluster_definition": "disks-managed/swarmmode-vmas.json",
       "category": "managed-disk"

--- a/test/e2e/swarm-deployments.json
+++ b/test/e2e/swarm-deployments.json
@@ -2,6 +2,9 @@
 	"deployments": [
 		{
 			"cluster_definition": "swarm.json"
+		}, 
+		{ 
+			"cluster_definition": "disks-managed/swarm-preAttachedDisks-vmss.json"
 		}
 	]
 }


### PR DESCRIPTION
Add back swarm e2e

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Swarm clusters are broken because of new Docker version incompatibility. This pins the Docker version for Swarm clusters.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
