### PR TITLE
point monitoring extension and docs to point upstream

### DIFF
--- a/examples/extensions/prometheus-grafana-k8s.json
+++ b/examples/extensions/prometheus-grafana-k8s.json
@@ -36,7 +36,7 @@
       { 
         "name": "prometheus-grafana-k8s", 
         "version": "v1",
-        "rootURL": "https://raw.githubusercontent.com/ritazh/acs-engine/feat-monitor/"
+        "rootURL": "https://raw.githubusercontent.com/Azure/acs-engine/master/"
       }
     ],
     "servicePrincipalProfile": {

--- a/extensions/prometheus-grafana-k8s/README.md
+++ b/extensions/prometheus-grafana-k8s/README.md
@@ -42,7 +42,7 @@ This is the prometheus-grafana extension.  Add this extension to the api model y
       { 
         "name": "prometheus-grafana-k8s", 
         "version": "v1",
-        "rootURL": "https://raw.githubusercontent.com/ritazh/acs-engine/feat-monitor/"
+        "rootURL": "https://raw.githubusercontent.com/Azure/acs-engine/master/"
       }
     ],
     "servicePrincipalProfile": {

--- a/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
@@ -80,8 +80,7 @@ install_helm() {
     mv linux-amd64/helm /usr/local/bin/helm
     echo $(date) " - Downloading prometheus values"
 
-    # TODO: replace this
-    curl https://raw.githubusercontent.com/ritazh/acs-engine/feat-monitor/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml > prometheus_values.yaml 
+    curl https://raw.githubusercontent.com/Azure/acs-engine/master/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml > prometheus_values.yaml 
 
     sleep 10
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR corrects the URL for the monitoring extension to point to upstream instead of @ritazh's fork, which was originally necessary in order to test this extension.

**Special notes for your reviewer**:

The original URL for the extension was necessary as it was the location for the test extension prior to the merge of #1837. Now that the PR is merged, these URLs should be changed to point to the maintained upstream repo.