### PR TITLE
Update k8s GPU doc

### DIFF
--- a/docs/kubernetes/gpu.md
+++ b/docs/kubernetes/gpu.md
@@ -39,18 +39,15 @@ spec:
       containers:
       - name: tensorflow
         image: <SOME_IMAGE>
-        command: ["python main.py"]      
+        command: <SOME_COMMAND>    
         imagePullPolicy: IfNotPresent
-        env:
-        - name: LD_LIBRARY_PATH
-          value: /usr/lib/nvidia:/usr/lib/x86_64-linux-gnu
         resources:
           limits:
             alpha.kubernetes.io/nvidia-gpu: 1
         volumeMounts:
         - mountPath: /usr/local/nvidia/bin
           name: bin
-        - mountPath: /usr/lib/nvidia
+        - mountPath: /usr/local/nvidia/lib64
           name: lib
         - mountPath: /usr/lib/x86_64-linux-gnu/libcuda.so.1
           name: libcuda

--- a/docs/kubernetes/gpu.md
+++ b/docs/kubernetes/gpu.md
@@ -64,7 +64,6 @@ spec:
 ```
 
 We specify `alpha.kubernetes.io/nvidia-gpu: 1` in the resources limits, and we mount the drivers from the host into the container.
-Note that we also modify the `LD_LIBRARY_PATH` environment variable to let python know where to find the driver's libraries.
 
 Some libraries, such as `libcuda.so` are installed under `/usr/lib/x86_64-linux-gnu` on the host, you might need to mount them separatly as shown above based on your needs.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix another issue with K8s GPU documentation.  
Modifying `LD_LIBRARY_PATH` is not ideal as the image we are running might also have made some changes to this env variable that we would be overwriting.  
This leads to issues with CUDA in the latest tensorflow images for example.

By instead mounting the drivers directly in `/usr/local/nvidia/lib64` we don't need to update `LD_LIBRARY_PATH` anymore and can avoid some potential issues.