### PR TITLE
Cordon retry

### DIFF
--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -36,6 +36,7 @@ type MockStorageClient struct{}
 type MockKubernetesClient struct {
 	FailListPods          bool
 	FailGetNode           bool
+	UpdateNodeFunc        func(*v1.Node) (*v1.Node, error)
 	FailUpdateNode        bool
 	FailSupportEviction   bool
 	FailDeletePod         bool
@@ -68,6 +69,9 @@ func (mkc *MockKubernetesClient) GetNode(name string) (*v1.Node, error) {
 
 //UpdateNode updates the node in the api server with the passed in info
 func (mkc *MockKubernetesClient) UpdateNode(node *v1.Node) (*v1.Node, error) {
+	if mkc.UpdateNodeFunc != nil {
+		return mkc.UpdateNodeFunc(node)
+	}
 	if mkc.FailUpdateNode {
 		return nil, fmt.Errorf("UpdateNode failed")
 	}

--- a/pkg/operations/cordondrainvm.go
+++ b/pkg/operations/cordondrainvm.go
@@ -9,7 +9,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
@@ -17,9 +16,8 @@ const (
 	interval            = time.Second * 1
 	mirrorPodAnnotation = "kubernetes.io/config.mirror"
 
-	// This is checked into their code but I was getting into vendoring issues trying to get the code into the vendor directory
-	kubernetesOptimisticLockErrorMsg = 
-	"the object has been modified; please apply your changes to the latest version and try again"
+	// This is checked into K8s code but I was getting into vendoring issues so I copied it here instead
+	kubernetesOptimisticLockErrorMsg = "the object has been modified; please apply your changes to the latest version and try again"
 )
 
 type drainOperation struct {
@@ -40,8 +38,9 @@ func SafelyDrainNode(az armhelpers.ACSEngineClient, logger *log.Entry, masterURL
 	}
 
 	//Mark the node unschedulable
-	for int i := 0 ; i < 5; i++ {
-		node, err := client.GetNode(nodeName)
+	var node *v1.Node
+	for i := 0; i < 5; i++ {
+		node, err = client.GetNode(nodeName)
 		if err != nil {
 			return err
 		}

--- a/pkg/operations/cordondrainvm.go
+++ b/pkg/operations/cordondrainvm.go
@@ -18,6 +18,7 @@ const (
 
 	// This is checked into K8s code but I was getting into vendoring issues so I copied it here instead
 	kubernetesOptimisticLockErrorMsg = "the object has been modified; please apply your changes to the latest version and try again"
+	cordonMaxRetries                 = 5
 )
 
 type drainOperation struct {
@@ -39,7 +40,7 @@ func SafelyDrainNode(az armhelpers.ACSEngineClient, logger *log.Entry, masterURL
 
 	//Mark the node unschedulable
 	var node *v1.Node
-	for i := 0; i < 5; i++ {
+	for i := 0; i < cordonMaxRetries; i++ {
 		node, err = client.GetNode(nodeName)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR makes the Cordoning of a node retry in cases where there was a concurrent modification between the get and PUT up to 5 times.
We have seen this in some tests.
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Retry Cordon in cases of a concurrent modification.
```
