### PR TITLE
setting coreos api models to use kubenet

### DIFF
--- a/examples/coreos/kubernetes-coreos-hybrid.json
+++ b/examples/coreos/kubernetes-coreos-hybrid.json
@@ -2,7 +2,10 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
+      "orchestratorType": "Kubernetes",
+      "kubernetesConfig": {
+        "networkPolicy": "none"
+      }
     },
     "masterProfile": {
       "count": 1,

--- a/examples/coreos/kubernetes-coreos.json
+++ b/examples/coreos/kubernetes-coreos.json
@@ -2,7 +2,10 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
+      "orchestratorType": "Kubernetes",
+      "kubernetesConfig": {
+        "networkPolicy": "none"
+      }
     },
     "masterProfile": {
       "count": 1,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: CoreOS Kubernetes clusters don't currently work w/ Azure CNI networking. Setting api model examples to explicitly use kubenet, now that Azure CNI is default networking implementation.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
