### PR TITLE
Fix wrong firstConsecutiveStaticIp 

### DIFF
--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -14,7 +14,7 @@
       "vmSize": "Standard_D2_v2",
       "OSDiskSizeGB": 200,
       "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
-      "firstConsecutiveStaticIP": "10.239.255.239",
+      "firstConsecutiveStaticIP": "10.230.255.239",
       "vnetCidr": "10.230.0.0/16"
     },
     "agentPoolProfiles": [

--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -5,7 +5,7 @@
       "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "enableRbac": true,
-        "clusterSubnet": "10.230.0.0/16"
+        "clusterSubnet": "10.239.0.0/16"
       }
     },
     "masterProfile": {

--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -14,8 +14,8 @@
       "vmSize": "Standard_D2_v2",
       "OSDiskSizeGB": 200,
       "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
-      "firstConsecutiveStaticIP": "10.230.255.239",
-      "vnetCidr": "10.230.0.0/16"
+      "firstConsecutiveStaticIP": "10.239.255.239",
+      "vnetCidr": "10.239.0.0/16"
     },
     "agentPoolProfiles": [
       {

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -108,13 +108,13 @@ var kubernetesManifestYamls = map[string]string{
 	"MASTER_KUBERNETES_ADDON_MANAGER_B64_GZIP_STR":            "k8s/kubernetesmaster-kube-addon-manager.yaml",
 }
 
-var kubernetesAritfacts = map[string]string{
+var kubernetesArtifacts = map[string]string{
 	"MASTER_PROVISION_B64_GZIP_STR":            kubernetesMasterCustomScript,
 	"MASTER_GENERATE_PROXY_CERTS_B64_GZIP_STR": kubernetesMasterGenerateProxyCertsScript,
 	"KUBELET_SERVICE_B64_GZIP_STR":             kubernetesKubeletService,
 }
 
-var kubernetesAritfacts15 = map[string]string{
+var kubernetesArtifacts15 = map[string]string{
 	"MASTER_PROVISION_B64_GZIP_STR":            kubernetesMasterCustomScript,
 	"MASTER_GENERATE_PROXY_CERTS_B64_GZIP_STR": kubernetesMasterGenerateProxyCertsScript,
 	"KUBELET_SERVICE_B64_GZIP_STR":             "k8s/kuberneteskubelet1.5.service",
@@ -1012,9 +1012,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			// add artifacts and addons
 			var artifiacts map[string]string
 			if strings.HasPrefix(profile.OrchestratorProfile.OrchestratorVersion, "1.5.") {
-				artifiacts = kubernetesAritfacts15
+				artifiacts = kubernetesArtifacts15
 			} else {
-				artifiacts = kubernetesAritfacts
+				artifiacts = kubernetesArtifacts
 			}
 			for placeholder, filename := range artifiacts {
 				addonTextContents := getBase64CustomScript(filename)
@@ -1069,9 +1069,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			// add artifacts
 			var artifiacts map[string]string
 			if strings.HasPrefix(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.5.") {
-				artifiacts = kubernetesAritfacts15
+				artifiacts = kubernetesArtifacts15
 			} else {
-				artifiacts = kubernetesAritfacts
+				artifiacts = kubernetesArtifacts
 			}
 			for placeholder, filename := range artifiacts {
 				addonTextContents := getBase64CustomScript(filename)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: There is a bug in example/e2e-tests/kubernetes/release/default/definition.json. In the MasterProfile, the firstConsecutiveStaticIp is not in the range of vnetCidr. Correct it from "10.239.255.239" to "10.230.255.239".

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
