### PR TITLE
E2E cleanup script hygiene: compare as strings

### DIFF
--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -42,7 +42,7 @@ az account set -s $SUBSCRIPTION_ID_TO_CLEANUP
 (( deadline=$(date +%s)-${expirationInSecs%.*} ))
 # find resource groups created before our deadline
 echo "Looking for resource groups created over ${EXPIRATION_IN_HOURS} hours ago..."
-for resourceGroup in `az group list | jq --arg dl "${deadline}" '.[] | select(.id | contains("acse-test-infrastructure") | not) | select(.tags.now|tonumber < $dl).name' | tr -d '\"'`; do
+for resourceGroup in `az group list | jq --arg dl $deadline '.[] | select(.id | contains("acse-test-infrastructure") | not) | select(.tags.now < $dl).name' | tr -d '\"'`; do
     echo "Will delete resource group ${resourceGroup}..."
     # delete old resource groups
     az group delete -y -n $resourceGroup --no-wait >> delete.log


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
