### PR TITLE
Azure CNI is default only in vlabs context

### DIFF
--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -37,7 +37,7 @@ const (
 	// address relative to the first consecutive Kubernetes static IP
 	DefaultInternalLbStaticIPOffset = 10
 	// DefaultNetworkPolicy defines the network policy to use by default
-	DefaultNetworkPolicy = "azure"
+	DefaultNetworkPolicy = "none"
 	// DefaultNetworkPolicyWindows defines the network policy to use by default for clusters with Windows agent pools
 	DefaultNetworkPolicyWindows = "none"
 	// DefaultKubernetesNodeStatusUpdateFrequency is 10s, see --node-status-update-frequency at https://kubernetes.io/docs/admin/kubelet/

--- a/pkg/api/vlabs/const.go
+++ b/pkg/api/vlabs/const.go
@@ -78,3 +78,11 @@ const (
 	// KubernetesMinMaxPods is the minimum valid value for MaxPods, necessary for running kube-system pods
 	KubernetesMinMaxPods = 5
 )
+
+// vlabs default configuration
+const (
+	// DefaultNetworkPolicy defines the network policy to use by default
+	DefaultNetworkPolicy = "azure"
+	// DefaultNetworkPolicyWindows defines the network policy to use by default for clusters with Windows agent pools
+	DefaultNetworkPolicyWindows = "none"
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
