### PR TITLE
more general vlabs kubernetes defaults enforcement

### DIFF
--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -564,6 +564,7 @@ func convertVLabsOrchestratorProfile(vp *vlabs.Properties, api *OrchestratorProf
 			api.KubernetesConfig = &KubernetesConfig{}
 			convertVLabsKubernetesConfig(vp, api.KubernetesConfig)
 		}
+		setVlabsKubernetesDefaults(vp, api)
 		api.OrchestratorVersion = common.RationalizeReleaseAndVersion(
 			vlabscs.OrchestratorType,
 			vlabscs.OrchestratorRelease,
@@ -620,15 +621,17 @@ func convertVLabsKubernetesConfig(vp *vlabs.Properties, api *KubernetesConfig) {
 	api.EtcdVersion = vlabs.EtcdVersion
 	api.EtcdDiskSizeGB = vlabs.EtcdDiskSizeGB
 	convertAddonsToAPI(vlabs, api)
-	setVlabsDefaultsKubernetesConfig(vp, api)
 }
 
-func setVlabsDefaultsKubernetesConfig(vp *vlabs.Properties, api *KubernetesConfig) {
-	if api.NetworkPolicy == "" {
+func setVlabsKubernetesDefaults(vp *vlabs.Properties, api *OrchestratorProfile) {
+	if api.KubernetesConfig == nil {
+		api.KubernetesConfig = &KubernetesConfig{}
+	}
+	if api.KubernetesConfig.NetworkPolicy == "" {
 		if vp.HasWindows() {
-			api.NetworkPolicy = vlabs.DefaultNetworkPolicyWindows
+			api.KubernetesConfig.NetworkPolicy = vlabs.DefaultNetworkPolicyWindows
 		} else {
-			api.NetworkPolicy = vlabs.DefaultNetworkPolicy
+			api.KubernetesConfig.NetworkPolicy = vlabs.DefaultNetworkPolicy
 		}
 	}
 }

--- a/pkg/api/convertertoapi_test.go
+++ b/pkg/api/convertertoapi_test.go
@@ -128,3 +128,41 @@ func TestOrchestratorVersion(t *testing.T) {
 		t.Fatalf("incorrect OrchestratorVersion '%s'", cs.Properties.OrchestratorProfile.OrchestratorVersion)
 	}
 }
+
+func TestKubernetesVlabsDefaults(t *testing.T) {
+	vp := makeKubernetesPropertiesVlabs()
+	ap := makeKubernetesProperties()
+	setVlabsKubernetesDefaults(vp, ap.OrchestratorProfile)
+	if ap.OrchestratorProfile.KubernetesConfig == nil {
+		t.Fatalf("KubernetesConfig cannot be nil after vlabs default conversion")
+	}
+	if ap.OrchestratorProfile.KubernetesConfig.NetworkPolicy != vlabs.DefaultNetworkPolicy {
+		t.Fatalf("vlabs defaults not applied, expected NetworkPolicy: %s, instead got: %s", vlabs.DefaultNetworkPolicy, ap.OrchestratorProfile.KubernetesConfig.NetworkPolicy)
+	}
+
+	vp = makeKubernetesPropertiesVlabs()
+	vp.WindowsProfile = &vlabs.WindowsProfile{}
+	vp.AgentPoolProfiles = append(vp.AgentPoolProfiles, &vlabs.AgentPoolProfile{OSType: "Windows"})
+	ap = makeKubernetesProperties()
+	setVlabsKubernetesDefaults(vp, ap.OrchestratorProfile)
+	if ap.OrchestratorProfile.KubernetesConfig == nil {
+		t.Fatalf("KubernetesConfig cannot be nil after vlabs default conversion")
+	}
+	if ap.OrchestratorProfile.KubernetesConfig.NetworkPolicy != vlabs.DefaultNetworkPolicyWindows {
+		t.Fatalf("vlabs defaults not applied, expected NetworkPolicy: %s, instead got: %s", vlabs.DefaultNetworkPolicyWindows, ap.OrchestratorProfile.KubernetesConfig.NetworkPolicy)
+	}
+}
+
+func makeKubernetesProperties() *Properties {
+	ap := &Properties{}
+	ap.OrchestratorProfile = &OrchestratorProfile{}
+	ap.OrchestratorProfile.OrchestratorType = "Kubernetes"
+	return ap
+}
+
+func makeKubernetesPropertiesVlabs() *vlabs.Properties {
+	vp := &vlabs.Properties{}
+	vp.OrchestratorProfile = &vlabs.OrchestratorProfile{}
+	vp.OrchestratorProfile.OrchestratorType = "Kubernetes"
+	return vp
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

We need to account for empty KubernetesConfig api models. Implemented here, with tests.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
