### PR TITLE
Support https for kubernetes-dashboard

### DIFF
--- a/parts/k8s/addons/1.9/kubernetesmasteraddons-kubernetes-dashboard-deployment.yaml
+++ b/parts/k8s/addons/1.9/kubernetesmasteraddons-kubernetes-dashboard-deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: kubernetes-dashboard
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-dashboard
+  labels:
+    k8s-app: kubernetes-dashboard
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-dashboard
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    kubernetes.io/cluster-service: "true"
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  ports:
+  - port: 443
+    targetPort: 8443
+  selector:
+    k8s-app: kubernetes-dashboard
+  type: NodePort
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: kubernetes-dashboard
+  template:
+    metadata:
+      labels:
+        k8s-app: kubernetes-dashboard
+    spec:
+      containers:
+      - args: 
+        - --auto-generate-certificates
+        - --heapster-host=http://heapster.kube-system:80
+        image: <kubernetesDashboardSpec>
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: "/"
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+        name: kubernetes-dashboard
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+        resources:
+          requests:
+            cpu: <kubernetesDashboardCPURequests>
+            memory: <kubernetesDashboardMemoryRequests>
+          limits:
+            cpu: <kubernetesDashboardCPULimit>
+            memory: <kubernetesDashboardMemoryLimit>
+        volumeMounts:
+         - name: kubernetes-dashboard-certs
+           mountPath: /certs
+      volumes:
+        - name: kubernetes-dashboard-certs
+          emptyDir: {}
+      serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        beta.kubernetes.io/os: linux


### PR DESCRIPTION
**What this PR does / why we need it**:
For kubernetes v1.9, default dashboard was turn on with https: https://github.com/kubernetes/kubernetes/pull/53046

Thus default dashboard location will turn to:
http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/

This will fail with `tls: oversized record received with length 20527` if dashboard does not use https

**Which issue this PR fixes**
Related:
- https://github.com/kubernetes/dashboard/wiki/FAQ#im-accessing-dashboard-over-https
- https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md
```
Updated Dashboard add-on to version 1.8.0: The Dashboard add-on now deploys with https enabled. The Dashboard can be accessed via kubectl proxy at http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/. The /ui redirect is deprecated and will be removed in 1.10. 
```
**Special notes for your reviewer**:
The old `kubernetesmasteraddons-kubernetes-dashboard-deployment.yaml` was copied to `kubernetesmasteraddons-kubernetes-dashboard-http-deployment.yaml`.

https related changes were applied to `kubernetesmasteraddons-kubernetes-dashboard-http-deployment.yaml` directly.

**Release note**:
Support https kubernetes dashboard