### PR TITLE
Add linux side custom bootstrap url to vlabs api

### DIFF
--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -711,6 +711,9 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 			if properties.OrchestratorProfile.DcosConfig.DcosWindowsBootstrapURL != "" {
 				dcosWindowsBootstrapURL = properties.OrchestratorProfile.DcosConfig.DcosWindowsBootstrapURL
 			}
+			if properties.OrchestratorProfile.DcosConfig.DcosBootstrapURL != "" {
+				dcosBootstrapURL = properties.OrchestratorProfile.DcosConfig.DcosBootstrapURL
+			}
 		}
 
 		addValue(parametersMap, "dcosBootstrapURL", dcosBootstrapURL)

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -638,6 +638,7 @@ func convertOrchestratorProfileToVLabs(api *OrchestratorProfile, o *vlabs.Orches
 }
 
 func convertDcosConfigToVLabs(api *DcosConfig, vlabs *vlabs.DcosConfig) {
+	vlabs.DcosBootstrapURL = api.DcosBootstrapURL
 	vlabs.DcosWindowsBootstrapURL = api.DcosWindowsBootstrapURL
 }
 

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -582,6 +582,7 @@ func convertVLabsOrchestratorProfile(vp *vlabs.Properties, api *OrchestratorProf
 }
 
 func convertVLabsDcosConfig(vlabs *vlabs.DcosConfig, api *DcosConfig) {
+	api.DcosBootstrapURL = vlabs.DcosBootstrapURL
 	api.DcosWindowsBootstrapURL = vlabs.DcosWindowsBootstrapURL
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -221,6 +221,7 @@ type KubernetesConfig struct {
 
 // DcosConfig Configuration for DC/OS
 type DcosConfig struct {
+	DcosBootstrapURL        string `json:"dcosBootstrapURL,omitempty"`
 	DcosWindowsBootstrapURL string `json:"dcosWindowsBootstrapURL,omitempty"`
 }
 

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -239,6 +239,7 @@ type KubernetesConfig struct {
 
 // DcosConfig Configuration for DC/OS
 type DcosConfig struct {
+	DcosBootstrapURL        string `json:"dcosBootstrapURL,omitempty"`
 	DcosWindowsBootstrapURL string `json:"dcosWindowsBootstrapURL,omitempty"`
 }
 

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -46,6 +46,11 @@ func Test_OrchestratorProfile_Validate(t *testing.T) {
 		t.Errorf("should error when DcosConfig populated for non-Kubernetes OrchestratorType")
 	}
 
+	o.DcosConfig.DcosBootstrapURL = "http://www.microsoft.com"
+	if err := o.Validate(false); err == nil {
+		t.Errorf("should error when DcosConfig populated for non-Kubernetes OrchestratorType")
+	}
+
 	o = &OrchestratorProfile{
 		OrchestratorType:    "Kubernetes",
 		OrchestratorVersion: "1.7.3",


### PR DESCRIPTION

Allows use of custom bootstrap URLs for both windows and linux. This is needed in order to deploy with acs-engine for Continuous intergration testing for windows dcos development. We need to be able to install a current built image rather than a boiler plate standard image.

Currently we can do that in windows, but not linux. 
