### PR TITLE
Persistent journald logs

### DIFF
--- a/parts/k8s/kubernetesmastercustomscript.sh
+++ b/parts/k8s/kubernetesmastercustomscript.sh
@@ -295,6 +295,10 @@ function extractKubectl(){
 function ensureJournal(){
     systemctl daemon-reload
     systemctlEnableAndCheck systemd-journald.service
+    echo "Storage=persistent" >> /etc/systemd/journald.conf
+    echo "SystemMaxUse=1G" >> /etc/systemd/journald.conf
+    echo "RuntimeMaxUse=1G" >> /etc/systemd/journald.conf
+    echo "ForwardToSyslog=no" >> /etc/systemd/journald.conf
     # only start if a reboot is not required
     if ! $REBOOTREQUIRED; then
         systemctl restart systemd-journald.service


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Kubelet logs are lost after node reboot.

- In /etc/systemd/journal.conf, it’s `#Storage=auto` by default and no persistent storage for journal logs
- And the kubelet container will also be destroyed after reboot and no container logs of kubelet can be found under /var/log/containers as well.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Kubelet logs are lost after node reboot.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
