### PR TITLE
Update prometheus-grafana extension to run on agent nodes

### DIFF
--- a/examples/extensions/prometheus-grafana-k8s.json
+++ b/examples/extensions/prometheus-grafana-k8s.json
@@ -7,19 +7,19 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_DS2_v2",
-      "extensions": [
-        { 
-          "name": "prometheus-grafana-k8s"
-        }
-      ]
+      "vmSize": "Standard_DS2_v2"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
         "vmSize": "Standard_DS2_v2",
-        "availabilityProfile": "AvailabilitySet"
+        "availabilityProfile": "AvailabilitySet",
+        "extensions": [
+          { 
+            "name": "prometheus-grafana-k8s"
+          }
+        ]
       }
     ],
     "linuxProfile": {

--- a/examples/extensions/prometheus-grafana-k8s.json
+++ b/examples/extensions/prometheus-grafana-k8s.json
@@ -36,7 +36,7 @@
       { 
         "name": "prometheus-grafana-k8s", 
         "version": "v1",
-        "rootURL": "https://raw.githubusercontent.com/Azure/acs-engine/master/"
+        "rootURL": "https://raw.githubusercontent.com/ritazh/acs-engine/feat-monitor-agent/"
       }
     ],
     "servicePrincipalProfile": {

--- a/examples/extensions/prometheus-grafana-k8s.json
+++ b/examples/extensions/prometheus-grafana-k8s.json
@@ -36,7 +36,7 @@
       { 
         "name": "prometheus-grafana-k8s", 
         "version": "v1",
-        "rootURL": "https://raw.githubusercontent.com/ritazh/acs-engine/feat-monitor-agent/"
+        "rootURL": "https://raw.githubusercontent.com/Azure/acs-engine/master/"
       }
     ],
     "servicePrincipalProfile": {

--- a/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
@@ -3,6 +3,9 @@ set -x
 
 echo $(date) " - Starting Script"
 
+echo $(date) " - Setting kubeconfig"
+export KUBECONFIG=/var/lib/kubelet/kubeconfig
+
 echo $(date) " - Waiting for API Server to start"
 kubernetesStarted=1
 for i in {1..600}; do
@@ -207,16 +210,16 @@ ensure_k8s_namespace_exists() {
 # should run the extension is to alphabetically determine
 # if this local machine is the first in the list of master nodes
 # if it is, then run the extension. if not, exit
-wait_for_master_nodes
-if [[ $? -ne 0 ]]; then
-    echo $(date) " - Error while waiting for kubectl to output master nodes. Exiting"
-    exit 1
-fi
-should_this_node_run_extension
-if [[ $? -ne 0 ]]; then
-    echo $(date) " - Not the first master node, no longer continuing extension. Exiting"
-    exit 1
-fi
+# wait_for_master_nodes
+# if [[ $? -ne 0 ]]; then
+#     echo $(date) " - Error while waiting for kubectl to output master nodes. Exiting"
+#     exit 1
+# fi
+# should_this_node_run_extension
+# if [[ $? -ne 0 ]]; then
+#     echo $(date) " - Not the first master node, no longer continuing extension. Exiting"
+#     exit 1
+# fi
 
 # Deploy container
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Support prometheus-grafana extension to run on either master nodes or agent nodes. This also serves as a demonstration of how to run extensions on agent nodes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #1955 

**Special notes for your reviewer**:
This update is a result of a discussion we had with @khenidak to ensure extensions can run on agent nodes so that the same extension can run on a managed k8s cluster.

NOTE: `examples/extensions/prometheus-grafana-k8s.json` is currently using my fork for `rootURL` so that the CI can pass. Will open another PR to update this value to point to upstream after this PR is merged.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
cc @tstringer 