### PR TITLE
add DenyEscalatingExec admission controller

### DIFF
--- a/parts/k8s/manifests/kubernetesmaster-kube-apiserver.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-apiserver.yaml
@@ -11,10 +11,10 @@ spec:
   containers:
     - name: "kube-apiserver"
       image: "<kubernetesHyperkubeSpec>"
-      command: 
+      command:
         - "/hyperkube"
         - "apiserver"
-        - "--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota"
+        - "--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,DenyEscalatingExec"
         - "--address=0.0.0.0"
         - "--allow-privileged"
         - "--insecure-port=8080"


### PR DESCRIPTION

**What this PR does / why we need it**:
Currently there are a few pods running privileged containers like kube-proxy and calico-node. If these containers are compromised, an attacker can easily compromise the underlying host. Given that these particular pods require privileged access, this PR adds the **DenyEscalatingExec** admission controller flag which prevents attaching or exec'ing into privileged pods running in the cluster. More info here: https://kubernetes.io/docs/admin/admission-controllers/#denyescalatingexec

Before this flag is applied you have the following:
```
kubectl exec  calico-node-06742  --namespace=kube-system 'ls'
Defaulting container name to calico-node.
Use 'kubectl describe pod/calico-node-06742' to see all of the containers in this pod.
bin
dev
etc
home
lib
lib64
licenses
media
mnt
proc
root
run
sbin
srv
startup.env
sys
tmp
usr
var
```

After the flag is applied an exec operation is denied:
```
kubectl exec  calico-node-06742  --namespace=kube-system 'ls'
Use 'kubectl describe pod/calico-node-06742' to see all of the containers in this pod.
Error from server (InternalError): Internal error occurred: [cannot exec into or attach to a privileged container, object does not implement the Object interfaces]
```

