### PR TITLE
Update GCR URLs for Docker images

### DIFF
--- a/examples/scale-up/kubernetes_orignal_params.json
+++ b/examples/scale-up/kubernetes_orignal_params.json
@@ -45,31 +45,31 @@
     "value": ""
   },
   "kubernetesAddonManagerSpec": {
-    "value": "gcr.io/google_containers/kube-addon-manager-amd64:v6.2"
+    "value": "k8s.gcr.io/kube-addon-manager-amd64:v6.2"
   },
   "kubernetesAddonResizerSpec": {
-    "value": "gcr.io/google_containers/addon-resizer:1.6"
+    "value": "k8s.gcr.io/addon-resizer:1.6"
   },
   "kubernetesDNSMasqSpec": {
-    "value": "gcr.io/google_containers/kube-dnsmasq-amd64:1.3"
+    "value": "k8s.gcr.io/kube-dnsmasq-amd64:1.3"
   },
   "kubernetesDashboardSpec": {
-    "value": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.1"
+    "value": "k8s.gcr.io/kubernetes-dashboard-amd64:v1.5.1"
   },
   "kubernetesExecHealthzSpec": {
-    "value": "gcr.io/google_containers/exechealthz-amd64:1.2"
+    "value": "k8s.gcr.io/exechealthz-amd64:1.2"
   },
   "kubernetesHeapsterSpec": {
-    "value": "gcr.io/google_containers/heapster:v1.2.0"
+    "value": "k8s.gcr.io/heapster:v1.2.0"
   },
   "kubernetesHyperkubeSpec": {
-    "value": "gcr.io/google_containers/hyperkube-amd64:v1.5.3"
+    "value": "k8s.gcr.io/hyperkube-amd64:v1.5.3"
   },
   "kubernetesKubeDNSSpec": {
-    "value": "gcr.io/google_containers/kubedns-amd64:1.7"
+    "value": "k8s.gcr.io/kubedns-amd64:1.7"
   },
   "kubernetesPodInfraContainerSpec": {
-    "value": "gcr.io/google_containers/pause-amd64:3.0"
+    "value": "k8s.gcr.io/pause-amd64:3.0"
   },
   "linuxAdminUsername": {
     "value": "azureuser"

--- a/examples/scale-up/kubernetes_scale_up_params.json
+++ b/examples/scale-up/kubernetes_scale_up_params.json
@@ -51,31 +51,31 @@
     "value": ""
   },
   "kubernetesAddonManagerSpec": {
-    "value": "gcr.io/google_containers/kube-addon-manager-amd64:v6.2"
+    "value": "k8s.gcr.io/kube-addon-manager-amd64:v6.2"
   },
   "kubernetesAddonResizerSpec": {
-    "value": "gcr.io/google_containers/addon-resizer:1.6"
+    "value": "k8s.gcr.io/addon-resizer:1.6"
   },
   "kubernetesDNSMasqSpec": {
-    "value": "gcr.io/google_containers/kube-dnsmasq-amd64:1.3"
+    "value": "k8s.gcr.io/kube-dnsmasq-amd64:1.3"
   },
   "kubernetesDashboardSpec": {
-    "value": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.1"
+    "value": "k8s.gcr.io/kubernetes-dashboard-amd64:v1.5.1"
   },
   "kubernetesExecHealthzSpec": {
-    "value": "gcr.io/google_containers/exechealthz-amd64:1.2"
+    "value": "k8s.gcr.io/exechealthz-amd64:1.2"
   },
   "kubernetesHeapsterSpec": {
-    "value": "gcr.io/google_containers/heapster:v1.2.0"
+    "value": "k8s.gcr.io/heapster:v1.2.0"
   },
   "kubernetesHyperkubeSpec": {
-    "value": "gcr.io/google_containers/hyperkube-amd64:v1.5.3"
+    "value": "k8s.gcr.io/hyperkube-amd64:v1.5.3"
   },
   "kubernetesKubeDNSSpec": {
-    "value": "gcr.io/google_containers/kubedns-amd64:1.7"
+    "value": "k8s.gcr.io/kubedns-amd64:1.7"
   },
   "kubernetesPodInfraContainerSpec": {
-    "value": "gcr.io/google_containers/pause-amd64:3.0"
+    "value": "k8s.gcr.io/pause-amd64:3.0"
   },
   "linuxAdminUsername": {
     "value": "azureuser"

--- a/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml
@@ -186,7 +186,7 @@ kubeStateMetrics:
   ## kube-state-metrics container image
   ##
   image:
-    repository: gcr.io/google_containers/kube-state-metrics
+    repository: k8s.gcr.io/kube-state-metrics
     tag: v1.1.0-rc.0
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Add future-proofing to the URLs referencing Kubernetes Docker images, as described in [this tweet](https://twitter.com/kubernetesonarm/status/944170779620626433).