### PR TITLE
enable default flexvolume plugin directory on Windows

### DIFF
--- a/parts/k8s/artifacts/1.5/kuberneteskubelet.service
+++ b/parts/k8s/artifacts/1.5/kuberneteskubelet.service
@@ -30,7 +30,6 @@ ExecStart=/usr/bin/docker run \
   --volume=/etc/kubernetes/:/etc/kubernetes:ro \
   --volume=/srv/kubernetes/:/srv/kubernetes:ro $DOCKER_OPTS \
   --volume=/var/lib/waagent/ManagedIdentity-Settings:/var/lib/waagent/ManagedIdentity-Settings:ro \
-  --volume=/usr/libexec/kubernetes/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins \
     ${KUBELET_IMAGE} \
       /hyperkube kubelet \
         --require-kubeconfig \

--- a/parts/k8s/artifacts/kuberneteskubelet.service
+++ b/parts/k8s/artifacts/kuberneteskubelet.service
@@ -30,7 +30,7 @@ ExecStart=/usr/bin/docker run \
   --volume=/etc/kubernetes/:/etc/kubernetes:ro \
   --volume=/srv/kubernetes/:/srv/kubernetes:ro $DOCKER_OPTS \
   --volume=/var/lib/waagent/ManagedIdentity-Settings:/var/lib/waagent/ManagedIdentity-Settings:ro \
-  --volume=/usr/libexec/kubernetes/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins \
+  --volume=/usr/libexec/kubernetes/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins:rw \
     ${KUBELET_IMAGE} \
       /hyperkube kubelet \
         --require-kubeconfig \

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -70,6 +70,8 @@ $global:NetworkMode = "L2Bridge"
 $global:CNIConfig = [Io.path]::Combine($global:CNIPath, "config", "`$global:NetworkMode.conf")
 $global:HNSModule = [Io.path]::Combine("$global:KubeDir", "hns.psm1")
 
+$global:VolumePluginDir = [Io.path]::Combine("$global:KubeDir", "volumeplugins")
+
 filter Timestamp {"$(Get-Date -Format o): $_"}
 
 function
@@ -158,6 +160,7 @@ New-InfraContainer()
 function
 Write-KubernetesStartFiles($podCIDR)
 {
+    mkdir $global:VolumePluginDir
     $KubeletArgList = @("--hostname-override=`$global:AzureHostname","--pod-infra-container-image=kubletwin/pause","--resolv-conf=""""""""","--kubeconfig=c:\k\config","--cloud-provider=azure","--cloud-config=c:\k\azure.json")
     $KubeletCommandLine = @"
 c:\k\kubelet.exe --hostname-override=`$global:AzureHostname --pod-infra-container-image=kubletwin/pause --resolv-conf="" --allow-privileged=true --enable-debugging-handlers --cluster-dns=`$global:KubeDnsServiceIp --cluster-domain=cluster.local  --kubeconfig=c:\k\config --hairpin-mode=promiscuous-bridge --v=2 --azure-container-registry-config=c:\k\azure.json --runtime-request-timeout=10m  --cloud-provider=azure --cloud-config=c:\k\azure.json
@@ -175,6 +178,7 @@ c:\k\kubelet.exe --hostname-override=`$global:AzureHostname --pod-infra-containe
 
     # more time is needed to pull windows server images
     $KubeletCommandLine += " --image-pull-progress-deadline=20m --cgroups-per-qos=false --enforce-node-allocatable=`"`""
+    $KubeletCommandLine += " --volume-plugin-dir=`$global:VolumePluginDir"
 
     $KubeletArgListStr = "`"" + ($KubeletArgList -join "`",`"") + "`""
 
@@ -192,6 +196,7 @@ c:\k\kubelet.exe --hostname-override=`$global:AzureHostname --pod-infra-containe
 `$global:NetworkMode = "$global:NetworkMode"
 `$global:CNIConfig = "$global:CNIConfig"
 `$global:HNSModule = "$global:HNSModule"
+`$global:VolumePluginDir = "$global:VolumePluginDir"
 
 function
 Get-DefaultGateway(`$CIDR)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
enable default flexvolume plugin directory on Windows.
You could follow this step by step [guide](https://github.com/andyzhangx/Demo/blob/master/windows/flexvolume/) to use flexvolume plugin on Windows

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This PR also disabled default flexvolume plugin directory on k8s 1.5 since 1.5 does not support flexvolume

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
enable default flexvolume plugin directory on Windows
```

@jackfrancis @JiangtianLi 
