### PR TITLE
remove organization[0] = "system:masters" config from etcd certs

### DIFF
--- a/pkg/acsengine/pki.go
+++ b/pkg/acsengine/pki.go
@@ -95,7 +95,6 @@ func CreatePki(extraFQDNs []string, extraIPs []net.IP, clusterDomain string, caP
 	go func() {
 		var err error
 		organization := make([]string, 1)
-		organization[0] = "system:masters"
 		ip := net.ParseIP("127.0.0.1").To4()
 		peerIPs := append(extraIPs, ip)
 		etcdServerCertificate, etcdServerPrivateKey, err = createCertificate("etcdserver", caCertificate, caPrivateKey, true, true, nil, peerIPs, organization)
@@ -105,7 +104,6 @@ func CreatePki(extraFQDNs []string, extraIPs []net.IP, clusterDomain string, caP
 	go func() {
 		var err error
 		organization := make([]string, 1)
-		organization[0] = "system:masters"
 		ip := net.ParseIP("127.0.0.1").To4()
 		peerIPs := append(extraIPs, ip)
 		etcdClientCertificate, etcdClientPrivateKey, err = createCertificate("etcdclient", caCertificate, caPrivateKey, true, false, nil, peerIPs, organization)
@@ -117,7 +115,6 @@ func CreatePki(extraFQDNs []string, extraIPs []net.IP, clusterDomain string, caP
 		go func(i int) {
 			var err error
 			organization := make([]string, 1)
-			organization[0] = "system:masters"
 			ip := net.ParseIP("127.0.0.1").To4()
 			peerIPs := append(extraIPs, ip)
 			etcdPeerCertificate := new(x509.Certificate)

--- a/pkg/acsengine/pki.go
+++ b/pkg/acsengine/pki.go
@@ -94,7 +94,7 @@ func CreatePki(extraFQDNs []string, extraIPs []net.IP, clusterDomain string, caP
 
 	go func() {
 		var err error
-		organization := make([]string, 1)
+		var organization []string
 		ip := net.ParseIP("127.0.0.1").To4()
 		peerIPs := append(extraIPs, ip)
 		etcdServerCertificate, etcdServerPrivateKey, err = createCertificate("etcdserver", caCertificate, caPrivateKey, true, true, nil, peerIPs, organization)
@@ -103,7 +103,7 @@ func CreatePki(extraFQDNs []string, extraIPs []net.IP, clusterDomain string, caP
 
 	go func() {
 		var err error
-		organization := make([]string, 1)
+		var organization []string
 		ip := net.ParseIP("127.0.0.1").To4()
 		peerIPs := append(extraIPs, ip)
 		etcdClientCertificate, etcdClientPrivateKey, err = createCertificate("etcdclient", caCertificate, caPrivateKey, true, false, nil, peerIPs, organization)
@@ -114,7 +114,7 @@ func CreatePki(extraFQDNs []string, extraIPs []net.IP, clusterDomain string, caP
 	for i := 0; i < masterCount; i++ {
 		go func(i int) {
 			var err error
-			organization := make([]string, 1)
+			var organization []string
 			ip := net.ParseIP("127.0.0.1").To4()
 			peerIPs := append(extraIPs, ip)
 			etcdPeerCertificate := new(x509.Certificate)


### PR DESCRIPTION

**What this PR does / why we need it**:
The _systems:masters_ OU field is required by components authenticating against the kubernetes API via client certs and require cluster-wide Admin-level permissions (via RBAC). The etcd certs do not require this field.   

