### PR TITLE
secure communciation from kubernetes API to kubelet API endpoint

### DIFF
--- a/parts/k8s/manifests/kubernetesmaster-kube-apiserver.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-apiserver.yaml
@@ -35,6 +35,8 @@ spec:
         - "--proxy-client-cert-file=/etc/kubernetes/certs/proxy.crt"
         - "--proxy-client-key-file=/etc/kubernetes/certs/proxy.key"
         - "--service-account-key-file=/etc/kubernetes/certs/apiserver.key"
+        - "--kubelet-client-certificate=/etc/kubernetes/certs/client.crt"
+        - "--kubelet-client-key=/etc/kubernetes/certs/client.key"
         - "--oidc-client-id="
         - "--oidc-issuer-url="
         - "--oidc-username-claim=oid"

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -13,9 +13,9 @@ func setKubeletConfig(cs *api.ContainerService) {
 	staticLinuxKubeletConfig := map[string]string{
 		"--address":                         "0.0.0.0",
 		"--allow-privileged":                "true",
-		"--anonymous-auth":		     "false",
-		"--authorization-mode":		     "Webhook",
-		"--client-ca-file":		     "/etc/kubernetes/certs/ca.crt",
+		"--anonymous-auth":                  "false",
+		"--authorization-mode":              "Webhook",
+		"--client-ca-file":                  "/etc/kubernetes/certs/ca.crt",
 		"--pod-manifest-path":               "/etc/kubernetes/manifests",
 		"--cloud-config":                    "/etc/kubernetes/azure.json",
 		"--cluster-domain":                  "cluster.local",

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -13,6 +13,9 @@ func setKubeletConfig(cs *api.ContainerService) {
 	staticLinuxKubeletConfig := map[string]string{
 		"--address":                         "0.0.0.0",
 		"--allow-privileged":                "true",
+		"--anonymous-auth":		     "false",
+		"--authorization-mode":		     "Webhook",
+		"--client-ca-file":		     "/etc/kubernetes/certs/ca.crt",
 		"--pod-manifest-path":               "/etc/kubernetes/manifests",
 		"--cloud-config":                    "/etc/kubernetes/azure.json",
 		"--cluster-domain":                  "cluster.local",


### PR DESCRIPTION
**What this PR does / why we need it**:
Communication from kubelet -> API server is currently secure, but not API server -> kubelet. The  kubelet exposes an unauthenticated endpoint on port 10250 which can be exploited from any other node on the cluster.


This PR adds:
- client cert authentication for the kubernetes API against the kubelet API
- Disables anonymous access to the kubelet API
- Restricts access to the kubelet API to only the kubernetes API

More info is available here:

https://kubernetes.io/docs/admin/kubelet-authentication-authorization/
https://kubernetes.io/docs/tasks/administer-cluster/securing-a-cluster/
https://github.com/kubernetes/kubernetes/issues/52184
 
