### PR TITLE
remove 1.9 from e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,12 +325,6 @@ workflows:
           filters:
             branches:
               ignore: master
-      - k8s-1.9-release-e2e:
-          requires:
-            - pr-e2e-hold
-          filters:
-            branches:
-              ignore: master
       - swarm-e2e:
           requires:
             - pr-e2e-hold
@@ -386,12 +380,6 @@ workflows:
             branches:
               only: master
       - k8s-hybrid-1.8-release-e2e:
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
-      - k8s-1.9-release-e2e:
           requires:
             - test
           filters:

--- a/test/acse-conf/acse-regression.json
+++ b/test/acse-conf/acse-regression.json
@@ -62,10 +62,6 @@
       "category": "version"
     },
     {
-      "cluster_definition": "kubernetes-releases/kubernetes1.9.json",
-      "category": "version"
-    },
-    {
       "cluster_definition": "networkpolicy/kubernetes-calico.json",
       "category": "network"
     },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

remove 1.9 from e2e tests until we rationalize dashboard tests for http/https

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
