### PR TITLE
v1.9 clusters have 443-enabled dashboards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,6 +325,12 @@ workflows:
           filters:
             branches:
               ignore: master
+      - k8s-1.9-release-e2e:
+          requires:
+            - pr-e2e-hold
+          filters:
+            branches:
+              ignore: master
       - swarm-e2e:
           requires:
             - pr-e2e-hold
@@ -380,6 +386,12 @@ workflows:
             branches:
               only: master
       - k8s-hybrid-1.8-release-e2e:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master
+      - k8s-1.9-release-e2e:
           requires:
             - test
           filters:

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -134,7 +134,11 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 			s, err := service.Get("kubernetes-dashboard", "kube-system")
 			Expect(err).NotTo(HaveOccurred())
-			port := s.GetNodePort(80)
+			dashboardPort := 80
+			if eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorRelease == "1.9" {
+				dashboardPort = 443
+			}
+			port := s.GetNodePort(dashboardPort)
 
 			master := fmt.Sprintf("azureuser@%s", kubeConfig.GetServerName())
 			nodeList, err := node.Get()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Adds a check to ginkgo test runner to determine if we should test dashboard against TCP 443 (v1.9.0 and above clusters) or TCP 80 (all others at the moment)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
