### PR TITLE
Handle error when getting service fails in e2e

### DIFF
--- a/test/e2e/kubernetes/service/service.go
+++ b/test/e2e/kubernetes/service/service.go
@@ -101,7 +101,7 @@ func (s *Service) WaitForExternalIP(wait, sleep time.Duration) (*Service, error)
 				errCh <- fmt.Errorf("Timeout exceeded while waiting for External IP to be provisioned")
 			default:
 				svc, _ := Get(s.Metadata.Name, s.Metadata.Namespace)
-				if svc.Status.LoadBalancer.Ingress != nil {
+				if svc != nil && svc.Status.LoadBalancer.Ingress != nil {
 					svcCh <- svc
 				}
 				time.Sleep(sleep)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
