### PR TITLE
restore ORCHESTRATOR_RELEASE for ginkgo E2E

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	"github.com/Azure/acs-engine/pkg/api/common"
@@ -144,7 +145,11 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			s, err := service.Get("kubernetes-dashboard", "kube-system")
 			Expect(err).NotTo(HaveOccurred())
 			dashboardPort := 80
-			if eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorRelease == "1.9" {
+			version, err := node.Version()
+			Expect(err).NotTo(HaveOccurred())
+
+			re := regexp.MustCompile("v1.9")
+			if re.FindString(version) != "" {
 				dashboardPort = 443
 			}
 			port := s.GetNodePort(dashboardPort)

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -62,11 +62,20 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			version, err := node.Version()
 			Expect(err).NotTo(HaveOccurred())
 
-			if eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorVersion != "" {
-				Expect(version).To(MatchRegexp("v" + eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorVersion))
+			var expectedVersion string
+			if eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorRelease != "" ||
+				eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorVersion != "" {
+				expectedVersion = common.RationalizeReleaseAndVersion(
+					common.Kubernetes,
+					eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorRelease,
+					eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorVersion)
 			} else {
-				Expect(version).To(Equal("v" + common.KubernetesDefaultVersion))
+				expectedVersion = common.RationalizeReleaseAndVersion(
+					common.Kubernetes,
+					eng.Config.OrchestratorRelease,
+					eng.Config.OrchestratorVersion)
 			}
+			Expect(version).To(Equal("v" + expectedVersion))
 		})
 
 		It("should have kube-dns running", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This allows us to re-use common api models and pass in different versions at runtime for validating a distribution of orchestrator versions

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
