### PR TITLE
download portmap

### DIFF
--- a/parts/k8s/kubernetesmastercustomscript.sh
+++ b/parts/k8s/kubernetesmastercustomscript.sh
@@ -238,7 +238,7 @@ function configAzureNetworkPolicy() {
     # Mirror from https://github.com/Azure/azure-container-networking/releases/tag/$AZURE_PLUGIN_VER/azure-vnet-cni-linux-amd64-$AZURE_PLUGIN_VER.tgz
     downloadUrl ${VNET_CNI_PLUGINS_URL} | tar -xz -C $CNI_BIN_DIR
     # Mirror from https://github.com/containernetworking/cni/releases/download/$CNI_RELEASE_VER/cni-amd64-$CNI_RELEASE_VERSION.tgz
-    downloadUrl ${CNI_PLUGINS_URL} | tar -xz -C $CNI_BIN_DIR ./loopback
+    downloadUrl ${CNI_PLUGINS_URL} | tar -xz -C $CNI_BIN_DIR ./loopback ./portmap
     chown -R root:root $CNI_BIN_DIR
     chmod -R 755 $CNI_BIN_DIR
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Download Linux CNI portmap plugin to enable hostport functionality in kubernetes.