### PR TITLE
Added Windows Custom Image. Only works in dcos, but can be added to k8s

### DIFF
--- a/parts/dcos/dcosWindowsAgentResourcesVmas.t
+++ b/parts/dcos/dcosWindowsAgentResourcesVmas.t
@@ -9,6 +9,23 @@
       },
       "type": "Microsoft.Network/networkSecurityGroups"
     },
+{{if HasWindowsCustomImage}}
+    {"type": "Microsoft.Compute/images",
+      "apiVersion": "2017-12-01",
+      "name": "{{.Name}}CustomWindowsImage",
+      "location": "[variables('location')]",
+      "properties": {
+        "storageProfile": {
+          "osDisk": {
+            "osType": "Windows",
+            "osState": "Generalized",
+            "blobUri": "[parameters('agentWindowsSourceUrl')]",
+            "storageAccountType": "Standard_LRS"
+          }
+        }
+      }
+    },
+{{end}}
     {
       "apiVersion": "[variables('apiVersionDefault')]",
       "copy": {
@@ -224,10 +241,14 @@
         "storageProfile": {
           {{GetDataDisks .}}
           "imageReference": {
+{{if HasWindowsCustomImage}}
+            "id": "[resourceId('Microsoft.Compute/images','{{.Name}}CustomWindowsImage')]"
+{{else}}
             "offer": "[variables('agentWindowsOffer')]",
             "publisher": "[variables('agentWindowsPublisher')]",
             "sku": "[variables('agentWindowsSKU')]",
             "version": "[variables('agentWindowsVersion')]"
+{{end}}
           }
           ,"osDisk": {
             "caching": "ReadOnly"

--- a/parts/dcos/dcosWindowsAgentResourcesVmss.t
+++ b/parts/dcos/dcosWindowsAgentResourcesVmss.t
@@ -9,6 +9,23 @@
       },
       "type": "Microsoft.Network/networkSecurityGroups"
     },
+{{if HasWindowsCustomImage}}
+    {"type": "Microsoft.Compute/images",
+      "apiVersion": "2017-12-01",
+      "name": "{{.Name}}CustomWindowsImage",
+      "location": "[variables('location')]",
+      "properties": {
+        "storageProfile": {
+          "osDisk": {
+            "osType": "Windows",
+            "osState": "Generalized",
+            "blobUri": "[parameters('agentWindowsSourceUrl')]",
+            "storageAccountType": "Standard_LRS"
+          }
+        }
+      }
+    },
+{{end}}
 {{if .IsStorageAccount}}
     {
       "apiVersion": "[variables('apiVersionStorage')]",
@@ -152,10 +169,14 @@
           },
           "storageProfile": {
             "imageReference": {
+{{if HasWindowsCustomImage}}
+              "id": "[resourceId('Microsoft.Compute/images','{{.Name}}CustomWindowsImage')]"
+{{else}}
               "publisher": "[variables('agentWindowsPublisher')]",
               "offer": "[variables('agentWindowsOffer')]",
               "sku": "[variables('agentWindowsSku')]",
               "version": "latest"
+{{end}}
             },
             {{GetDataDisks .}}
             "osDisk": {

--- a/parts/windowsparams.t
+++ b/parts/windowsparams.t
@@ -16,4 +16,11 @@
         "description": "Version of the Windows Server 2016 OS image to use for the agent virtual machines."
       },
       "type": "string"
+    },
+    "agentWindowsSourceUrl": {
+      "defaultValue": "",
+      "metadata": {
+        "description": "The source of the generalized blob which will be used to create a custom windows image for the agent virtual machines."
+      },
+      "type": "string"
     }

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -699,6 +699,9 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 		if properties.WindowsProfile.ImageVersion != "" {
 			addValue(parametersMap, "agentWindowsVersion", properties.WindowsProfile.ImageVersion)
 		}
+		if properties.WindowsProfile.WindowsImageSourceURL != "" {
+			addValue(parametersMap, "agentWindowsSourceUrl", properties.WindowsProfile.WindowsImageSourceURL)
+		}
 		if properties.OrchestratorProfile.OrchestratorType == api.Kubernetes {
 			k8sVersion := properties.OrchestratorProfile.OrchestratorVersion
 			addValue(parametersMap, "kubeBinariesSASURL", cloudSpecConfig.KubernetesSpecConfig.KubeBinariesSASURLBase+KubeConfigs[k8sVersion]["windowszip"])
@@ -1196,6 +1199,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		},
 		"HasWindowsSecrets": func() bool {
 			return cs.Properties.WindowsProfile.HasSecrets()
+		},
+		"HasWindowsCustomImage": func() bool {
+			return cs.Properties.WindowsProfile.HasCustomImage()
 		},
 		"GetConfigurationScriptRootURL": func() string {
 			if cs.Properties.LinuxProfile.ScriptRootURL == "" {

--- a/pkg/acsengine/transform/json.go
+++ b/pkg/acsengine/transform/json.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	//fmt
 	"encoding/json"
 	"strings"
 

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -574,6 +574,7 @@ func convertWindowsProfileToVLabs(api *WindowsProfile, vlabsProfile *vlabs.Windo
 	vlabsProfile.AdminUsername = api.AdminUsername
 	vlabsProfile.AdminPassword = api.AdminPassword
 	vlabsProfile.ImageVersion = api.ImageVersion
+	vlabsProfile.WindowsImageSourceURL = api.WindowsImageSourceURL
 	vlabsProfile.Secrets = []vlabs.KeyVaultSecrets{}
 	for _, s := range api.Secrets {
 		secret := &vlabs.KeyVaultSecrets{}

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -500,6 +500,7 @@ func convertVLabsWindowsProfile(vlabs *vlabs.WindowsProfile, api *WindowsProfile
 	api.AdminUsername = vlabs.AdminUsername
 	api.AdminPassword = vlabs.AdminPassword
 	api.ImageVersion = vlabs.ImageVersion
+	api.WindowsImageSourceURL = vlabs.WindowsImageSourceURL
 	api.Secrets = []KeyVaultSecrets{}
 	for _, s := range vlabs.Secrets {
 		secret := &KeyVaultSecrets{}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -123,10 +123,11 @@ type PublicKey struct {
 
 // WindowsProfile represents the windows parameters passed to the cluster
 type WindowsProfile struct {
-	AdminUsername string            `json:"adminUsername"`
-	AdminPassword string            `json:"adminPassword"`
-	ImageVersion  string            `json:"imageVersion"`
-	Secrets       []KeyVaultSecrets `json:"secrets,omitempty"`
+	AdminUsername         string            `json:"adminUsername"`
+	AdminPassword         string            `json:"adminPassword"`
+	ImageVersion          string            `json:"imageVersion"`
+	WindowsImageSourceURL string            `json:"windowsImageSourceURL"`
+	Secrets               []KeyVaultSecrets `json:"secrets,omitempty"`
 }
 
 // ProvisioningState represents the current state of container service resource.
@@ -554,6 +555,11 @@ func (a *AgentPoolProfile) HasDisks() bool {
 // HasSecrets returns true if the customer specified secrets to install
 func (w *WindowsProfile) HasSecrets() bool {
 	return len(w.Secrets) > 0
+}
+
+// HasCustomImage returns true if there is a custom windows os image url specified
+func (w *WindowsProfile) HasCustomImage() bool {
+	return len(w.WindowsImageSourceURL) > 0
 }
 
 // HasSecrets returns true if the customer specified secrets to install

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -125,10 +125,11 @@ type PublicKey struct {
 
 // WindowsProfile represents the windows parameters passed to the cluster
 type WindowsProfile struct {
-	AdminUsername string            `json:"adminUsername,omitempty"`
-	AdminPassword string            `json:"adminPassword,omitempty"`
-	ImageVersion  string            `json:"imageVersion,omitempty"`
-	Secrets       []KeyVaultSecrets `json:"secrets,omitempty"`
+	AdminUsername         string            `json:"adminUsername,omitempty"`
+	AdminPassword         string            `json:"adminPassword,omitempty"`
+	ImageVersion          string            `json:"imageVersion,omitempty"`
+	WindowsImageSourceURL string            `json:"WindowsImageSourceUrl"`
+	Secrets               []KeyVaultSecrets `json:"secrets,omitempty"`
 }
 
 // ProvisioningState represents the current state of container service resource.

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -142,6 +142,7 @@ func (o *OrchestratorProfile) Validate(isUpdate bool) error {
 	if o.OrchestratorType != DCOS && o.DcosConfig != nil && (*o.DcosConfig != DcosConfig{}) {
 		return fmt.Errorf("DcosConfig can be specified only when OrchestratorType is DCOS")
 	}
+
 	return nil
 }
 
@@ -450,6 +451,12 @@ func (a *Properties) Validate(isUpdate bool) error {
 			if !keyvaultIDRegex.MatchString(extension.ExtensionParametersKeyVaultRef.VaultID) {
 				return fmt.Errorf("Extension %s's keyvault secret reference is of incorrect format", extension.Name)
 			}
+		}
+	}
+
+	if a.OrchestratorProfile.OrchestratorType != DCOS && a.WindowsProfile != nil {
+		if a.WindowsProfile.WindowsImageSourceURL != "" {
+			return fmt.Errorf("Windows Custom Images are only supported if the Orchestrator Type is DCOS")
 		}
 	}
 


### PR DESCRIPTION

**What this PR does / why we need it**:
Allows the use of custom windows system disk images in the VLabs API deployments. This in turn allows us to use confidential daily build, or specially provisioned images.  This is implemented completely for DC/OS. Someone in the k8s team will probably want to apply the changes the k8s parts.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

While this is implemented completely for DC/OS, it modifies the WindowsProfile so should be usable in any of the different code legs, such as k8s or docker swarm with fairly simple mods.

**Release note**:

