### PR TITLE
Enable host port

### DIFF
--- a/parts/k8s/kubernetesmastercustomscript.sh
+++ b/parts/k8s/kubernetesmastercustomscript.sh
@@ -242,7 +242,7 @@ function configAzureNetworkPolicy() {
     chown -R root:root $CNI_BIN_DIR
     chmod -R 755 $CNI_BIN_DIR
 
-    # Copy config file
+    # Copy config file. After azure cni is released, we should change the 10-azure.conf to 10-azure.conflist
     mv $CNI_BIN_DIR/10-azure.conf $CNI_CONFIG_DIR/
     chmod 600 $CNI_CONFIG_DIR/10-azure.conf
 

--- a/parts/k8s/kubernetesmastercustomscript.sh
+++ b/parts/k8s/kubernetesmastercustomscript.sh
@@ -238,7 +238,7 @@ function configAzureNetworkPolicy() {
     # Mirror from https://github.com/Azure/azure-container-networking/releases/tag/$AZURE_PLUGIN_VER/azure-vnet-cni-linux-amd64-$AZURE_PLUGIN_VER.tgz
     downloadUrl ${VNET_CNI_PLUGINS_URL} | tar -xz -C $CNI_BIN_DIR
     # Mirror from https://github.com/containernetworking/cni/releases/download/$CNI_RELEASE_VER/cni-amd64-$CNI_RELEASE_VERSION.tgz
-    downloadUrl ${CNI_PLUGINS_URL} | tar -xz -C $CNI_BIN_DIR ./loopback
+    downloadUrl ${CNI_PLUGINS_URL} | tar -xz -C $CNI_BIN_DIR ./loopback ./portmap
     chown -R root:root $CNI_BIN_DIR
     chmod -R 755 $CNI_BIN_DIR
 

--- a/parts/k8s/kubernetesmastercustomscript.sh
+++ b/parts/k8s/kubernetesmastercustomscript.sh
@@ -243,8 +243,8 @@ function configAzureNetworkPolicy() {
     chmod -R 755 $CNI_BIN_DIR
 
     # Copy config file. After azure cni is released, we should change the 10-azure.conf to 10-azure.conflist
-    mv $CNI_BIN_DIR/10-azure.conf $CNI_CONFIG_DIR/
-    chmod 600 $CNI_CONFIG_DIR/10-azure.conf
+    mv $CNI_BIN_DIR/10-azure.conflist $CNI_CONFIG_DIR/
+    chmod 600 $CNI_CONFIG_DIR/10-azure.conflist
 
     # Dump ebtables rules.
     /sbin/ebtables -t nat --list


### PR DESCRIPTION
**What this PR does / why we need it**:

Update Azure cni config file to enable hostport functionality of Kubernetes.

This PR contains changes that download portmap plugin from cni repo which will handle functionality of hostport specified in pod yaml