### PR TITLE
stop running make coverage + make test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,6 @@ jobs:
           command: make test
       - store_test_results:
           path: test/junit
-      - run:
-          name: Generate test coverage results
-          command:  make coverage
   swarm-e2e:
     working_directory: /go/src/github.com/Azure/acs-engine
     docker:

--- a/scripts/ginkgo.coverage.sh
+++ b/scripts/ginkgo.coverage.sh
@@ -23,6 +23,7 @@ profile="${coverdir}/cover.out"
 hash goveralls 2>/dev/null || go get github.com/mattn/goveralls
 hash godir 2>/dev/null || go get github.com/Masterminds/godir
 
+# TODO this appears to run all unit tests, rather than just generate coverage data
 generate_cover_data() {
   ginkgo -skipPackage test/e2e -cover -r .
   find . -type f -name "*.coverprofile" | while read -r file; do mv $file ${coverdir}; done


### PR DESCRIPTION
it’s re-running unit tests

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Remove `make coverage` until we can fix it so that it only generates coverage data (and doesn't re-run unit tests, when run in addition to `make test`).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
