### PR TITLE
azure cloudprovider is default, not static

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -154,6 +154,8 @@ Below is a list of kubelet options that acs-engine will configure by default:
 
 |kubelet option|default value|
 |---|---|
+|"--cloud-config"|"/etc/kubernetes/azure.json"|
+|"--cloud-provider"|"azure"|
 |"--pod-infra-container-image"|"pause-amd64:<version>"|
 |"--max-pods"|"110"|
 |"--eviction-hard"|"memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%"|
@@ -171,8 +173,6 @@ Below is a list of kubelet options that are *not* currently user-configurable, e
 |"--allow-privileged"|"true"|
 |"--pod-manifest-path"|"/etc/kubernetes/manifests"|
 |"--cluster-domain"|"cluster.local"|
-|"--cloud-config"|"/etc/kubernetes/azure.json"|
-|"--cloud-provider"|"azure"|
 |"--network-plugin"|"cni"|
 |"--node-labels"|(based on Azure node metadata)|
 |"--cgroups-per-qos"|"false"|

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -17,7 +17,6 @@ func setKubeletConfig(cs *api.ContainerService) {
 		"--authorization-mode":              "Webhook",
 		"--client-ca-file":                  "/etc/kubernetes/certs/ca.crt",
 		"--pod-manifest-path":               "/etc/kubernetes/manifests",
-		"--cloud-config":                    "/etc/kubernetes/azure.json",
 		"--cluster-domain":                  "cluster.local",
 		"--cluster-dns":                     DefaultKubernetesDNSServiceIP,
 		"--cgroups-per-qos":                 "false",
@@ -46,6 +45,7 @@ func setKubeletConfig(cs *api.ContainerService) {
 		"--image-gc-low-threshold":       strconv.Itoa(DefaultKubernetesGCLowThreshold),
 		"--non-masquerade-cidr":          DefaultNonMasqueradeCidr,
 		"--cloud-provider":               "azure",
+		"--cloud-config":                 "/etc/kubernetes/azure.json",
 	}
 
 	// If no user-configurable kubelet config values exists, use the defaults


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This allows deployment of clusters that have kubelet cloudprovider flags disabled, and on a per-master or per-node basis. Caveat emptor!

Here is the relevant api model input pattern, with master-specific kubelet config:

```
  "properties": {
    "orchestratorProfile": {
      <orchestratorProfile stuff>
      "kubernetesConfig": {
        "kubeletConfig": {
          "--cloud-provider": "",
          "--cloud-config": ""
        }
      }
    },
    "masterProfile": {
      <masterProfile stuff>
      "kubernetesConfig": {
        "kubeletConfig": {
          "--cloud-provider": "azure",
          "--cloud-config": "/etc/kubernetes/azure.json"
        }
      }
    }
```

In practice what this means is that agent nodes will inherit the "default" kubelet config (specified in the `kubernetesConfig` inside `orchestratorProfile`) and that master has some overrides (specified in the `kubernetesConfig` inside `masterProfile`.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
configurable cloudprovider
```
  