### PR TITLE
Add --feature-gates handling for kubelet and api server

### DIFF
--- a/examples/feature-gates/kubernetes-featuresgates.json
+++ b/examples/feature-gates/kubernetes-featuresgates.json
@@ -1,0 +1,44 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "1.8",
+      "kubernetesConfig": {
+        "kubeletConfig" : {
+          "--feature-gates": "MountPropagation=true,DebugContainers=true"
+        },
+        "apiServerConfig" : {
+          "--feature-gates": "MountPropagation=true"
+        }
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    }
+  }
+}

--- a/parts/k8s/artifacts/1.5/kuberneteskubelet.service
+++ b/parts/k8s/artifacts/1.5/kuberneteskubelet.service
@@ -39,7 +39,7 @@ ExecStart=/usr/bin/docker run \
         --node-labels="${KUBELET_NODE_LABELS}" \
         --hairpin-mode=promiscuous-bridge \
         ${KUBELET_CONFIG} \
-        --v=2 ${KUBELET_FEATURE_GATES}
+        --v=2
 
 [Install]
 WantedBy=multi-user.target

--- a/parts/k8s/artifacts/kuberneteskubelet.service
+++ b/parts/k8s/artifacts/kuberneteskubelet.service
@@ -36,7 +36,7 @@ ExecStart=/usr/bin/docker run \
         --require-kubeconfig \
         --enable-server \
         --node-labels="${KUBELET_NODE_LABELS}" \
-        --v=2 ${KUBELET_FEATURE_GATES} \
+        --v=2 \
         --non-masquerade-cidr=${KUBELET_NON_MASQUERADE_CIDR} \
         --volume-plugin-dir=/etc/kubernetes/volumeplugins \
         $KUBELET_CONFIG \

--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -110,7 +110,6 @@ write_files:
     KUBELET_NODE_LABELS={{GetAgentKubernetesLabels . "',variables('labelResourceGroup'),'"}}
 {{if IsKubernetesVersionGe "1.6.0"}}
     KUBELET_NON_MASQUERADE_CIDR={{WrapAsVariable "kubernetesNonMasqueradeCidr"}}
-    KUBELET_FEATURE_GATES=--feature-gates=Accelerators=true
 {{end}}
 
 AGENT_ARTIFACTS_CONFIG_PLACEHOLDER

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -123,13 +123,7 @@ func setMissingKubeletValues(p *api.KubernetesConfig, d map[string]string) {
 		}
 	}
 }
-func copyMap(input map[string]string) map[string]string {
-	copy := map[string]string{}
-	for key, value := range input {
-		copy[key] = value
-	}
-	return copy
-}
+
 func combineValues(inputs ...string) string {
 	var valueMap map[string]string
 	valueMap = make(map[string]string)
@@ -138,6 +132,7 @@ func combineValues(inputs ...string) string {
 	}
 	return mapToString(valueMap)
 }
+
 func applyValueStringToMap(valueMap map[string]string, input string) {
 	values := strings.Split(input, ",")
 	for index := 0; index < len(values); index++ {
@@ -149,6 +144,7 @@ func applyValueStringToMap(valueMap map[string]string, input string) {
 		}
 	}
 }
+
 func mapToString(valueMap map[string]string) string {
 	// Order by key for consistency
 	keys := []string{}

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -89,6 +89,7 @@ func setKubeletConfig(cs *api.ContainerService) {
 	if cs.Properties.MasterProfile != nil {
 		if cs.Properties.MasterProfile.KubernetesConfig == nil {
 			cs.Properties.MasterProfile.KubernetesConfig = &api.KubernetesConfig{}
+			cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig = copyMap(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig)
 		}
 		setMissingKubeletValues(cs.Properties.MasterProfile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
 		addDefaultFeatureGates(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig, o.OrchestratorVersion, "", "")
@@ -98,6 +99,7 @@ func setKubeletConfig(cs *api.ContainerService) {
 	for _, profile := range cs.Properties.AgentPoolProfiles {
 		if profile.KubernetesConfig == nil {
 			profile.KubernetesConfig = &api.KubernetesConfig{}
+			profile.KubernetesConfig.KubeletConfig = copyMap(profile.KubernetesConfig.KubeletConfig)
 		}
 		setMissingKubeletValues(profile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
 		addDefaultFeatureGates(profile.KubernetesConfig.KubeletConfig, o.OrchestratorVersion, "1.6.0", "Accelerators=true")
@@ -131,7 +133,13 @@ func setMissingKubeletValues(p *api.KubernetesConfig, d map[string]string) {
 		}
 	}
 }
-
+func copyMap(input map[string]string) map[string]string {
+	copy := map[string]string{}
+	for key, value := range input {
+		copy[key] = value
+	}
+	return copy
+}
 func combineValues(inputs ...string) string {
 	var valueMap map[string]string
 	valueMap = make(map[string]string)

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -54,7 +54,7 @@ func setKubeletConfig(cs *api.ContainerService) {
 
 	// If no user-configurable kubelet config values exists, use the defaults
 	setMissingKubeletValues(o.KubernetesConfig, defaultKubeletConfig)
-	addDefaultFeatureGates(o.KubernetesConfig.KubeletConfig, "", "")
+	addDefaultFeatureGates(o.KubernetesConfig.KubeletConfig, o.OrchestratorVersion, "", "")
 
 	// Override default cloud-provider?
 	if helpers.IsTrueBoolPointer(o.KubernetesConfig.UseCloudControllerManager) {
@@ -91,7 +91,7 @@ func setKubeletConfig(cs *api.ContainerService) {
 			cs.Properties.MasterProfile.KubernetesConfig = &api.KubernetesConfig{}
 		}
 		setMissingKubeletValues(cs.Properties.MasterProfile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
-		addDefaultFeatureGates(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig, "", "")
+		addDefaultFeatureGates(cs.Properties.MasterProfile.KubernetesConfig.KubeletConfig, o.OrchestratorVersion, "", "")
 
 	}
 	// Agent-specific kubelet config changes go here
@@ -100,15 +100,15 @@ func setKubeletConfig(cs *api.ContainerService) {
 			profile.KubernetesConfig = &api.KubernetesConfig{}
 		}
 		setMissingKubeletValues(profile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
-		addDefaultFeatureGates(profile.KubernetesConfig.KubeletConfig, o.OrchestratorVersion, "Accelerators=true")
+		addDefaultFeatureGates(profile.KubernetesConfig.KubeletConfig, o.OrchestratorVersion, "1.6.0", "Accelerators=true")
 	}
 }
 
 // combine user-provided --feature-gates vals with defaults
 // a minimum k8s version may be declared as required for defaults assignment
-func addDefaultFeatureGates(m map[string]string, minVersion string, defaults string) {
+func addDefaultFeatureGates(m map[string]string, version string, minVersion string, defaults string) {
 	if minVersion != "" {
-		if isKubernetesVersionGe(minVersion, "1.6.0") {
+		if isKubernetesVersionGe(version, minVersion) {
 			m["--feature-gates"] = combineValues(m["--feature-gates"], defaults)
 		} else {
 			m["--feature-gates"] = combineValues(m["--feature-gates"], "")

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -52,10 +52,6 @@ func setKubeletConfig(cs *api.ContainerService) {
 		"--cloud-config":                 "/etc/kubernetes/azure.json",
 	}
 
-	if isKubernetesVersionGe(o.OrchestratorVersion, "1.6.0") {
-		defaultKubeletConfig["--feature-gates"] = "Accelerators=true"
-	}
-
 	// If no user-configurable kubelet config values exists, use the defaults
 	setMissingKubeletValues(o.KubernetesConfig, defaultKubeletConfig)
 	addDefaultFeatureGates(o.KubernetesConfig.KubeletConfig, o.OrchestratorVersion)
@@ -147,8 +143,10 @@ func applyValueStringToMap(valueMap map[string]string, input string) {
 	for index := 0; index < len(values); index++ {
 		// trim spaces (e.g. if the input was "foo=true, bar=true" - we want to drop the space after the comma)
 		value := strings.Trim(values[index], " ")
-		valueParts := strings.Split(value, "=") // TODO validate that there are two parts
-		valueMap[valueParts[0]] = valueParts[1]
+		valueParts := strings.Split(value, "=")
+		if len(valueParts) == 2 {
+			valueMap[valueParts[0]] = valueParts[1]
+		}
 	}
 }
 func mapToString(valueMap map[string]string) string {

--- a/pkg/acsengine/defaults_test.go
+++ b/pkg/acsengine/defaults_test.go
@@ -377,10 +377,6 @@ func TestKubeletFeatureGatesEnsureMasterAndAgentConfigUsedFor1_6_0(t *testing.T)
 	}
 }
 
-// TODO - tests:
-//  - check merging
-//  - check that master/agent overrides are used correctly
-
 func getMockAddon(name string) api.KubernetesAddon {
 	return api.KubernetesAddon{
 		Name:    name,

--- a/pkg/acsengine/defaults_test.go
+++ b/pkg/acsengine/defaults_test.go
@@ -287,6 +287,100 @@ func TestPointerToBool(t *testing.T) {
 	}
 }
 
+func TestKubeletFeatureGatesEnsureAcceleratorsNotSetFor1_5_0(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.5.0")
+	properties := mockCS.Properties
+
+	// No KubernetesConfig.KubeletConfig set for MasterProfile or AgentProfile
+	// so they will inherit the top-level config
+	properties.OrchestratorProfile.KubernetesConfig = getKubernetesConfigWithFeatureGates("TopLevel=true")
+
+	setKubeletConfig(&mockCS)
+
+	// Verify that the Accelerators feature gate has not been applied to master or agents
+	agentFeatureGates := properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig["--feature-gates"]
+	if agentFeatureGates != "TopLevel=true" {
+		t.Fatalf("setKubeletConfig modified the agent profile (version 1.5.0): expected 'TopLevel=true' got '%s'", agentFeatureGates)
+	}
+	masterFeatureFates := properties.MasterProfile.KubernetesConfig.KubeletConfig["--feature-gates"]
+	if masterFeatureFates != "TopLevel=true" {
+		t.Fatalf("setKubeletConfig modified feature gates for master profile: 'TopLevel=true' got '%s'", agentFeatureGates)
+	}
+}
+func TestKubeletFeatureGatesEnsureAcceleratorsOnAgentsFor1_6_0(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.6.0")
+	properties := mockCS.Properties
+
+	// No KubernetesConfig.KubeletConfig set for MasterProfile or AgentProfile
+	// so they will inherit the top-level config
+	properties.OrchestratorProfile.KubernetesConfig = getKubernetesConfigWithFeatureGates("TopLevel=true")
+
+	setKubeletConfig(&mockCS)
+
+	agentFeatureGates := properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig["--feature-gates"]
+	if agentFeatureGates != "Accelerators=true,TopLevel=true" {
+		t.Fatalf("setKubeletConfig did not add 'Accelerators=true' for agent profile: expected 'Accelerators=true;TopLevel=true' got '%s'", agentFeatureGates)
+	}
+
+	// Verify that the Accelerators feature gate override has only been applied to the agents
+	masterFeatureFates := properties.MasterProfile.KubernetesConfig.KubeletConfig["--feature-gates"]
+	if masterFeatureFates != "TopLevel=true" {
+		t.Fatalf("setKubeletConfig modified feature gates for master profile: expected 'TopLevel=true' got '%s'", agentFeatureGates)
+	}
+}
+
+func TestKubeletFeatureGatesEnsureMasterAndAgentConfigUsedFor1_5_0(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.5.0")
+	properties := mockCS.Properties
+
+	// Set MasterProfile and AgentProfiles KubernetesConfig.KubeletConfit ig values
+	// Verify that they are used instead of the top-level config
+	properties.OrchestratorProfile.KubernetesConfig = getKubernetesConfigWithFeatureGates("TopLevel=true")
+	properties.MasterProfile = &api.MasterProfile{KubernetesConfig: getKubernetesConfigWithFeatureGates("MasterLevel=true")}
+	properties.AgentPoolProfiles[0].KubernetesConfig = getKubernetesConfigWithFeatureGates("AgentLevel=true")
+
+	setKubeletConfig(&mockCS)
+
+	agentFeatureGates := properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig["--feature-gates"]
+	if agentFeatureGates != "AgentLevel=true" {
+		t.Fatalf("setKubeletConfig agent profile: expected 'AgentLevel=true' got '%s'", agentFeatureGates)
+	}
+
+	// Verify that the Accelerators feature gate override has only been applied to the agents
+	masterFeatureFates := properties.MasterProfile.KubernetesConfig.KubeletConfig["--feature-gates"]
+	if masterFeatureFates != "MasterLevel=true" {
+		t.Fatalf("setKubeletConfig master profile: expected 'MasterLevel=true' got '%s'", agentFeatureGates)
+	}
+}
+
+func TestKubeletFeatureGatesEnsureMasterAndAgentConfigUsedFor1_6_0(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.6.0")
+	properties := mockCS.Properties
+
+	// Set MasterProfile and AgentProfiles KubernetesConfig.KubeletConfig values
+	// Verify that they are used instead of the top-level config
+	properties.OrchestratorProfile.KubernetesConfig = getKubernetesConfigWithFeatureGates("TopLevel=true")
+	properties.MasterProfile = &api.MasterProfile{KubernetesConfig: getKubernetesConfigWithFeatureGates("MasterLevel=true")}
+	properties.AgentPoolProfiles[0].KubernetesConfig = getKubernetesConfigWithFeatureGates("AgentLevel=true")
+
+	setKubeletConfig(&mockCS)
+
+	agentFeatureGates := properties.AgentPoolProfiles[0].KubernetesConfig.KubeletConfig["--feature-gates"]
+	if agentFeatureGates != "Accelerators=true,AgentLevel=true" {
+		t.Fatalf("setKubeletConfig agent profile: expected 'Accelerators=true,AgentLevel=true' got '%s'", agentFeatureGates)
+	}
+
+	// Verify that the Accelerators feature gate override has only been applied to the agents
+	masterFeatureFates := properties.MasterProfile.KubernetesConfig.KubeletConfig["--feature-gates"]
+	if masterFeatureFates != "MasterLevel=true" {
+		t.Fatalf("setKubeletConfig master profile: expected 'MasterLevel=true' got '%s'", agentFeatureGates)
+	}
+}
+
+// TODO - tests:
+//  - check merging
+//  - check that master/agent overrides are used correctly
+
 func getMockAddon(name string) api.KubernetesAddon {
 	return api.KubernetesAddon{
 		Name:    name,
@@ -300,5 +394,25 @@ func getMockAddon(name string) api.KubernetesAddon {
 				MemoryLimits:   "150Mi",
 			},
 		},
+	}
+}
+
+func getMockBaseContainerService(orchestratorVersion string) api.ContainerService {
+	return api.ContainerService{
+		Properties: &api.Properties{
+			OrchestratorProfile: &api.OrchestratorProfile{
+				OrchestratorVersion: orchestratorVersion,
+				KubernetesConfig:    &api.KubernetesConfig{},
+			},
+			MasterProfile: &api.MasterProfile{},
+			AgentPoolProfiles: []*api.AgentPoolProfile{
+				{},
+			},
+		},
+	}
+}
+func getKubernetesConfigWithFeatureGates(featureGates string) *api.KubernetesConfig {
+	return &api.KubernetesConfig{
+		KubeletConfig: map[string]string{"--feature-gates": featureGates},
 	}
 }


### PR DESCRIPTION
Current work in progress, for feedback

Add handling of `--feature-gates` for kubernetes. The `--feature-gates` value is a comma separated string, e.g. `key1=value1,key2=value2`
For `kubeletConfig`, this preserves the existing behaviour of adding `Accelerators=true` for the agent config (i.e. not master) for kubernetes 1.6.0 and later

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: As per #2021, adding support for `--feature-gates` will enable easier testing of kubernetes features (especially preview features)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2021 

**Special notes for your reviewer**: 

* I think that this fits with the discussion in [issue #2021](#2021) - let me know if you want any further changes

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note

```
