### PR TITLE
apiserver default config changes

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -276,11 +276,17 @@ Below is a list of cloud-controller-manager options that are *not* currently use
 
 See [here](https://kubernetes.io/docs/reference/generated/kube-apiserver/) for a reference of supported apiserver options.
 
+Below is a list of apiserver options that acs-engine will configure by default:
+
+|apiserver option|default value|
+|"--admission-control"|"NamespaceLifecycle, LimitRanger, ServiceAccount, DefaultStorageClass, ResourceQuota, DenyEscalatingExec, AlwaysPullImages, SecurityContextDeny"|
+|"--authorization-mode"|"Node", "RBAC" (*the latter if enabledRbac is true*)|
+
+
 Below is a list of apiserver options that are *not* currently user-configurable, either because a higher order configuration vector is available that enforces kubelet configuration, or because a static configuration is required to build a functional cluster:
 
 |apiserver option|default value|
 |---|---|
-|"--admission-control"|"NamespaceLifecycle, LimitRanger, ServiceAccount, DefaultStorageClass, ResourceQuota, DenyEscalatingExec, AlwaysPullImages, SecurityContextDeny"|
 |"--address"|"0.0.0.0"|
 |"--advertise-address"|*calculated value that represents listening URI for API server*|
 |"--allow-privileged"|"true"|
@@ -308,7 +314,6 @@ Below is a list of apiserver options that are *not* currently user-configurable,
 |"--service-cluster-ip-range"|*see serviceCIDR*|
 |"--storage-backend"|*calculated value that represents etcd version*|
 |"--v"|"4"|
-|"--authorization-mode"|"Node", and "RBAC" (*if enabledRbac is true*)|
 |"--experimental-encryption-provider-config"|"/etc/kubernetes/encryption-config.yaml" (*if enableDataEncryptionAtRest is true*)|
 |"--requestheader-client-ca-file"|"/etc/kubernetes/certs/proxy-ca.crt" (*if enableAggregatedAPIs is true*)|
 |"--proxy-client-cert-file"|"/etc/kubernetes/certs/proxy.crt" (*if enableAggregatedAPIs is true*)|

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -10,7 +10,6 @@ import (
 func setAPIServerConfig(cs *api.ContainerService) {
 	o := cs.Properties.OrchestratorProfile
 	staticLinuxAPIServerConfig := map[string]string{
-		"--admission-control":          "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,DenyEscalatingExec,AlwaysPullImages,SecurityContextDeny",
 		"--address":                    "0.0.0.0",
 		"--advertise-address":          "<kubernetesAPIServerIP>",
 		"--allow-privileged":           "true",
@@ -19,7 +18,6 @@ func setAPIServerConfig(cs *api.ContainerService) {
 		"--audit-log-maxbackup":        "10",
 		"--audit-log-maxsize":          "100",
 		"--audit-log-path":             "/var/log/apiserver/audit.log",
-		"--authorization-mode":         "Node",
 		"--insecure-port":              "8080",
 		"--secure-port":                "443",
 		"--service-account-lookup":     "true",
@@ -39,11 +37,6 @@ func setAPIServerConfig(cs *api.ContainerService) {
 		"--service-cluster-ip-range":   o.KubernetesConfig.ServiceCIDR,
 		"--storage-backend":            o.GetAPIServerEtcdAPIVersion(),
 		"--v":                          "4",
-	}
-
-	// RBAC configuration
-	if helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableRbac) {
-		staticLinuxAPIServerConfig["--authorization-mode"] = "Node,RBAC"
 	}
 
 	// Data Encryption at REST configuration
@@ -87,7 +80,15 @@ func setAPIServerConfig(cs *api.ContainerService) {
 	// TODO placeholder for specific config overrides for Windows clusters
 
 	// Default apiserver config
-	defaultAPIServerConfig := map[string]string{}
+	defaultAPIServerConfig := map[string]string{
+		"--admission-control":  "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,DenyEscalatingExec,AlwaysPullImages,SecurityContextDeny",
+		"--authorization-mode": "Node",
+	}
+
+	// RBAC configuration
+	if helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableRbac) {
+		defaultAPIServerConfig["--authorization-mode"] = "Node,RBAC"
+	}
 
 	// If no user-configurable apiserver config values exists, use the defaults
 	if o.KubernetesConfig.APIServerConfig == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Makes `--admission-control` and `--authorization-mode` user-configurable apiserver options (with defaults)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```