### PR TITLE
Add the ability to use AAD groups

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -325,6 +325,7 @@ Below is a list of apiserver options that are *not* currently user-configurable,
 |"--cloud-provider"|"azure" (*unless useCloudControllerManager is true*)|
 |"--cloud-config"|"/etc/kubernetes/azure.json" (*unless useCloudControllerManager is true*)|
 |"--oidc-username-claim"|"oid" (*if has AADProfile*)|
+|"--oidc-groups-claim"|"groups" (*if has AADProfile*)|
 |"--oidc-client-id"|*calculated value that represents OID client ID* (*if has AADProfile*)|
 |"--oidc-issuer-url"|*calculated value that represents OID issuer URL* (*if has AADProfile*)|
 

--- a/docs/kubernetes/aad.md
+++ b/docs/kubernetes/aad.md
@@ -8,7 +8,7 @@ Please also refer to [Azure Active Directory plugin for client authentication](h
 
 ## Prerequision
 1. An Azure Active Directory tenant, will refer as `AAD Tenant`. You can use the tenant for your Azure subscription;
-2. A `Web app / API` type AAD application, will refer as `Server Application`. This application represents the `apiserver`;
+2. A `Web app / API` type AAD application, will refer as `Server Application`. This application represents the `apiserver`;  For groups to work properly, you'll need to edit the `Server Application` Manifest and set `groupMembershipClaims` to either `All` or `SecurityGroup`.
 3. A `Native` type AAD application, will refer as `Client Application`. This application is for user login via `kubectl`. You'll need to add delegated permission to `Server Application`, please see [troubleshooting](#loginpageerror) section for detail.
 
 ## Deployment
@@ -46,9 +46,14 @@ Following instructions are for turnning on RBAC manually together with AAD integ
 ```
 kubectl create clusterrolebinding aad-default-cluster-admin-binding --clusterrole=cluster-admin --user={UserName}
 ```
-For example, if your `IssuerUrl` is `https://sts.windows.net/e2917176-1632-47a0-ad18-671d485757a3/`, and your `ObjectID` is `22fa281b-bf62-4b14-972c-0dbca24a25a2`, the command would be:
+For example, if your `IssuerUrl` is `https://sts.windows.net/e2917176-1632-47a0-ad18-671d485757a3/`, and your User `ObjectID` is `22fa281b-bf62-4b14-972c-0dbca24a25a2`, the command would be:
 ```
 kubectl create clusterrolebinding aad-default-cluster-admin-binding --clusterrole=cluster-admin --user=https://sts.windows.net/e2917176-1632-47a0-ad18-671d485757a3/#22fa281b-bf62-4b14-972c-0dbca24a25a2
+```
+4. (Optional) Add groups into your admin role
+For example, if your `IssuerUrl` is `https://sts.windows.net/e2917176-1632-47a0-ad18-671d485757a3/`, and your Group `ObjectID` is `7d04bcd3-3c48-49ab-a064-c0b7d69896da`, the command would be: 
+```
+kubectl create clusterrolebinding aad-default-group-cluster-admin-binding --clusterrole=cluster-admin --group=7d04bcd3-3c48-49ab-a064-c0b7d69896da
 ```
 
 4. Turn on RBAC on master nodes.

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -64,6 +64,7 @@ func setAPIServerConfig(cs *api.ContainerService) {
 	// AAD configuration
 	if cs.Properties.HasAadProfile() {
 		staticLinuxAPIServerConfig["--oidc-username-claim"] = "oid"
+		staticLinuxAPIServerConfig["--oidc-groups-claim"] = "groups"
 		staticLinuxAPIServerConfig["--oidc-client-id"] = "spn:" + cs.Properties.AADProfile.ServerAppID
 		issuerHost := "sts.windows.net"
 		if GetCloudTargetEnv(cs.Location) == "AzureChinaCloud" {


### PR DESCRIPTION
**What this PR does / why we need it**: As per #1611, this adds the ability to use AAD groups and documents how to use it.  The groups functionality is already built into AAD and it's just making sure it's turned on the `Server Application` AAD Manifest.  Then, on the Kubernetes cluster side, it's just configuring the --oidc-groups-claim, which as no default, so it has to be set to groups for it read from AAD provided groups.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1611

**Special notes for your reviewer**:
* This adds a parameter to to be included in the OIDC configuration, explicitly setting the groups claim `--oidc-groups-claim` to `groups`
* Updated the documentation to include how to use groups and mention the steps that are required.

**Release note**:
