### PR TITLE
Use Api Certs for kubelet client authentication

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -309,8 +309,8 @@ Below is a list of apiserver options that are *not* currently user-configurable,
 |"--tls-private-key-file"|"/etc/kubernetes/certs/apiserver.key"|
 |"--client-ca-file"|"/etc/kubernetes/certs/ca.crt"|
 |"--service-account-key-file"|"/etc/kubernetes/certs/apiserver.key"|
-|"--kubelet-client-certificate"|"/etc/kubernetes/certs/client.crt"|
-|"--kubelet-client-key"|"/etc/kubernetes/certs/client.key"|
+|"--kubelet-client-certificate"|"/etc/kubernetes/certs/apiserver.crt"|
+|"--kubelet-client-key"|"/etc/kubernetes/certs/apiserver.key"|
 |"--service-cluster-ip-range"|*see serviceCIDR*|
 |"--storage-backend"|*calculated value that represents etcd version*|
 |"--v"|"4"|

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -32,8 +32,8 @@ func setAPIServerConfig(cs *api.ContainerService) {
 		"--profiling":                  "false",
 		"--repair-malformed-updates":   "false",
 		"--service-account-key-file":   "/etc/kubernetes/certs/apiserver.key",
-		"--kubelet-client-certificate": "/etc/kubernetes/certs/client.crt",
-		"--kubelet-client-key":         "/etc/kubernetes/certs/client.key",
+		"--kubelet-client-certificate": "/etc/kubernetes/certs/apiserver.crt",
+		"--kubelet-client-key":         "/etc/kubernetes/certs/apiserver.key",
 		"--service-cluster-ip-range":   o.KubernetesConfig.ServiceCIDR,
 		"--storage-backend":            o.GetAPIServerEtcdAPIVersion(),
 		"--v":                          "4",
@@ -81,7 +81,7 @@ func setAPIServerConfig(cs *api.ContainerService) {
 
 	// Default apiserver config
 	defaultAPIServerConfig := map[string]string{
-		"--admission-control":  "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,DenyEscalatingExec,AlwaysPullImages,SecurityContextDeny",
+		"--admission-control":  "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,DenyEscalatingExec,AlwaysPullImages,SecurityContextDeny,PodSecurityPolicy",
 		"--authorization-mode": "Node",
 	}
 


### PR DESCRIPTION

Use k8s API certs for kubelet client authentication and not the node client certs. Fixes an error in my earlier PR Azure/acs-engine#1978
