### PR TITLE
enableSecureKubelet and unit tests

### DIFF
--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -115,4 +115,11 @@ func setAPIServerConfig(cs *api.ContainerService) {
 	for key, val := range overrideAPIServerConfig {
 		o.KubernetesConfig.APIServerConfig[key] = val
 	}
+
+	// Remove flags for secure communication to kubelet, if configured
+	if !helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableSecureKubelet) {
+		for _, key := range []string{"--kubelet-client-certificate", "--kubelet-client-key"} {
+			delete(o.KubernetesConfig.APIServerConfig, key)
+		}
+	}
 }

--- a/pkg/acsengine/defaults-apiserver_test.go
+++ b/pkg/acsengine/defaults-apiserver_test.go
@@ -1,0 +1,263 @@
+package acsengine
+
+import (
+	"testing"
+
+	"github.com/Azure/acs-engine/pkg/api"
+	"github.com/Azure/acs-engine/pkg/api/common"
+	"github.com/satori/uuid"
+)
+
+func TestAPIServerConfigEnableDataEncryptionAtRest(t *testing.T) {
+	// Test EnableDataEncryptionAtRest = true
+	cs := createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableDataEncryptionAtRest = pointerToBool(true)
+	setAPIServerConfig(cs)
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--experimental-encryption-provider-config"] != "/etc/kubernetes/encryption-config.yaml" {
+		t.Fatalf("got unexpected '--experimental-encryption-provider-config' API server config value for EnableDataEncryptionAtRest=true: %s",
+			a["--experimental-encryption-provider-config"])
+	}
+
+	// Test EnableDataEncryptionAtRest = false
+	cs = createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableDataEncryptionAtRest = pointerToBool(false)
+	setAPIServerConfig(cs)
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if _, ok := a["--experimental-encryption-provider-config"]; ok {
+		t.Fatalf("got unexpected '--experimental-encryption-provider-config' API server config value for EnableDataEncryptionAtRest=false: %s",
+			a["--experimental-encryption-provider-config"])
+	}
+}
+
+func TestAPIServerConfigEnableAggregatedAPIs(t *testing.T) {
+	// Test EnableAggregatedAPIs = true
+	cs := createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs = true
+	setAPIServerConfig(cs)
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--requestheader-client-ca-file"] != "/etc/kubernetes/certs/proxy-ca.crt" {
+		t.Fatalf("got unexpected '--requestheader-client-ca-file' API server config value for EnableAggregatedAPIs=true: %s",
+			a["--requestheader-client-ca-file"])
+	}
+	if a["--proxy-client-cert-file"] != "/etc/kubernetes/certs/proxy.crt" {
+		t.Fatalf("got unexpected '--proxy-client-cert-file' API server config value for EnableAggregatedAPIs=true: %s",
+			a["--proxy-client-cert-file"])
+	}
+	if a["--proxy-client-key-file"] != "/etc/kubernetes/certs/proxy.key" {
+		t.Fatalf("got unexpected '--proxy-client-key-file' API server config value for EnableAggregatedAPIs=true: %s",
+			a["--proxy-client-key-file"])
+	}
+	if a["--requestheader-allowed-names"] != "" {
+		t.Fatalf("got unexpected '--requestheader-allowed-names' API server config value for EnableAggregatedAPIs=true: %s",
+			a["--requestheader-allowed-names"])
+	}
+	if a["--requestheader-extra-headers-prefix"] != "X-Remote-Extra-" {
+		t.Fatalf("got unexpected '--requestheader-extra-headers-prefix' API server config value for EnableAggregatedAPIs=true: %s",
+			a["--requestheader-extra-headers-prefix"])
+	}
+	if a["--requestheader-group-headers"] != "X-Remote-Group" {
+		t.Fatalf("got unexpected '--requestheader-group-headers' API server config value for EnableAggregatedAPIs=true: %s",
+			a["--requestheader-group-headers"])
+	}
+	if a["--requestheader-username-headers"] != "X-Remote-User" {
+		t.Fatalf("got unexpected '--requestheader-username-headers' API server config value for EnableAggregatedAPIs=true: %s",
+			a["--requestheader-username-headers"])
+	}
+
+	// Test EnableAggregatedAPIs = false
+	cs = createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs = false
+	setAPIServerConfig(cs)
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	for _, key := range []string{"--requestheader-client-ca-file", "--proxy-client-cert-file", "--proxy-client-key-file",
+		"--requestheader-allowed-names", "--requestheader-extra-headers-prefix", "--requestheader-group-headers",
+		"--requestheader-username-headers"} {
+		if _, ok := a[key]; ok {
+			t.Fatalf("got unexpected '%s' API server config value for EnableAggregatedAPIs=false: %s",
+				key, a[key])
+		}
+	}
+}
+
+func TestAPIServerConfigUseCloudControllerManager(t *testing.T) {
+	// Test UseCloudControllerManager = true
+	cs := createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = pointerToBool(true)
+	setAPIServerConfig(cs)
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if _, ok := a["--cloud-provider"]; ok {
+		t.Fatalf("got unexpected '--cloud-provider' API server config value for UseCloudControllerManager=false: %s",
+			a["--cloud-provider"])
+	}
+	if _, ok := a["--cloud-config"]; ok {
+		t.Fatalf("got unexpected '--cloud-config' API server config value for UseCloudControllerManager=false: %s",
+			a["--cloud-config"])
+	}
+
+	// Test UseCloudControllerManager = false
+	cs = createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = pointerToBool(false)
+	setAPIServerConfig(cs)
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--cloud-provider"] != "azure" {
+		t.Fatalf("got unexpected '--cloud-provider' API server config value for UseCloudControllerManager=true: %s",
+			a["--cloud-provider"])
+	}
+	if a["--cloud-config"] != "/etc/kubernetes/azure.json" {
+		t.Fatalf("got unexpected '--cloud-config' API server config value for UseCloudControllerManager=true: %s",
+			a["--cloud-config"])
+	}
+}
+
+func TestAPIServerConfigHasAadProfile(t *testing.T) {
+	// Test HasAadProfile = true
+	cs := createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.AADProfile = &api.AADProfile{
+		ServerAppID: "test-id",
+	}
+	setAPIServerConfig(cs)
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--oidc-username-claim"] != "oid" {
+		t.Fatalf("got unexpected '--oidc-username-claim' API server config value for HasAadProfile=true: %s",
+			a["--oidc-username-claim"])
+	}
+	if a["--oidc-groups-claim"] != "groups" {
+		t.Fatalf("got unexpected '--oidc-groups-claim' API server config value for HasAadProfile=true: %s",
+			a["--oidc-groups-claim"])
+	}
+	if a["--oidc-client-id"] != "spn:"+cs.Properties.AADProfile.ServerAppID {
+		t.Fatalf("got unexpected '--oidc-client-id' API server config value for HasAadProfile=true: %s",
+			a["--oidc-client-id"])
+	}
+	if a["--oidc-issuer-url"] != "https://sts.windows.net/" {
+		t.Fatalf("got unexpected '--oidc-issuer-url' API server config value for HasAadProfile=true: %s",
+			a["--oidc-issuer-url"])
+	}
+
+	// Test China Cloud settings
+	cs = createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.AADProfile = &api.AADProfile{
+		ServerAppID: "test-id",
+	}
+	cs.Location = "chinaeast"
+	setAPIServerConfig(cs)
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--oidc-issuer-url"] != "https://sts.chinacloudapi.cn/" {
+		t.Fatalf("got unexpected '--oidc-issuer-url' API server config value for HasAadProfile=true using China cloud: %s",
+			a["--oidc-issuer-url"])
+	}
+
+	// Test HasAadProfile = false
+	cs = createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	setAPIServerConfig(cs)
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	for _, key := range []string{"--oidc-username-claim", "--oidc-groups-claim", "--oidc-client-id", "--oidc-issuer-url"} {
+		if _, ok := a[key]; ok {
+			t.Fatalf("got unexpected '%s' API server config value for HasAadProfile=false: %s",
+				key, a[key])
+		}
+	}
+}
+
+func TestAPIServerConfigEnableRbac(t *testing.T) {
+	// Test EnableRbac = true
+	cs := createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableRbac = pointerToBool(true)
+	setAPIServerConfig(cs)
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--authorization-mode"] != "Node,RBAC" {
+		t.Fatalf("got unexpected '--authorization-mode' API server config value for EnableRbac=true: %s",
+			a["--authorization-mode"])
+	}
+
+	// Test EnableRbac = false
+	cs = createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableRbac = pointerToBool(false)
+	setAPIServerConfig(cs)
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--authorization-mode"] != "Node" {
+		t.Fatalf("got unexpected '--authorization-mode' API server config value for EnableRbac=true: %s",
+			a["--authorization-mode"])
+	}
+}
+
+func TestAPIServerConfigEnableSecureKubelet(t *testing.T) {
+	// Test EnableSecureKubelet = true
+	cs := createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = pointerToBool(true)
+	setAPIServerConfig(cs)
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--kubelet-client-certificate"] != "/etc/kubernetes/certs/client.crt" {
+		t.Fatalf("got unexpected '--kubelet-client-certificate' API server config value for EnableSecureKubelet=true: %s",
+			a["--kubelet-client-certificate"])
+	}
+	if a["--kubelet-client-key"] != "/etc/kubernetes/certs/client.key" {
+		t.Fatalf("got unexpected '--kubelet-client-key' API server config value for EnableSecureKubelet=true: %s",
+			a["--kubelet-client-key"])
+	}
+
+	// Test EnableSecureKubelet = false
+	cs = createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableDataEncryptionAtRest = pointerToBool(false)
+	setAPIServerConfig(cs)
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	for _, key := range []string{"--kubelet-client-certificate", "--kubelet-client-key"} {
+		if _, ok := a[key]; ok {
+			t.Fatalf("got unexpected '%s' API server config value for EnableSecureKubelet=false: %s",
+				key, a[key])
+		}
+	}
+}
+
+func createContainerService(containerServiceName string, orchestratorVersion string, masterCount int, agentCount int) *api.ContainerService {
+	cs := api.ContainerService{}
+	cs.ID = uuid.NewV4().String()
+	cs.Location = "eastus"
+	cs.Name = containerServiceName
+
+	cs.Properties = &api.Properties{}
+
+	cs.Properties.MasterProfile = &api.MasterProfile{}
+	cs.Properties.MasterProfile.Count = masterCount
+	cs.Properties.MasterProfile.DNSPrefix = "testmaster"
+	cs.Properties.MasterProfile.VMSize = "Standard_D2_v2"
+
+	cs.Properties.AgentPoolProfiles = []*api.AgentPoolProfile{}
+	agentPool := &api.AgentPoolProfile{}
+	agentPool.Count = agentCount
+	agentPool.Name = "agentpool1"
+	agentPool.VMSize = "Standard_D2_v2"
+	agentPool.OSType = "Linux"
+	agentPool.AvailabilityProfile = "AvailabilitySet"
+	agentPool.StorageProfile = "StorageAccount"
+
+	cs.Properties.AgentPoolProfiles = append(cs.Properties.AgentPoolProfiles, agentPool)
+
+	cs.Properties.LinuxProfile = &api.LinuxProfile{
+		AdminUsername: "azureuser",
+		SSH: struct {
+			PublicKeys []api.PublicKey `json:"publicKeys"`
+		}{},
+	}
+
+	cs.Properties.LinuxProfile.AdminUsername = "azureuser"
+	cs.Properties.LinuxProfile.SSH.PublicKeys = append(
+		cs.Properties.LinuxProfile.SSH.PublicKeys, api.PublicKey{KeyData: "test"})
+
+	cs.Properties.ServicePrincipalProfile = &api.ServicePrincipalProfile{}
+	cs.Properties.ServicePrincipalProfile.ClientID = "DEC923E3-1EF1-4745-9516-37906D56DEC4"
+	cs.Properties.ServicePrincipalProfile.Secret = "DEC923E3-1EF1-4745-9516-37906D56DEC4"
+
+	cs.Properties.OrchestratorProfile = &api.OrchestratorProfile{}
+	cs.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
+	cs.Properties.OrchestratorProfile.OrchestratorVersion = orchestratorVersion
+	cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{}
+
+	cs.Properties.CertificateProfile = &api.CertificateProfile{}
+	cs.Properties.CertificateProfile.CaCertificate = "cacert"
+	cs.Properties.CertificateProfile.KubeConfigCertificate = "kubeconfigcert"
+	cs.Properties.CertificateProfile.KubeConfigPrivateKey = "kubeconfigkey"
+
+	return &cs
+}

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -13,6 +13,9 @@ func setKubeletConfig(cs *api.ContainerService) {
 	staticLinuxKubeletConfig := map[string]string{
 		"--address":                         "0.0.0.0",
 		"--allow-privileged":                "true",
+		"--anonymous-auth":                  "false",
+		"--authorization-mode":              "Webhook",
+		"--client-ca-file":                  "/etc/kubernetes/certs/ca.crt",
 		"--pod-manifest-path":               "/etc/kubernetes/manifests",
 		"--cluster-domain":                  "cluster.local",
 		"--cluster-dns":                     DefaultKubernetesDNSServiceIP,
@@ -33,9 +36,6 @@ func setKubeletConfig(cs *api.ContainerService) {
 
 	// Default Kubelet config
 	defaultKubeletConfig := map[string]string{
-		"--anonymous-auth":               "false",
-		"--authorization-mode":           "Webhook",
-		"--client-ca-file":               "/etc/kubernetes/certs/ca.crt",
 		"--network-plugin":               "cni",
 		"--pod-infra-container-image":    cloudSpecConfig.KubernetesSpecConfig.KubernetesImageBase + KubeConfigs[o.OrchestratorVersion]["pause"],
 		"--max-pods":                     strconv.Itoa(DefaultKubernetesKubeletMaxPods),

--- a/pkg/acsengine/defaults-kubelet_test.go
+++ b/pkg/acsengine/defaults-kubelet_test.go
@@ -1,0 +1,99 @@
+package acsengine
+
+import (
+	"testing"
+
+	"github.com/Azure/acs-engine/pkg/api/common"
+)
+
+func TestKubeletConfigUseCloudControllerManager(t *testing.T) {
+	// Test UseCloudControllerManager = true
+	cs := createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = pointerToBool(true)
+	setKubeletConfig(cs)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--cloud-provider"] != "external" {
+		t.Fatalf("got unexpected '--cloud-provider' kubelet config value for UseCloudControllerManager=true: %s",
+			k["--cloud-provider"])
+	}
+
+	// Test UseCloudControllerManager = false
+	cs = createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = pointerToBool(false)
+	setAPIServerConfig(cs)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--cloud-provider"] != "azure" {
+		t.Fatalf("got unexpected '--cloud-provider' kubelet config value for UseCloudControllerManager=true: %s",
+			k["--cloud-provider"])
+	}
+
+}
+
+func TestKubeletConfigNetworkPolicy(t *testing.T) {
+	// Test NetworkPolicy = none
+	cs := createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = NetworkPolicyNone
+	setKubeletConfig(cs)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--network-plugin"] != NetworkPluginKubenet {
+		t.Fatalf("got unexpected '--network-plugin' kubelet config value for NetworkPolicy=none: %s",
+			k["--network-plugin"])
+	}
+
+	// Test NetworkPolicy = azure
+	cs = createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = "azure"
+	setKubeletConfig(cs)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--network-plugin"] != "cni" {
+		t.Fatalf("got unexpected '--network-plugin' kubelet config value for NetworkPolicy=azure: %s",
+			k["--network-plugin"])
+	}
+
+}
+
+func TestKubeletConfig1Dot5(t *testing.T) {
+	// Test Kubelet v1.5 settings
+	cs := createContainerService("testcluster", common.KubernetesVersion1Dot5Dot8, 3, 2)
+	setKubeletConfig(cs)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	for _, key := range []string{"--non-masquerade-cidr", "--cgroups-per-qos", "--enforce-node-allocatable"} {
+		if _, ok := k[key]; ok {
+			t.Fatalf("'%s' kubelet config value should not be present for clusters < v1.6: %s",
+				key, k[key])
+		}
+	}
+}
+
+func TestKubeletConfigEnableSecureKubelet(t *testing.T) {
+	// Test EnableSecureKubelet = true
+	cs := createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = pointerToBool(true)
+	setKubeletConfig(cs)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--anonymous-auth"] != "false" {
+		t.Fatalf("got unexpected '--anonymous-auth' kubelet config value for EnableSecureKubelet=true: %s",
+			k["--anonymous-auth"])
+	}
+	if k["--authorization-mode"] != "Webhook" {
+		t.Fatalf("got unexpected '--authorization-mode' kubelet config value for EnableSecureKubelet=true: %s",
+			k["--authorization-mode"])
+	}
+	if k["--client-ca-file"] != "/etc/kubernetes/certs/ca.crt" {
+		t.Fatalf("got unexpected '--client-ca-file' kubelet config value for EnableSecureKubelet=true: %s",
+			k["--client-ca-file"])
+	}
+
+	// Test EnableSecureKubelet = false
+	cs = createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = "azure"
+	setKubeletConfig(cs)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	for _, key := range []string{"--anonymous-auth", "--authorization-mode", "--client-ca-file"} {
+		if _, ok := k[key]; ok {
+			t.Fatalf("got unexpected '%s' kubelet config value for EnableSecureKubelet=false: %s",
+				key, k[key])
+		}
+	}
+
+}

--- a/pkg/acsengine/defaults-kubelet_test.go
+++ b/pkg/acsengine/defaults-kubelet_test.go
@@ -20,10 +20,10 @@ func TestKubeletConfigUseCloudControllerManager(t *testing.T) {
 	// Test UseCloudControllerManager = false
 	cs = createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
 	cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager = pointerToBool(false)
-	setAPIServerConfig(cs)
+	setKubeletConfig(cs)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	if k["--cloud-provider"] != "azure" {
-		t.Fatalf("got unexpected '--cloud-provider' kubelet config value for UseCloudControllerManager=true: %s",
+		t.Fatalf("got unexpected '--cloud-provider' kubelet config value for UseCloudControllerManager=false: %s",
 			k["--cloud-provider"])
 	}
 

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -399,6 +399,10 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 			a.OrchestratorProfile.KubernetesConfig.EnableRbac = pointerToBool(api.DefaultRBACEnabled)
 		}
 
+		if a.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet == nil {
+			a.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = pointerToBool(api.DefaultSecureKubeletEnabled)
+		}
+
 		// Configure kubelet
 		setKubeletConfig(cs)
 		// Configure controller-manager

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -93,6 +93,8 @@ const (
 	DefaultReschedulerAddonEnabled = false
 	// DefaultRBACEnabled determines the acs-engine provided default for enabling kubernetes RBAC
 	DefaultRBACEnabled = true
+	// DefaultSecureKubeletEnabled determines the acs-engine provided default for securing kubelet communications
+	DefaultSecureKubeletEnabled = true
 	// DefaultTillerAddonName is the name of the tiller addon deployment
 	DefaultTillerAddonName = "tiller"
 	// DefaultACIConnectorAddonName is the name of the tiller addon deployment

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -666,6 +666,7 @@ func convertKubernetesConfigToVLabs(api *KubernetesConfig, vlabs *vlabs.Kubernet
 	vlabs.UseCloudControllerManager = api.UseCloudControllerManager
 	vlabs.UseInstanceMetadata = api.UseInstanceMetadata
 	vlabs.EnableRbac = api.EnableRbac
+	vlabs.EnableSecureKubelet = api.EnableSecureKubelet
 	vlabs.EnableAggregatedAPIs = api.EnableAggregatedAPIs
 	vlabs.EnableDataEncryptionAtRest = api.EnableDataEncryptionAtRest
 	vlabs.GCHighThreshold = api.GCHighThreshold

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -610,6 +610,7 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 	api.UseCloudControllerManager = vlabs.UseCloudControllerManager
 	api.UseInstanceMetadata = vlabs.UseInstanceMetadata
 	api.EnableRbac = vlabs.EnableRbac
+	api.EnableSecureKubelet = vlabs.EnableSecureKubelet
 	api.EnableAggregatedAPIs = vlabs.EnableAggregatedAPIs
 	api.EnableDataEncryptionAtRest = vlabs.EnableDataEncryptionAtRest
 	api.GCHighThreshold = vlabs.GCHighThreshold

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -235,6 +235,7 @@ type KubernetesConfig struct {
 	UseCloudControllerManager    *bool             `json:"useCloudControllerManager,omitempty"`
 	UseInstanceMetadata          *bool             `json:"useInstanceMetadata,omitempty"`
 	EnableRbac                   *bool             `json:"enableRbac,omitempty"`
+	EnableSecureKubelet          *bool             `json:"enableSecureKubelet,omitempty"`
 	EnableAggregatedAPIs         bool              `json:"enableAggregatedAPIs,omitempty"`
 	GCHighThreshold              int               `json:"gchighthreshold,omitempty"`
 	GCLowThreshold               int               `json:"gclowthreshold,omitempty"`
@@ -616,12 +617,15 @@ func (p *Properties) HasAadProfile() bool {
 
 // GetAPIServerEtcdAPIVersion Used to set apiserver's etcdapi version
 func (o *OrchestratorProfile) GetAPIServerEtcdAPIVersion() string {
-	// if we are here, version has already been validated..
-	etcdversion, _ := semver.NewVersion(o.KubernetesConfig.EtcdVersion)
-	if 2 == etcdversion.Major() {
-		return "etcd2"
+	ret := "etcd3"
+	if o.KubernetesConfig != nil {
+		// if we are here, version has already been validated..
+		etcdversion, _ := semver.NewVersion(o.KubernetesConfig.EtcdVersion)
+		if etcdversion != nil && 2 == etcdversion.Major() {
+			return "etcd2"
+		}
 	}
-	return "etcd3"
+	return ret
 }
 
 // IsTillerEnabled checks if the tiller addon is enabled

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -243,6 +243,7 @@ type KubernetesConfig struct {
 	UseCloudControllerManager    *bool             `json:"useCloudControllerManager,omitempty"`
 	UseInstanceMetadata          *bool             `json:"useInstanceMetadata,omitempty"`
 	EnableRbac                   *bool             `json:"enableRbac,omitempty"`
+	EnableSecureKubelet          *bool             `json:"enableSecureKubelet,omitempty"`
 	EnableAggregatedAPIs         bool              `json:"enableAggregatedAPIs,omitempty"`
 	GCHighThreshold              int               `json:"gchighthreshold,omitempty"`
 	GCLowThreshold               int               `json:"gclowthreshold,omitempty"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Adds a `enableSecureKubelet` option to `kubernetesConfig` for opting out of securt communications between API server and kubelet.

Also added unit tests for default kubelet and apiserver config enforcement.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
enableSecureKubelet
```
