### PR TITLE
Fix inconsistent capitalisation in vlabs API JSON

### DIFF
--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -128,7 +128,7 @@ type WindowsProfile struct {
 	AdminUsername         string            `json:"adminUsername,omitempty"`
 	AdminPassword         string            `json:"adminPassword,omitempty"`
 	ImageVersion          string            `json:"imageVersion,omitempty"`
-	WindowsImageSourceURL string            `json:"WindowsImageSourceUrl"`
+	WindowsImageSourceURL string            `json:"windowsImageSourceUrl,omitempty"`
 	Secrets               []KeyVaultSecrets `json:"secrets,omitempty"`
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Properties names in the API JSON are normally camelCased.  We recently added one that was PascalCased.  You're reeling, I know.  But with this PR, we can get through it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: None

**Special notes for your reviewer**: I couldn't find any test JSON that used the existing casing; if changing the PascalCase to camelCase breaks anything then it's probably not worth worrying about!

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
