### PR TITLE
Fix issue with apiserver when using AADProfile (#2047)

### DIFF
--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -244,12 +244,6 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
     sed -i "s|<kubernetesControllerManagerConfig>|{{GetK8sRuntimeConfigKeyVals .OrchestratorProfile.KubernetesConfig.ControllerManagerConfig}}|g" "/etc/kubernetes/manifests/kube-controller-manager.yaml"
     sed -i "s|<kubernetesAPIServerConfig>|{{GetK8sRuntimeConfigKeyVals .OrchestratorProfile.KubernetesConfig.APIServerConfig}}|g" "/etc/kubernetes/manifests/kube-apiserver.yaml"
     sed -i "s|<kubernetesAPIServerIP>|{{WrapAsVariable "kubernetesAPIServerIP"}}|g" "/etc/kubernetes/manifests/kube-apiserver.yaml"
-{{ if .HasAadProfile }}
-    VAR_AAD_TENANT_ID={{WrapAsVariable "aadTenantId"}}
-    VAR_TENANT_ID={{WrapAsVariable "tenantId"}}
-    AAD_TENANT_ID=${VAR_AAD_TENANT_ID:-$VAR_TENANT_ID}
-    sed -i "/--oidc-issuer-url/s/$/$AAD_TENANT_ID/" "/etc/kubernetes/manifests/kube-apiserver.yaml"
-{{end}}
 
 - path: "/opt/azure/containers/provision.sh"
   permissions: "0744"

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -70,7 +70,7 @@ func setAPIServerConfig(cs *api.ContainerService) {
 		if GetCloudTargetEnv(cs.Location) == "AzureChinaCloud" {
 			issuerHost = "sts.chinacloudapi.cn"
 		}
-		staticLinuxAPIServerConfig["--oidc-issuer-url"] = "https://" + issuerHost + "/"
+		staticLinuxAPIServerConfig["--oidc-issuer-url"] = "https://" + issuerHost + "/" + cs.Properties.AADProfile.TenantID + "/"
 	}
 
 	staticWindowsAPIServerConfig := make(map[string]string)

--- a/pkg/acsengine/defaults-apiserver_test.go
+++ b/pkg/acsengine/defaults-apiserver_test.go
@@ -140,11 +140,12 @@ func TestAPIServerConfigHasAadProfile(t *testing.T) {
 	cs = createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
 	cs.Properties.AADProfile = &api.AADProfile{
 		ServerAppID: "test-id",
+		TenantID:    "test-tenant",
 	}
 	cs.Location = "chinaeast"
 	setAPIServerConfig(cs)
 	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
-	if a["--oidc-issuer-url"] != "https://sts.chinacloudapi.cn/" {
+	if a["--oidc-issuer-url"] != "https://sts.chinacloudapi.cn/"+cs.Properties.AADProfile.TenantID+"/" {
 		t.Fatalf("got unexpected '--oidc-issuer-url' API server config value for HasAadProfile=true using China cloud: %s",
 			a["--oidc-issuer-url"])
 	}

--- a/pkg/acsengine/defaults-apiserver_test.go
+++ b/pkg/acsengine/defaults-apiserver_test.go
@@ -115,6 +115,7 @@ func TestAPIServerConfigHasAadProfile(t *testing.T) {
 	cs := createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
 	cs.Properties.AADProfile = &api.AADProfile{
 		ServerAppID: "test-id",
+		TenantID:    "test-tenant",
 	}
 	setAPIServerConfig(cs)
 	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
@@ -130,7 +131,7 @@ func TestAPIServerConfigHasAadProfile(t *testing.T) {
 		t.Fatalf("got unexpected '--oidc-client-id' API server config value for HasAadProfile=true: %s",
 			a["--oidc-client-id"])
 	}
-	if a["--oidc-issuer-url"] != "https://sts.windows.net/" {
+	if a["--oidc-issuer-url"] != "https://sts.windows.net/"+cs.Properties.AADProfile.TenantID+"/" {
 		t.Fatalf("got unexpected '--oidc-issuer-url' API server config value for HasAadProfile=true: %s",
 			a["--oidc-issuer-url"])
 	}


### PR DESCRIPTION
Fixes issue mentioned in https://github.com/Azure/acs-engine/issues/2047 where kube-apiserver.yaml file is incorrect when setting AADProfile in api-model. Moved issuer url generation to go file instead of using sed.