### PR TITLE
Make sure --cluster-dns uses DNSServiceIp set in KubernetesConfig

### DIFF
--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -22,7 +22,7 @@ func setKubeletConfig(cs *api.ContainerService) {
 		"--client-ca-file":                  "/etc/kubernetes/certs/ca.crt",
 		"--pod-manifest-path":               "/etc/kubernetes/manifests",
 		"--cluster-domain":                  "cluster.local",
-		"--cluster-dns":                     DefaultKubernetesDNSServiceIP,
+		"--cluster-dns":                     o.KubernetesConfig.DNSServiceIP,
 		"--cgroups-per-qos":                 "false",
 		"--enforce-node-allocatable":        "",
 		"--kubeconfig":                      "/var/lib/kubelet/kubeconfig",


### PR DESCRIPTION
**What this PR does / why we need it**:

--cluster-dns setting was always using default value, even if another ip was set in kubernetesConfig.DNSServiceIP. Unless custom ip is specified in kubernetesConfig.DNSServiceIP default value will still be set there. Just makes sure --cluster-dns get correct ip if using custom ip.

This issues caused dns lookup problems on pods ( / network issues). DNS Service IP was outside of Service CIDR if set to custom cidr. 

**Which issue this PR fixes**