### PR TITLE
Add documentation to update Route Table when Custom VNET is in different RG

### DIFF
--- a/docs/custom-vnet.md
+++ b/docs/custom-vnet.md
@@ -170,7 +170,7 @@ Depending on the number of agent you have asked for the deployment can take a wh
 
 ## Post-Deployment: Attach Cluster Route Table to VNET
 
-For Kubernetes clusters, we need to update the VNET to attach to the route table created by the above `az group deployment create` command. An example in bash form:
+For Kubernetes clusters, we need to update the VNET to attach to the route table created by the above `az group deployment create` command. An example in bash form for if the VNET is in the same ResourceGroup as the Kubernetes Cluster:
 
 ```
 #!/bin/bash
@@ -179,6 +179,16 @@ az network vnet subnet update -n KubernetesSubnet -g acs-custom-vnet --vnet-name
 ```
 
 ... where `KubernetesSubnet` is the name of the vnet subnet, and `KubernetesCustomVNET` is the name of the custom VNET itself.
+
+An example in bash for for if the VNET is in a separate ResourceGroup:
+
+```
+#!/bin/bash
+rt=$(az network route-table list -g RESOURCE_GROUP_NAME_KUBE -o json | jq -r '.[].id')
+az network vnet subnet update 
+-g RESOURCE_GROUP_NAME_VNET --route-table $rt --ids "/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_NAME_VNET/providers/Microsoft.Network/VirtualNetworks/KUBERNETES_CUSTOM_VNET/subnets/KUBERNETES_SUBNET"
+```
+... where `RESOURCE_GROUP_NAME_KUBE` is the name of the Resource Group that contains the Kubernetes cluster, `SUBSCRIPTION_ID` is the id of the Azure subscription that both the VNET & Cluster are in, `RESOURCE_GROUP_NAME_VNET` is the name of the Resource Group that the VNET is in,  `KUBERNETES_SUBNET` is the name of the vnet subnet, and `KUBERNETES_CUSTOM_VNET` is the name of the custom VNET itself.
 
 ## Connect to your new cluster
 Once the deployment is completed, you can follow [this documentation](https://docs.microsoft.com/en-us/azure/container-service/container-service-connect) to connect to your new Azure Container Service cluster.

--- a/docs/custom-vnet.md
+++ b/docs/custom-vnet.md
@@ -170,23 +170,28 @@ Depending on the number of agent you have asked for the deployment can take a wh
 
 ## Post-Deployment: Attach Cluster Route Table to VNET
 
-For Kubernetes clusters, we need to update the VNET to attach to the route table created by the above `az group deployment create` command. An example in bash form for if the VNET is in the same ResourceGroup as the Kubernetes Cluster:
+For Kubernetes clusters, we need to update the VNET to attach to the route table created by the above `az group deployment create` command. An example in bash form if the VNET is in the same ResourceGroup as the Kubernetes Cluster:
 
 ```
 #!/bin/bash
 rt=$(az network route-table list -g acs-custom-vnet -o json | jq -r '.[].id')
-az network vnet subnet update -n KubernetesSubnet -g acs-custom-vnet --vnet-name KubernetesCustomVNET --route-table $rt
+az network vnet subnet update -n KubernetesSubnet \
+-g acs-custom-vnet \
+--vnet-name KubernetesCustomVNET \
+--route-table $rt
 ```
 
 ... where `KubernetesSubnet` is the name of the vnet subnet, and `KubernetesCustomVNET` is the name of the custom VNET itself.
 
-An example in bash for for if the VNET is in a separate ResourceGroup:
+An example in bash form if the VNET is in a separate ResourceGroup:
 
 ```
 #!/bin/bash
 rt=$(az network route-table list -g RESOURCE_GROUP_NAME_KUBE -o json | jq -r '.[].id')
-az network vnet subnet update 
--g RESOURCE_GROUP_NAME_VNET --route-table $rt --ids "/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_NAME_VNET/providers/Microsoft.Network/VirtualNetworks/KUBERNETES_CUSTOM_VNET/subnets/KUBERNETES_SUBNET"
+az network vnet subnet update \
+-g RESOURCE_GROUP_NAME_VNET \
+--route-table $rt \
+--ids "/subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP_NAME_VNET/providers/Microsoft.Network/VirtualNetworks/KUBERNETES_CUSTOM_VNET/subnets/KUBERNETES_SUBNET"
 ```
 ... where `RESOURCE_GROUP_NAME_KUBE` is the name of the Resource Group that contains the Kubernetes cluster, `SUBSCRIPTION_ID` is the id of the Azure subscription that both the VNET & Cluster are in, `RESOURCE_GROUP_NAME_VNET` is the name of the Resource Group that the VNET is in,  `KUBERNETES_SUBNET` is the name of the vnet subnet, and `KUBERNETES_CUSTOM_VNET` is the name of the custom VNET itself.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated Custom VNET docs to add instructions for route table when the… Custom VNET is in a different Resource Group to the Kubernetes cluster. 
From my experiments, although the existing example bash script does not error, it does not successfully update the Route Table in the VNET when the VNET is in a different Resource Group to the Kubernetes cluster. From https://github.com/Azure/azure-cli/issues/4817 it appears that this works when you use the full canonical ids for the subnet, this PR adds an example that does this

**Which issue this PR fixes**
`fixes #2085`

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add to Custom VNet documentation to show how to update Route Table when Custom VNET is in different Resource Group
```
