### PR TITLE
re-enable read-only port on kubelet

### DIFF
--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -23,7 +23,6 @@ func setKubeletConfig(cs *api.ContainerService) {
 		"--enforce-node-allocatable":        "",
 		"--kubeconfig":                      "/var/lib/kubelet/kubeconfig",
 		"--azure-container-registry-config": "/etc/kubernetes/azure.json",
-		"--read-only-port":                  "0",
 		"--keep-terminated-pod-volumes":     "false",
 	}
 


### PR DESCRIPTION
fixes heapster connection issues

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Re-enables kubelet read-only-port, which our current heapster configuration needs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2083

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
re-enable read-only port on kubelet to fix heapster
```