### PR TITLE
Preserve subnets during scale up

### DIFF
--- a/pkg/acsengine/transform/transform.go
+++ b/pkg/acsengine/transform/transform.go
@@ -36,10 +36,12 @@ const (
 	vmssResourceType = "Microsoft.Compute/virtualMachineScaleSets"
 	vmExtensionType  = "Microsoft.Compute/virtualMachines/extensions"
 	nicResourceType  = "Microsoft.Network/networkInterfaces"
+	vnetResourceType = "Microsoft.Network/virtualNetworks"
 
 	// resource ids
-	nsgID = "nsgID"
-	rtID  = "routeTableID"
+	nsgID  = "nsgID"
+	rtID   = "routeTableID"
+	vnetID = "vnetID"
 )
 
 // Translator defines all required interfaces for i18n.Translator.
@@ -104,6 +106,7 @@ func (t *Transformer) NormalizeForK8sVMASScalingUp(logger *logrus.Entry, templat
 	}
 	rtIndex := -1
 	nsgIndex := -1
+	vnetIndex := -1;
 	resources := templateMap[resourcesFieldName].([]interface{})
 	for index, resource := range resources {
 		resourceMap, ok := resource.(map[string]interface{})
@@ -129,6 +132,14 @@ func (t *Transformer) NormalizeForK8sVMASScalingUp(logger *logrus.Entry, templat
 			}
 			rtIndex = index
 		}
+		if ok && resourceType == vnetResourceType {
+			if vnetIndex != -1 {
+				err := t.Translator.Errorf("Found 2 resources with type %s in the template. There should only be 1", vnetResourceType)
+				logger.Warnf(err.Error())
+				return err
+			}
+			vnetIndex = index
+		}
 
 		dependencies, ok := resourceMap[dependsOnFieldName].([]interface{})
 		if !ok {
@@ -138,7 +149,8 @@ func (t *Transformer) NormalizeForK8sVMASScalingUp(logger *logrus.Entry, templat
 		for dIndex := len(dependencies) - 1; dIndex >= 0; dIndex-- {
 			dependency := dependencies[dIndex].(string)
 			if strings.Contains(dependency, nsgResourceType) || strings.Contains(dependency, nsgID) ||
-				strings.Contains(dependency, rtResourceType) || strings.Contains(dependency, rtID) {
+				strings.Contains(dependency, rtResourceType) || strings.Contains(dependency, rtID) ||
+				strings.Contains(dependency, vnetResourceType) || strings.Contains(dependency, vnetID) {
 				dependencies = append(dependencies[:dIndex], dependencies[dIndex+1:]...)
 			}
 		}
@@ -160,6 +172,11 @@ func (t *Transformer) NormalizeForK8sVMASScalingUp(logger *logrus.Entry, templat
 		logger.Infof("Found no resources with type %s in the template.", rtResourceType)
 	} else {
 		indexesToRemove = append(indexesToRemove, rtIndex)
+	}
+	if vnetIndex == -1 {
+		logger.Infof("Found no resources with type %s in the template.", vnetResourceType)
+	} else {
+		indexesToRemove = append(indexesToRemove, vnetIndex)
 	}
 	indexesToRemove = append(indexesToRemove, nsgIndex)
 	templateMap[resourcesFieldName] = removeIndexesFromArray(resources, indexesToRemove)

--- a/pkg/acsengine/transform/transform.go
+++ b/pkg/acsengine/transform/transform.go
@@ -106,7 +106,7 @@ func (t *Transformer) NormalizeForK8sVMASScalingUp(logger *logrus.Entry, templat
 	}
 	rtIndex := -1
 	nsgIndex := -1
-	vnetIndex := -1;
+	vnetIndex := -1
 	resources := templateMap[resourcesFieldName].([]interface{})
 	for index, resource := range resources {
 		resourceMap, ok := resource.(map[string]interface{})

--- a/pkg/acsengine/transform/transformtestfiles/k8s_agent_upgrade_template.json
+++ b/pkg/acsengine/transform/transformtestfiles/k8s_agent_upgrade_template.json
@@ -1659,9 +1659,6 @@
         "count": "[sub(variables('agentppol1Count'), variables('agentppol1Offset'))]",
         "name": "loop"
       },
-      "dependsOn": [
-        "[variables('vnetID')]"
-      ],
       "location": "[variables('location')]",
       "name": "[concat(variables('agentppol1VMNamePrefix'), 'nic-', copyIndex(variables('agentppol1Offset')))]",
       "properties": {
@@ -1710,9 +1707,6 @@
         "count": "[sub(variables('agentpool2Count'), variables('agentpool2Offset'))]",
         "name": "loop"
       },
-      "dependsOn": [
-        "[variables('vnetID')]"
-      ],
       "location": "[variables('location')]",
       "name": "[concat(variables('agentpool2VMNamePrefix'), 'nic-', copyIndex(variables('agentpool2Offset')))]",
       "properties": {
@@ -1765,33 +1759,6 @@
         "platformUpdateDomainCount": "3"
       },
       "type": "Microsoft.Compute/availabilitySets"
-    },
-    {
-      "apiVersion": "[variables('apiVersionDefault')]",
-      "location": "[variables('location')]",
-      "name": "[variables('virtualNetworkName')]",
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "[variables('vnetCidr')]"
-          ]
-        },
-        "subnets": [
-          {
-            "name": "[variables('subnetName')]",
-            "properties": {
-              "addressPrefix": "[variables('subnet')]",
-              "networkSecurityGroup": {
-                "id": "[variables('nsgID')]"
-              },
-              "routeTable": {
-                "id": "[variables('routeTableID')]"
-              }
-            }
-          }
-        ]
-      },
-      "type": "Microsoft.Network/virtualNetworks"
     },
     {
       "apiVersion": "[variables('apiVersionDefault')]",
@@ -1854,9 +1821,6 @@
     },
     {
       "apiVersion": "[variables('apiVersionDefault')]",
-      "dependsOn": [
-        "[variables('vnetID')]"
-      ],
       "location": "[variables('location')]",
       "name": "[variables('masterInternalLbName')]",
       "properties": {
@@ -1950,7 +1914,6 @@
         "name": "nicLoopNode"
       },
       "dependsOn": [
-        "[variables('vnetID')]",
         "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')))]",
         "[variables('masterInternalLbName')]"
       ],

--- a/pkg/acsengine/transform/transformtestfiles/k8s_master_upgrade_template.json
+++ b/pkg/acsengine/transform/transformtestfiles/k8s_master_upgrade_template.json
@@ -1659,9 +1659,6 @@
         "count": "[sub(variables('agentppol1Count'), variables('agentppol1Offset'))]",
         "name": "loop"
       },
-      "dependsOn": [
-        "[variables('vnetID')]"
-      ],
       "location": "[variables('location')]",
       "name": "[concat(variables('agentppol1VMNamePrefix'), 'nic-', copyIndex(variables('agentppol1Offset')))]",
       "properties": {
@@ -1710,9 +1707,6 @@
         "count": "[sub(variables('agentpool2Count'), variables('agentpool2Offset'))]",
         "name": "loop"
       },
-      "dependsOn": [
-        "[variables('vnetID')]"
-      ],
       "location": "[variables('location')]",
       "name": "[concat(variables('agentpool2VMNamePrefix'), 'nic-', copyIndex(variables('agentpool2Offset')))]",
       "properties": {
@@ -1859,37 +1853,6 @@
     },
     {
       "apiVersion": "[variables('apiVersionDefault')]",
-      "dependsOn": [
-        "[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgName'))]",
-        "[concat('Microsoft.Network/routeTables/', variables('routeTableName'))]"
-      ],
-      "location": "[variables('location')]",
-      "name": "[variables('virtualNetworkName')]",
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "[variables('vnetCidr')]"
-          ]
-        },
-        "subnets": [
-          {
-            "name": "[variables('subnetName')]",
-            "properties": {
-              "addressPrefix": "[variables('subnet')]",
-              "networkSecurityGroup": {
-                "id": "[variables('nsgID')]"
-              },
-              "routeTable": {
-                "id": "[variables('routeTableID')]"
-              }
-            }
-          }
-        ]
-      },
-      "type": "Microsoft.Network/virtualNetworks"
-    },
-    {
-      "apiVersion": "[variables('apiVersionDefault')]",
       "location": "[variables('location')]",
       "name": "[variables('nsgName')]",
       "properties": {
@@ -1993,9 +1956,6 @@
     },
     {
       "apiVersion": "[variables('apiVersionDefault')]",
-      "dependsOn": [
-        "[variables('vnetID')]"
-      ],
       "location": "[variables('location')]",
       "name": "[variables('masterInternalLbName')]",
       "properties": {
@@ -2089,7 +2049,6 @@
         "name": "nicLoopNode"
       },
       "dependsOn": [
-        "[variables('vnetID')]",
         "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')))]",
         "[variables('masterInternalLbName')]"
       ],

--- a/pkg/acsengine/transform/transformtestfiles/k8s_scale_template.json
+++ b/pkg/acsengine/transform/transformtestfiles/k8s_scale_template.json
@@ -1659,9 +1659,6 @@
         "count": "[sub(variables('agentppol1Count'), variables('agentppol1Offset'))]",
         "name": "loop"
       },
-      "dependsOn": [
-        "[variables('vnetID')]"
-      ],
       "location": "[variables('location')]",
       "name": "[concat(variables('agentppol1VMNamePrefix'), 'nic-', copyIndex(variables('agentppol1Offset')))]",
       "properties": {
@@ -1801,9 +1798,6 @@
         "count": "[sub(variables('agentpool2Count'), variables('agentpool2Offset'))]",
         "name": "loop"
       },
-      "dependsOn": [
-        "[variables('vnetID')]"
-      ],
       "location": "[variables('location')]",
       "name": "[concat(variables('agentpool2VMNamePrefix'), 'nic-', copyIndex(variables('agentpool2Offset')))]",
       "properties": {
@@ -1950,33 +1944,6 @@
     },
     {
       "apiVersion": "[variables('apiVersionDefault')]",
-      "location": "[variables('location')]",
-      "name": "[variables('virtualNetworkName')]",
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "[variables('vnetCidr')]"
-          ]
-        },
-        "subnets": [
-          {
-            "name": "[variables('subnetName')]",
-            "properties": {
-              "addressPrefix": "[variables('subnet')]",
-              "networkSecurityGroup": {
-                "id": "[variables('nsgID')]"
-              },
-              "routeTable": {
-                "id": "[variables('routeTableID')]"
-              }
-            }
-          }
-        ]
-      },
-      "type": "Microsoft.Network/virtualNetworks"
-    },
-    {
-      "apiVersion": "[variables('apiVersionDefault')]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
       ],
@@ -2036,9 +2003,6 @@
     },
     {
       "apiVersion": "[variables('apiVersionDefault')]",
-      "dependsOn": [
-        "[variables('vnetID')]"
-      ],
       "location": "[variables('location')]",
       "name": "[variables('masterInternalLbName')]",
       "properties": {
@@ -2132,7 +2096,6 @@
         "name": "nicLoopNode"
       },
       "dependsOn": [
-        "[variables('vnetID')]",
         "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')))]",
         "[variables('masterInternalLbName')]"
       ],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: When you scale up an acs-engine cluster (using `az acs scale` or `acs-engine scale`), any subnets of the cluster vnet other than the automatic `k8s-master` subnet are deleted.  This is unexpected, and if the subnet is in use (for example because it contains a gateway or IP address) then the subnet cannot be deleted and this blocks the scaling operation.

The underlying problem is that scale up recreates the ARM template for the resource group and re-applies it.  Because the ARM template includes only the original automatic subnet, ARM assumes that the desired state of the vnet is to contain only the automatic subnet, and therefore attempts to delete any other subnets.

This PR excludes the vnet from the ARM template generated for scaling, using the same techniques already used to exclude the route table and NSG.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2063 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
