### PR TITLE
Add autoscale test to E2E

### DIFF
--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -56,8 +56,14 @@ type Container struct {
 // CreateLinuxDeploy will create a deployment for a given image with a name in a namespace
 // --overrides='{ "apiVersion": "extensions/v1beta1", "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}}}'
 func CreateLinuxDeploy(image, name, namespace, miscOpts string) (*Deployment, error) {
+	var err error
+	var out []byte
 	overrides := `{ "apiVersion": "extensions/v1beta1", "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}}}`
-	out, err := exec.Command("kubectl", "run", name, "-n", namespace, "--image", image, "--overrides", overrides, miscOpts).CombinedOutput()
+	if miscOpts != "" {
+		out, err = exec.Command("kubectl", "run", name, "-n", namespace, "--image", image, "--overrides", overrides, miscOpts).CombinedOutput()
+	} else {
+		out, err = exec.Command("kubectl", "run", name, "-n", namespace, "--image", image, "--overrides", overrides).CombinedOutput()
+	}
 	if err != nil {
 		log.Printf("Error trying to deploy %s [%s] in namespace %s:%s\n", name, image, namespace, string(out))
 		return nil, err

--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -78,9 +78,9 @@ func CreateLinuxDeploy(image, name, namespace, miscOpts string) (*Deployment, er
 
 // RunLinuxDeploy will create a deployment that runs a bash command in a pod
 // --overrides='{ "apiVersion": "extensions/v1beta1", "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}}}'
-func RunLinuxDeploy(image, name, namespace, command string) (*Deployment, error) {
+func RunLinuxDeploy(image, name, namespace, command string, replicas int) (*Deployment, error) {
 	overrides := `{ "apiVersion": "extensions/v1beta1", "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}}}`
-	out, err := exec.Command("kubectl", "run", name, "-n", namespace, "--image", image, "--overrides", overrides, "--command", "--", "/bin/sh", "-c", command).CombinedOutput()
+	out, err := exec.Command("kubectl", "run", name, "-n", namespace, "--image", image, "--replicas", strconv.Itoa(replicas), "--overrides", overrides, "--command", "--", "/bin/sh", "-c", command).CombinedOutput()
 	if err != nil {
 		log.Printf("Error trying to deploy %s [%s] in namespace %s:%s\n", name, image, namespace, string(out))
 		return nil, err

--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -55,9 +55,9 @@ type Container struct {
 
 // CreateLinuxDeploy will create a deployment for a given image with a name in a namespace
 // --overrides='{ "apiVersion": "extensions/v1beta1", "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}}}'
-func CreateLinuxDeploy(image, name, namespace string) (*Deployment, error) {
+func CreateLinuxDeploy(image, name, namespace, miscOpts string) (*Deployment, error) {
 	overrides := `{ "apiVersion": "extensions/v1beta1", "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}}}`
-	out, err := exec.Command("kubectl", "run", name, "-n", namespace, "--image", image, "--overrides", overrides).CombinedOutput()
+	out, err := exec.Command("kubectl", "run", name, "-n", namespace, "--image", image, "--overrides", overrides, miscOpts).CombinedOutput()
 	if err != nil {
 		log.Printf("Error trying to deploy %s [%s] in namespace %s:%s\n", name, image, namespace, string(out))
 		return nil, err

--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -70,6 +70,23 @@ func CreateLinuxDeploy(image, name, namespace, miscOpts string) (*Deployment, er
 	return d, nil
 }
 
+// RunLinuxDeploy will create a deployment that runs a bash command in a pod
+// --overrides='{ "apiVersion": "extensions/v1beta1", "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}}}'
+func RunLinuxDeploy(image, name, namespace, command string) (*Deployment, error) {
+	overrides := `{ "apiVersion": "extensions/v1beta1", "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}}}`
+	out, err := exec.Command("kubectl", "run", name, "-n", namespace, "--image", image, "--overrides", overrides, "--command", "--", "/bin/sh", "-c", command).CombinedOutput()
+	if err != nil {
+		log.Printf("Error trying to deploy %s [%s] in namespace %s:%s\n", name, image, namespace, string(out))
+		return nil, err
+	}
+	d, err := Get(name, namespace)
+	if err != nil {
+		log.Printf("Error while trying to fetch Deployment %s in namespace %s:%s\n", name, namespace, err)
+		return nil, err
+	}
+	return d, nil
+}
+
 // CreateWindowsDeploy will crete a deployment for a given image with a name in a namespace
 func CreateWindowsDeploy(image, name, namespace string, port int, hostport int) (*Deployment, error) {
 	overrides := `{ "apiVersion": "extensions/v1beta1", "spec":{"template":{"spec": {"nodeSelector":{"beta.kubernetes.io/os":"windows"}}}}}`
@@ -113,10 +130,10 @@ func (d *Deployment) Delete() error {
 }
 
 // Expose will create a load balancer and expose the deployment on a given port
-func (d *Deployment) Expose(targetPort, exposedPort int) error {
-	out, err := exec.Command("kubectl", "expose", "deployment", d.Metadata.Name, "--type", "LoadBalancer", "-n", d.Metadata.Namespace, "--target-port", strconv.Itoa(targetPort), "--port", strconv.Itoa(exposedPort)).CombinedOutput()
+func (d *Deployment) Expose(svcType string, targetPort, exposedPort int) error {
+	out, err := exec.Command("kubectl", "expose", "deployment", d.Metadata.Name, "--type", svcType, "-n", d.Metadata.Namespace, "--target-port", strconv.Itoa(targetPort), "--port", strconv.Itoa(exposedPort)).CombinedOutput()
 	if err != nil {
-		log.Printf("Error while trying to expose target port (%v) for deployment %s in namespace %s on port %v:%s\n", targetPort, d.Metadata.Name, d.Metadata.Namespace, exposedPort, string(out))
+		log.Printf("Error while trying to expose (%s) target port (%v) for deployment %s in namespace %s on port %v:%s\n", svcType, targetPort, d.Metadata.Name, d.Metadata.Namespace, exposedPort, string(out))
 		return err
 	}
 	return nil

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -126,6 +126,46 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			Expect(running).To(Equal(true))
 		})
 
+		It("should be able to autoscale", func() {
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			phpApacheName := fmt.Sprintf("php-apache-%s-%v", cfg.Name, r.Intn(99999))
+			phpApacheDeploy, err := deployment.CreateLinuxDeploy("gcr.io/google_containers/hpa-example", phpApacheName, "default", "--requests=cpu=50m,memory=50M --expose --port=80")
+			Expect(err).NotTo(HaveOccurred())
+
+			running, err := pod.WaitOnReady(phpApacheName, "default", 3, 30*time.Second, cfg.Timeout)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(running).To(Equal(true))
+
+			phpPods, err := phpApacheDeploy.Pods()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(phpPods)).To(Equal(1))
+
+			out, err := exec.Command("kubectl", "autoscale", "deployment", phpApacheName, "--cpu-percent=5", "--min=1", "--max=10").CombinedOutput()
+			if err != nil {
+				fmt.Println(out)
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			commandString := fmt.Sprintf("--command -- /bin/sh -c 'while true; do wget -q -O- http://%s.default.svc.cluster.local; done'", phpApacheName)
+			loadTestName := fmt.Sprintf("load-test-%s-%v", cfg.Name, r.Intn(99999))
+			loadTestDeploy, err := deployment.CreateLinuxDeploy("busybox", loadTestName, "default", commandString)
+			Expect(err).NotTo(HaveOccurred())
+
+			running, err = pod.WaitOnReady(loadTestName, "default", 3, 30*time.Second, cfg.Timeout)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(running).To(Equal(true))
+
+			loadTestPods, err := loadTestDeploy.Pods()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(loadTestPods)).ToNot(BeZero())
+
+			time.Sleep(1 * time.Minute)
+
+			phpPods, err = phpApacheDeploy.Pods()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(phpPods) > 1).To(BeTrue())
+		})
+
 		It("should be able to access the dashboard from each node", func() {
 			running, err := pod.WaitOnReady("kubernetes-dashboard", "kube-system", 3, 30*time.Second, cfg.Timeout)
 			Expect(err).NotTo(HaveOccurred())
@@ -180,7 +220,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if eng.HasLinuxAgents() {
 				r := rand.New(rand.NewSource(time.Now().UnixNano()))
 				deploymentName := fmt.Sprintf("nginx-%s-%v", cfg.Name, r.Intn(99999))
-				nginxDeploy, err := deployment.CreateLinuxDeploy("library/nginx:latest", deploymentName, "default")
+				nginxDeploy, err := deployment.CreateLinuxDeploy("library/nginx:latest", deploymentName, "default", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				running, err := pod.WaitOnReady(deploymentName, "default", 3, 30*time.Second, cfg.Timeout)

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -212,17 +212,17 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			// Launch a simple busybox pod that wget's continuously to the apache serviceto simulate load
 			commandString := fmt.Sprintf("while true; do wget -q -O- http://%s.default.svc.cluster.local; done", phpApacheName)
 			loadTestName := fmt.Sprintf("load-test-%s-%v", cfg.Name, r.Intn(99999))
-			loadTestDeploy, err := deployment.RunLinuxDeploy("busybox", loadTestName, "default", commandString)
+			loadTestDeploy, err := deployment.RunLinuxDeploy("busybox", loadTestName, "default", commandString, 3)
 			Expect(err).NotTo(HaveOccurred())
 
 			running, err = pod.WaitOnReady(loadTestName, "default", 3, 30*time.Second, cfg.Timeout)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(running).To(Equal(true))
 
-			// We should have exactly one load tester pod running
+			// We should have three load tester pods running
 			loadTestPods, err := loadTestDeploy.Pods()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(loadTestPods)).To(Equal(1))
+			Expect(len(loadTestPods)).To(Equal(3))
 
 			// Wait 90 seconds for autoscaler to respond to load
 			time.Sleep(90 * time.Second)

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -177,7 +177,10 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 	Describe("with a linux agent pool", func() {
 		It("should be able to autoscale", func() {
-			if eng.HasLinuxAgents() {
+			version, err := node.Version()
+			Expect(err).NotTo(HaveOccurred())
+			re := regexp.MustCompile("v1.9")
+			if eng.HasLinuxAgents() && re.FindString(version) == "" {
 				// Inspired by http://blog.kubernetes.io/2016/07/autoscaling-in-kubernetes.html
 				r := rand.New(rand.NewSource(time.Now().UnixNano()))
 				phpApacheName := fmt.Sprintf("php-apache-%s-%v", cfg.Name, r.Intn(99999))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Tests out autoscale functionality on Kubernetes clusters.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
