### PR TITLE
Kind should be only EncryptionConfig for encyption-config.yaml

### DIFF
--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -91,7 +91,6 @@ write_files:
   permissions: "0600"
   owner: "root"
   content: |
-    apiVersion: v1
     kind: EncryptionConfig
     apiVersion: v1
     resources:

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -93,7 +93,6 @@ write_files:
   content: |
     apiVersion: v1
     kind: Config
-    kind: EncryptionConfig
     apiVersion: v1
     resources:
       - resources:

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -92,7 +92,7 @@ write_files:
   owner: "root"
   content: |
     apiVersion: v1
-    kind: Config
+    kind: EncryptionConfig
     apiVersion: v1
     resources:
       - resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Removes the unnecessary Config `Kind` value in `/etc/kubernetes/encryption-config.yaml`.

See https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
EncryptionConfig for encryption at rest implementation
```