### PR TITLE
WIP - Azure CNI by default for Windows vlabs api

### DIFF
--- a/pkg/api/vlabs/const.go
+++ b/pkg/api/vlabs/const.go
@@ -87,5 +87,5 @@ const (
 	// DefaultNetworkPolicy defines the network policy to use by default
 	DefaultNetworkPolicy = "azure"
 	// DefaultNetworkPolicyWindows defines the network policy to use by default for clusters with Windows agent pools
-	DefaultNetworkPolicyWindows = "none"
+	DefaultNetworkPolicyWindows = "azure"
 )

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -674,7 +674,7 @@ func (a *Properties) validateNetworkPolicy() error {
 	}
 
 	// Temporary safety check, to be removed when Windows support is added.
-	if (networkPolicy == "calico" || networkPolicy == "azure") && a.HasWindows() {
+	if (networkPolicy == "calico") && a.HasWindows() {
 		return fmt.Errorf("networkPolicy '%s' is not supporting windows agents", networkPolicy)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Turn on Azure CNI by default for Windows clusters in vlabs

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Azure CNI by default for Windows in vlabs
```
