### PR TITLE
Restore KubernetesConfig properties

### DIFF
--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -23,7 +23,6 @@ func setKubeletConfig(cs *api.ContainerService) {
 		"--enforce-node-allocatable":        "",
 		"--kubeconfig":                      "/var/lib/kubelet/kubeconfig",
 		"--azure-container-registry-config": "/etc/kubernetes/azure.json",
-		"--read-only-port":                  "0",
 		"--keep-terminated-pod-volumes":     "false",
 	}
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -195,6 +195,7 @@ func (a *KubernetesAddon) IsEnabled(ifNil bool) bool {
 	return *a.Enabled
 }
 
+// TODO use this when strict JSON accommodates struct embedding
 // CloudProviderConfig contains the KubernetesConfig properties specific to the Cloud Provider
 type CloudProviderConfig struct {
 	CloudProviderBackoff         bool    `json:"cloudProviderBackoff,omitempty"`
@@ -207,6 +208,7 @@ type CloudProviderConfig struct {
 	CloudProviderRateLimitBucket int     `json:"cloudProviderRateLimitBucket,omitempty"`
 }
 
+// TODO use this when strict JSON accommodates struct embedding
 // KubernetesConfigDeprecated are properties that are no longer operable and will be ignored
 type KubernetesConfigDeprecated struct {
 	NonMasqueradeCidr                string `json:"nonMasqueradeCidr,omitempty"`
@@ -220,34 +222,46 @@ type KubernetesConfigDeprecated struct {
 // KubernetesConfig contains the Kubernetes config structure, containing
 // Kubernetes specific configuration
 type KubernetesConfig struct {
-	KubernetesImageBase string `json:"kubernetesImageBase,omitempty"`
-	ClusterSubnet       string `json:"clusterSubnet,omitempty"`
-	NetworkPolicy       string `json:"networkPolicy,omitempty"`
-	MaxPods             int    `json:"maxPods,omitempty"`
-	DockerBridgeSubnet  string `json:"dockerBridgeSubnet,omitempty"`
-	DNSServiceIP        string `json:"dnsServiceIP,omitempty"`
-	ServiceCIDR         string `json:"serviceCidr,omitempty"`
-	CloudProviderConfig
-	UseManagedIdentity           bool              `json:"useManagedIdentity,omitempty"`
-	CustomHyperkubeImage         string            `json:"customHyperkubeImage,omitempty"`
-	DockerEngineVersion          string            `json:"dockerEngineVersion,omitempty"`
-	CustomCcmImage               string            `json:"customCcmImage,omitempty"` // Image for cloud-controller-manager
-	UseCloudControllerManager    *bool             `json:"useCloudControllerManager,omitempty"`
-	UseInstanceMetadata          *bool             `json:"useInstanceMetadata,omitempty"`
-	EnableRbac                   *bool             `json:"enableRbac,omitempty"`
-	EnableSecureKubelet          *bool             `json:"enableSecureKubelet,omitempty"`
-	EnableAggregatedAPIs         bool              `json:"enableAggregatedAPIs,omitempty"`
-	GCHighThreshold              int               `json:"gchighthreshold,omitempty"`
-	GCLowThreshold               int               `json:"gclowthreshold,omitempty"`
-	EtcdVersion                  string            `json:"etcdVersion,omitempty"`
-	EtcdDiskSizeGB               string            `json:"etcdDiskSizeGB,omitempty"`
-	EnableDataEncryptionAtRest   *bool             `json:"enableDataEncryptionAtRest,omitempty"`
-	Addons                       []KubernetesAddon `json:"addons,omitempty"`
-	KubeletConfig                map[string]string `json:"kubeletConfig,omitempty"`
-	ControllerManagerConfig      map[string]string `json:"controllerManagerConfig,omitempty"`
-	CloudControllerManagerConfig map[string]string `json:"cloudControllerManagerConfig,omitempty"`
-	APIServerConfig              map[string]string `json:"apiServerConfig,omitempty"`
-	KubernetesConfigDeprecated
+	KubernetesImageBase              string            `json:"kubernetesImageBase,omitempty"`
+	ClusterSubnet                    string            `json:"clusterSubnet,omitempty"`
+	NetworkPolicy                    string            `json:"networkPolicy,omitempty"`
+	MaxPods                          int               `json:"maxPods,omitempty"`
+	DockerBridgeSubnet               string            `json:"dockerBridgeSubnet,omitempty"`
+	DNSServiceIP                     string            `json:"dnsServiceIP,omitempty"`
+	ServiceCIDR                      string            `json:"serviceCidr,omitempty"`
+	UseManagedIdentity               bool              `json:"useManagedIdentity,omitempty"`
+	CustomHyperkubeImage             string            `json:"customHyperkubeImage,omitempty"`
+	DockerEngineVersion              string            `json:"dockerEngineVersion,omitempty"`
+	CustomCcmImage                   string            `json:"customCcmImage,omitempty"` // Image for cloud-controller-manager
+	UseCloudControllerManager        *bool             `json:"useCloudControllerManager,omitempty"`
+	UseInstanceMetadata              *bool             `json:"useInstanceMetadata,omitempty"`
+	EnableRbac                       *bool             `json:"enableRbac,omitempty"`
+	EnableSecureKubelet              *bool             `json:"enableSecureKubelet,omitempty"`
+	EnableAggregatedAPIs             bool              `json:"enableAggregatedAPIs,omitempty"`
+	GCHighThreshold                  int               `json:"gchighthreshold,omitempty"`
+	GCLowThreshold                   int               `json:"gclowthreshold,omitempty"`
+	EtcdVersion                      string            `json:"etcdVersion,omitempty"`
+	EtcdDiskSizeGB                   string            `json:"etcdDiskSizeGB,omitempty"`
+	EnableDataEncryptionAtRest       *bool             `json:"enableDataEncryptionAtRest,omitempty"`
+	Addons                           []KubernetesAddon `json:"addons,omitempty"`
+	KubeletConfig                    map[string]string `json:"kubeletConfig,omitempty"`
+	ControllerManagerConfig          map[string]string `json:"controllerManagerConfig,omitempty"`
+	CloudControllerManagerConfig     map[string]string `json:"cloudControllerManagerConfig,omitempty"`
+	APIServerConfig                  map[string]string `json:"apiServerConfig,omitempty"`
+	CloudProviderBackoff             bool              `json:"cloudProviderBackoff,omitempty"`
+	CloudProviderBackoffRetries      int               `json:"cloudProviderBackoffRetries,omitempty"`
+	CloudProviderBackoffJitter       float64           `json:"cloudProviderBackoffJitter,omitempty"`
+	CloudProviderBackoffDuration     int               `json:"cloudProviderBackoffDuration,omitempty"`
+	CloudProviderBackoffExponent     float64           `json:"cloudProviderBackoffExponent,omitempty"`
+	CloudProviderRateLimit           bool              `json:"cloudProviderRateLimit,omitempty"`
+	CloudProviderRateLimitQPS        float64           `json:"cloudProviderRateLimitQPS,omitempty"`
+	CloudProviderRateLimitBucket     int               `json:"cloudProviderRateLimitBucket,omitempty"`
+	NonMasqueradeCidr                string            `json:"nonMasqueradeCidr,omitempty"`
+	NodeStatusUpdateFrequency        string            `json:"nodeStatusUpdateFrequency,omitempty"`
+	HardEvictionThreshold            string            `json:"hardEvictionThreshold,omitempty"`
+	CtrlMgrNodeMonitorGracePeriod    string            `json:"ctrlMgrNodeMonitorGracePeriod,omitempty"`
+	CtrlMgrPodEvictionTimeout        string            `json:"ctrlMgrPodEvictionTimeout,omitempty"`
+	CtrlMgrRouteReconciliationPeriod string            `json:"ctrlMgrRouteReconciliationPeriod,omitempty"`
 }
 
 // DcosConfig Configuration for DC/OS

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -195,8 +195,8 @@ func (a *KubernetesAddon) IsEnabled(ifNil bool) bool {
 	return *a.Enabled
 }
 
-// TODO use this when strict JSON accommodates struct embedding
 // CloudProviderConfig contains the KubernetesConfig properties specific to the Cloud Provider
+// TODO use this when strict JSON accommodates struct embedding
 type CloudProviderConfig struct {
 	CloudProviderBackoff         bool    `json:"cloudProviderBackoff,omitempty"`
 	CloudProviderBackoffRetries  int     `json:"cloudProviderBackoffRetries,omitempty"`
@@ -208,8 +208,8 @@ type CloudProviderConfig struct {
 	CloudProviderRateLimitBucket int     `json:"cloudProviderRateLimitBucket,omitempty"`
 }
 
-// TODO use this when strict JSON accommodates struct embedding
 // KubernetesConfigDeprecated are properties that are no longer operable and will be ignored
+// TODO use this when strict JSON accommodates struct embedding
 type KubernetesConfigDeprecated struct {
 	NonMasqueradeCidr                string `json:"nonMasqueradeCidr,omitempty"`
 	NodeStatusUpdateFrequency        string `json:"nodeStatusUpdateFrequency,omitempty"`

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -213,8 +213,8 @@ func (a *KubernetesAddon) IsEnabled(ifNil bool) bool {
 	return *a.Enabled
 }
 
-// TODO use this when strict JSON checking accommodates struct embedding
 // CloudProviderConfig contains the KubernetesConfig parameters specific to the Cloud Provider
+// TODO use this when strict JSON checking accommodates struct embedding
 type CloudProviderConfig struct {
 	CloudProviderBackoff         bool    `json:"cloudProviderBackoff,omitempty"`
 	CloudProviderBackoffRetries  int     `json:"cloudProviderBackoffRetries,omitempty"`

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -213,6 +213,7 @@ func (a *KubernetesAddon) IsEnabled(ifNil bool) bool {
 	return *a.Enabled
 }
 
+// TODO use this when strict JSON checking accommodates struct embedding
 // CloudProviderConfig contains the KubernetesConfig parameters specific to the Cloud Provider
 type CloudProviderConfig struct {
 	CloudProviderBackoff         bool    `json:"cloudProviderBackoff,omitempty"`
@@ -228,14 +229,13 @@ type CloudProviderConfig struct {
 // KubernetesConfig contains the Kubernetes config structure, containing
 // Kubernetes specific configuration
 type KubernetesConfig struct {
-	KubernetesImageBase string `json:"kubernetesImageBase,omitempty"`
-	ClusterSubnet       string `json:"clusterSubnet,omitempty"`
-	DNSServiceIP        string `json:"dnsServiceIP,omitempty"`
-	ServiceCidr         string `json:"serviceCidr,omitempty"`
-	NetworkPolicy       string `json:"networkPolicy,omitempty"`
-	MaxPods             int    `json:"maxPods,omitempty"`
-	DockerBridgeSubnet  string `json:"dockerBridgeSubnet,omitempty"`
-	CloudProviderConfig
+	KubernetesImageBase          string            `json:"kubernetesImageBase,omitempty"`
+	ClusterSubnet                string            `json:"clusterSubnet,omitempty"`
+	DNSServiceIP                 string            `json:"dnsServiceIP,omitempty"`
+	ServiceCidr                  string            `json:"serviceCidr,omitempty"`
+	NetworkPolicy                string            `json:"networkPolicy,omitempty"`
+	MaxPods                      int               `json:"maxPods,omitempty"`
+	DockerBridgeSubnet           string            `json:"dockerBridgeSubnet,omitempty"`
 	UseManagedIdentity           bool              `json:"useManagedIdentity,omitempty"`
 	CustomHyperkubeImage         string            `json:"customHyperkubeImage,omitempty"`
 	DockerEngineVersion          string            `json:"dockerEngineVersion,omitempty"`
@@ -255,6 +255,14 @@ type KubernetesConfig struct {
 	ControllerManagerConfig      map[string]string `json:"controllerManagerConfig,omitempty"`
 	CloudControllerManagerConfig map[string]string `json:"cloudControllerManagerConfig,omitempty"`
 	APIServerConfig              map[string]string `json:"apiServerConfig,omitempty"`
+	CloudProviderBackoff         bool              `json:"cloudProviderBackoff,omitempty"`
+	CloudProviderBackoffRetries  int               `json:"cloudProviderBackoffRetries,omitempty"`
+	CloudProviderBackoffJitter   float64           `json:"cloudProviderBackoffJitter,omitempty"`
+	CloudProviderBackoffDuration int               `json:"cloudProviderBackoffDuration,omitempty"`
+	CloudProviderBackoffExponent float64           `json:"cloudProviderBackoffExponent,omitempty"`
+	CloudProviderRateLimit       bool              `json:"cloudProviderRateLimit,omitempty"`
+	CloudProviderRateLimitQPS    float64           `json:"cloudProviderRateLimitQPS,omitempty"`
+	CloudProviderRateLimitBucket int               `json:"cloudProviderRateLimitBucket,omitempty"`
 }
 
 // DcosConfig Configuration for DC/OS

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -74,19 +74,17 @@ func Test_KubernetesConfig_Validate(t *testing.T) {
 		}
 
 		c = KubernetesConfig{
-			ClusterSubnet:      "10.120.0.0/16",
-			DockerBridgeSubnet: "10.120.1.0/16",
-			MaxPods:            42,
-			CloudProviderConfig: CloudProviderConfig{
-				CloudProviderBackoff:         ValidKubernetesCloudProviderBackoff,
-				CloudProviderBackoffRetries:  ValidKubernetesCloudProviderBackoffRetries,
-				CloudProviderBackoffJitter:   ValidKubernetesCloudProviderBackoffJitter,
-				CloudProviderBackoffDuration: ValidKubernetesCloudProviderBackoffDuration,
-				CloudProviderBackoffExponent: ValidKubernetesCloudProviderBackoffExponent,
-				CloudProviderRateLimit:       ValidKubernetesCloudProviderRateLimit,
-				CloudProviderRateLimitQPS:    ValidKubernetesCloudProviderRateLimitQPS,
-				CloudProviderRateLimitBucket: ValidKubernetesCloudProviderRateLimitBucket,
-			},
+			ClusterSubnet:                "10.120.0.0/16",
+			DockerBridgeSubnet:           "10.120.1.0/16",
+			MaxPods:                      42,
+			CloudProviderBackoff:         ValidKubernetesCloudProviderBackoff,
+			CloudProviderBackoffRetries:  ValidKubernetesCloudProviderBackoffRetries,
+			CloudProviderBackoffJitter:   ValidKubernetesCloudProviderBackoffJitter,
+			CloudProviderBackoffDuration: ValidKubernetesCloudProviderBackoffDuration,
+			CloudProviderBackoffExponent: ValidKubernetesCloudProviderBackoffExponent,
+			CloudProviderRateLimit:       ValidKubernetesCloudProviderRateLimit,
+			CloudProviderRateLimitQPS:    ValidKubernetesCloudProviderRateLimitQPS,
+			CloudProviderRateLimitBucket: ValidKubernetesCloudProviderRateLimitBucket,
 			KubeletConfig: map[string]string{
 				"--node-status-update-frequency": ValidKubernetesNodeStatusUpdateFrequency,
 			},
@@ -253,10 +251,8 @@ func Test_KubernetesConfig_Validate(t *testing.T) {
 	// Tests that apply to pre-1.6 releases
 	for _, k8sVersion := range []string{common.KubernetesVersion1Dot5Dot8} {
 		c := KubernetesConfig{
-			CloudProviderConfig: CloudProviderConfig{
-				CloudProviderBackoff:   true,
-				CloudProviderRateLimit: true,
-			},
+			CloudProviderBackoff:   true,
+			CloudProviderRateLimit: true,
 		}
 		if err := c.Validate(k8sVersion); err == nil {
 			t.Error("should error because backoff and rate limiting are not available before v1.6.6")
@@ -269,10 +265,8 @@ func Test_KubernetesConfig_Validate(t *testing.T) {
 		common.KubernetesVersion1Dot8Dot1, common.KubernetesVersion1Dot8Dot2, common.KubernetesVersion1Dot8Dot4, common.KubernetesVersion1Dot8Dot6,
 		common.KubernetesVersion1Dot9Dot0, common.KubernetesVersion1Dot9Dot1} {
 		c := KubernetesConfig{
-			CloudProviderConfig: CloudProviderConfig{
-				CloudProviderBackoff:   true,
-				CloudProviderRateLimit: true,
-			},
+			CloudProviderBackoff:   true,
+			CloudProviderRateLimit: true,
 		}
 		if err := c.Validate(k8sVersion); err != nil {
 			t.Error("should not error when basic backoff and rate limiting are set to true with no options")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Restores preëxisting properties to `KubernetesConfig` (both `vlabs` and non-versioned apis) to fix JSON validation.

**Special notes for your reviewer**: Long-term we want to evolve our JSON validation to accommodate JSON struct embedded type definitions.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
fix JSON validation for KubernetesConfig
```
