### PR TITLE
add Azure Active Directory Admin Group Object ID flag

### DIFF
--- a/docs/kubernetes/aad.md
+++ b/docs/kubernetes/aad.md
@@ -56,6 +56,16 @@ For example, if your `IssuerUrl` is `https://sts.windows.net/e2917176-1632-47a0-
 kubectl create clusterrolebinding aad-default-group-cluster-admin-binding --clusterrole=cluster-admin --group=7d04bcd3-3c48-49ab-a064-c0b7d69896da
 ```
 
+   Or alternatively you can set the Group `ObjectID` with the `adminGroupID` flag as follows:
+```
+"aadProfile": {
+    "serverAppID": "",
+    "clientAppID": "",
+    "adminGroupID": "7d04bcd3-3c48-49ab-a064-c0b7d69896da"
+}
+```
+The above config would automatically generate a clusterrolebinding with the cluster-admin clusterrole for the specified Group `ObjectID` on cluster deployment.
+
 4. Turn on RBAC on master nodes.
     On master nodes, edit `/etc/kubernetes/manifests/kube-apiserver.yaml`, add `--authorization-mode=RBAC` under `command` property. Reboot nodes.
 5. Now that AAD account will be cluster admin, other accounts can still login but do not have permission for operating the cluster.

--- a/parts/k8s/addons/kubernetesmasteraddons-aad-default-admin-group-rbac.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-aad-default-admin-group-rbac.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aad-default-admin-group
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: "EnsureExists"
+subjects:
+- kind: Group
+  name: "<aadAdminGroupId>"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -206,6 +206,10 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
     sed -i "s|<kubernetesTillerMemoryLimit>|{{WrapAsVariable "kubernetesTillerMemoryLimit"}}|g" "/etc/kubernetes/addons/kube-tiller-deployment.yaml"
 {{end}}
 
+{{if AdminGroupID }}
+    sed -i "s|<aadAdminGroupId>|{{WrapAsVariable "aadAdminGroupId"}}|g" "/etc/kubernetes/addons/aad-default-admin-group-rbac.yaml"
+{{end}}
+
 {{if .OrchestratorProfile.KubernetesConfig.IsACIConnectorEnabled}}
     ACI_CONNECTOR_CREDENTIALS=$(printf "{\"clientId\": \"{{WrapAsVariable "kubernetesACIConnectorClientId"}}\", \"clientSecret\": \"{{WrapAsVariable "kubernetesACIConnectorClientKey"}}\", \"tenantId\": \"{{WrapAsVariable "kubernetesACIConnectorTenantId"}}\", \"subscriptionId\": \"{{WrapAsVariable "kubernetesACIConnectorSubscriptionId"}}\", \"activeDirectoryEndpointUrl\": \"https://login.microsoftonline.com\",\"resourceManagerEndpointUrl\": \"https://management.azure.com/\", \"activeDirectoryGraphResourceId\": \"https://graph.windows.net/\", \"sqlManagementEndpointUrl\": \"https://management.core.windows.net:8443/\", \"galleryEndpointUrl\": \"https://gallery.azure.com/\", \"managementEndpointUrl\": \"https://management.core.windows.net/\"}" | base64 -w 0)
     sed -i "s|<kubernetesACIConnectorSpec>|{{WrapAsVariable "kubernetesACIConnectorSpec"}}|g" "/etc/kubernetes/addons/aci-connector-deployment.yaml"

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -111,6 +111,7 @@
     "sshPublicKeyData": "[parameters('sshRSAPublicKey')]",
 {{if .HasAadProfile}}
     "aadTenantId": "[parameters('aadTenantId')]",
+    "aadAdminGroupId": "[parameters('aadAdminGroupId')]",
 {{end}}
 {{if not IsHostedMaster}}
   {{if GetClassicMode}}

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -6,6 +6,13 @@
       },
       "type": "string"
     },
+    "aadAdminGroupId": {
+      "defaultValue": "",
+      "metadata": {
+        "description": "The AAD default Admin group Object ID used to create a cluster-admin RBAC role."
+      },
+      "type": "string"
+    },
 {{end}}
     "apiServerCertificate": {
       "metadata": {

--- a/pkg/acsengine/addons.go
+++ b/pkg/acsengine/addons.go
@@ -66,6 +66,11 @@ func kubernetesAddonSettingsInit(profile *api.Properties) []kubernetesFeatureSet
 			"calico-daemonset.yaml",
 			profile.OrchestratorProfile.KubernetesConfig.NetworkPolicy == "calico",
 		},
+		{
+			"kubernetesmasteraddons-aad-default-admin-group-rbac.yaml",
+			"aad-default-admin-group-rbac.yaml",
+			profile.AADProfile != nil && profile.AADProfile.AdminGroupID != "",
+		},
 	}
 }
 

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -641,6 +641,9 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 
 		if properties.AADProfile != nil {
 			addValue(parametersMap, "aadTenantId", properties.AADProfile.TenantID)
+			if properties.AADProfile.AdminGroupID != "" {
+				addValue(parametersMap, "aadAdminGroupId", properties.AADProfile.AdminGroupID)
+			}
 		}
 	}
 
@@ -1560,6 +1563,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		},
 		"UseCloudControllerManager": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager != nil && *cs.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager
+		},
+		"AdminGroupID": func() bool {
+			return cs.Properties.AADProfile != nil && cs.Properties.AADProfile.AdminGroupID != ""
 		},
 		"EnableDataEncryptionAtRest": func() bool {
 			return helpers.IsTrueBoolPointer(cs.Properties.OrchestratorProfile.KubernetesConfig.EnableDataEncryptionAtRest)

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -1015,4 +1015,5 @@ func convertAADProfileToVLabs(api *AADProfile, vlabs *vlabs.AADProfile) {
 	vlabs.ClientAppID = api.ClientAppID
 	vlabs.ServerAppID = api.ServerAppID
 	vlabs.TenantID = api.TenantID
+	vlabs.AdminGroupID = api.AdminGroupID
 }

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -1010,6 +1010,7 @@ func convertVLabsAADProfile(vlabs *vlabs.AADProfile, api *AADProfile) {
 	api.ClientAppID = vlabs.ClientAppID
 	api.ServerAppID = vlabs.ServerAppID
 	api.TenantID = vlabs.TenantID
+	api.AdminGroupID = vlabs.AdminGroupID
 }
 
 func addDCOSPublicAgentPool(api *Properties) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -424,6 +424,10 @@ type AADProfile struct {
 	// If not specified, will use the tenant of the deployment subscription.
 	// Optional
 	TenantID string `json:"tenantID,omitempty"`
+	// The Azure Active Directory Group Object ID that will be assigned the
+	// cluster-admin RBAC role.
+	// Optional
+	AdminGroupID string `json:"adminGroupID,omitempty"`
 }
 
 // CustomProfile specifies custom properties that are used for

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -358,6 +358,10 @@ type AADProfile struct {
 	// If not specified, will use the tenant of the deployment subscription.
 	// Optional
 	TenantID string `json:"tenantID,omitempty"`
+	// The Azure Active Directory Group Object ID that will be assigned the
+	// cluster-admin RBAC role.
+	// Optional
+	AdminGroupID string `json:"adminGroupID,omitempty"`
 }
 
 // KeyVaultSecrets specifies certificates to install on the pool

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -305,6 +305,11 @@ func (profile *AADProfile) Validate() error {
 			return fmt.Errorf("tenantID '%v' is invalid", profile.TenantID)
 		}
 	}
+	if len(profile.AdminGroupID) > 0 {
+		if _, err := uuid.FromString(profile.AdminGroupID); err != nil {
+			return fmt.Errorf("adminGroupID '%v' is invalid", profile.AdminGroupID)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION

**What this PR does / why we need it**:
When using AADProfile with RBAC, you currently need to manually create an RBAC role to grant either an AAD User or Group cluster-admin privileges. 
This PR adds an `adminGroupID` flag to specify an AAD Group `Object ID`; with this, the required rbac bindings would be generated for Group `Object ID` and applied to the cluster on deployment. 
