### PR TITLE
Remove SecurityContextDeny setting in API server admission control.

### DIFF
--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -82,7 +82,7 @@ func setAPIServerConfig(cs *api.ContainerService) {
 
 	// Default apiserver config
 	defaultAPIServerConfig := map[string]string{
-		"--admission-control":  "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,DenyEscalatingExec,AlwaysPullImages,SecurityContextDeny",
+		"--admission-control":  "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,DenyEscalatingExec,AlwaysPullImages",
 		"--authorization-mode": "Node",
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**: Remove SecurityContextDeny setting in API server admission control since it introduces friction for users to apply workloads with security requirement. This issue should be addressed later by adopting a default allow-all Pod Security Policy, see issue #2123.

**Which issue this PR fixes**: #2109 
