### PR TITLE
--authorization-mode=Node only if secure kubelet

### DIFF
--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -88,11 +88,11 @@ func setAPIServerConfig(cs *api.ContainerService) {
 
 	// RBAC configuration
 	if helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableRbac) {
-		defaultAPIServerConfig["--authorization-mode"] = "RBAC"
-		if isKubernetesVersionGe(o.OrchestratorVersion, "1.7.0") {
-			defaultAPIServerConfig["--authorization-mode"] = "Node,RBAC"
+		defaultAPIServerConfig["--authorization-mode"] = "Node,RBAC"
+		if !isKubernetesVersionGe(o.OrchestratorVersion, "1.7.0") || !helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableSecureKubelet) {
+			defaultAPIServerConfig["--authorization-mode"] = "RBAC"
 		}
-	} else if !isKubernetesVersionGe(o.OrchestratorVersion, "1.7.0") {
+	} else if !isKubernetesVersionGe(o.OrchestratorVersion, "1.7.0") || !helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableSecureKubelet) {
 		// remove authorization-mode for 1.6 clusters without RBAC since Node authorization isn't supported
 		for _, key := range []string{"--authorization-mode"} {
 			delete(defaultAPIServerConfig, key)

--- a/pkg/acsengine/defaults-apiserver_test.go
+++ b/pkg/acsengine/defaults-apiserver_test.go
@@ -221,7 +221,7 @@ func TestAPIServerConfigEnableSecureKubelet(t *testing.T) {
 
 	// Test EnableSecureKubelet = false
 	cs = createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
-	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableDataEncryptionAtRest = pointerToBool(false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = pointerToBool(false)
 	setAPIServerConfig(cs)
 	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
 	for _, key := range []string{"--kubelet-client-certificate", "--kubelet-client-key"} {
@@ -274,7 +274,21 @@ func createContainerService(containerServiceName string, orchestratorVersion str
 	cs.Properties.OrchestratorProfile = &api.OrchestratorProfile{}
 	cs.Properties.OrchestratorProfile.OrchestratorType = api.Kubernetes
 	cs.Properties.OrchestratorProfile.OrchestratorVersion = orchestratorVersion
-	cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{}
+	cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{
+		EnableSecureKubelet: pointerToBool(api.DefaultSecureKubeletEnabled),
+		EnableRbac:          pointerToBool(api.DefaultRBACEnabled),
+		EtcdDiskSizeGB:      DefaultEtcdDiskSize,
+		ServiceCIDR:         DefaultKubernetesServiceCIDR,
+		DockerBridgeSubnet:  DefaultDockerBridgeSubnet,
+		DNSServiceIP:        DefaultKubernetesDNSServiceIP,
+		GCLowThreshold:      DefaultKubernetesGCLowThreshold,
+		GCHighThreshold:     DefaultKubernetesGCHighThreshold,
+		MaxPods:             DefaultKubernetesMaxPodsVNETIntegrated,
+		ClusterSubnet:       DefaultKubernetesSubnet,
+		ContainerRuntime:    DefaultContainerRuntime,
+		NetworkPolicy:       DefaultNetworkPolicy,
+		EtcdVersion:         DefaultEtcdVersion,
+	}
 
 	cs.Properties.CertificateProfile = &api.CertificateProfile{}
 	cs.Properties.CertificateProfile.CaCertificate = "cacert"

--- a/pkg/acsengine/defaults-kubelet_test.go
+++ b/pkg/acsengine/defaults-kubelet_test.go
@@ -86,7 +86,7 @@ func TestKubeletConfigEnableSecureKubelet(t *testing.T) {
 
 	// Test EnableSecureKubelet = false
 	cs = createContainerService("testcluster", common.KubernetesVersion1Dot7Dot12, 3, 2)
-	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = "azure"
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = pointerToBool(false)
 	setKubeletConfig(cs)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
 	for _, key := range []string{"--anonymous-auth", "--authorization-mode", "--client-ca-file"} {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: If we turn off secure kublet communications, we need to not set `--authorization-mode` in the API server.

Also cleaned up related unit tests

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
--authorization-mode=Node only if secure kubelet
```