### PR TITLE
Enable iptables forward for kubernetes

### DIFF
--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -91,7 +91,7 @@ write_files:
 {{if .IsCoreOS}}
     ExecStartPre=/bin/mv /tmp/kubectldir/hyperkube /opt/kubectl
     ExecStart=/bin/chmod a+x /opt/kubectl
-{{else}}    
+{{else}}
     ExecStartPre=/bin/mv /tmp/kubectldir/hyperkube /usr/local/bin/kubectl
     ExecStart=/bin/chmod a+x /usr/local/bin/kubectl
 {{end}}
@@ -158,20 +158,20 @@ coreos:
       command: "start"
       content: |
         # Note: Initiated as a service since there is no runcmd within CoreOS on cloud-config/Ignition
-        [Unit] 
+        [Unit]
         Description=Start provision setup service
 
         [Service]
         ExecStart=/opt/azure/containers/provision-setup.sh
 {{else}}
 runcmd:
-- echo `date`,`hostname`, startruncmd>>/opt/m 
+- echo `date`,`hostname`, startruncmd>>/opt/m
 - apt-mark hold walinuxagent{{GetKubernetesAgentPreprovisionYaml .}}
-- echo `date`,`hostname`, preaptupdate>>/opt/m 
+- echo `date`,`hostname`, preaptupdate>>/opt/m
 - apt-get update
-- echo `date`,`hostname`, postaptupdate>>/opt/m 
+- echo `date`,`hostname`, postaptupdate>>/opt/m
 - apt-get install -y apt-transport-https ca-certificates nfs-common
-- echo `date`,`hostname`, aptinstall>>/opt/m 
+- echo `date`,`hostname`, aptinstall>>/opt/m
 - systemctl enable rpcbind
 - systemctl enable rpc-statd
 - systemctl start rpcbind
@@ -183,6 +183,8 @@ runcmd:
 - apt-get update
 - apt-get install -y ebtables
 - apt-get install -y docker-engine
+- echo "ExecStartPost=/sbin/iptables -P FORWARD ACCEPT" >> /etc/systemd/system/docker.service.d/exec_start.conf
+- systemctl daemon-reload
 - echo `date`,`hostname`, postdockerinstall>>/opt/m
 - systemctl restart docker
 - mkdir -p /etc/kubernetes/manifests
@@ -193,5 +195,5 @@ runcmd:
 - echo `date`,`hostname`, POST-APT-SYSTEMD-DAILY>>/opt/m
 - apt-mark unhold walinuxagent
 - mkdir -p /opt/azure/containers && touch /opt/azure/containers/runcmd.complete
-- echo `date`,`hostname`, endruncmd>>/opt/m 
+- echo `date`,`hostname`, endruncmd>>/opt/m
 {{end}}

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -374,6 +374,8 @@ runcmd:
 - retrycmd_if_failure apt-get update
 - retrycmd_if_failure apt-get install -y ebtables
 - retrycmd_if_failure apt-get install -y docker-engine
+- echo "ExecStartPost=/sbin/iptables -P FORWARD ACCEPT" >> /etc/systemd/system/docker.service.d/exec_start.conf
+- systemctl daemon-reload
 - systemctl restart docker
 - mkdir -p /etc/kubernetes/manifests
 - usermod -aG docker {{WrapAsVariable "username"}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

For docker version >=1.13, docker changes FORWARD to DROP by default. It could cause kube-dns fail to start normally.

This PR enable iptables forward for kubernetes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2100

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
