### PR TITLE
Add regression tests for 3 masters & 5 masters

### DIFF
--- a/examples/multiple-masters/kubernetes-3-masters.json
+++ b/examples/multiple-masters/kubernetes-3-masters.json
@@ -1,0 +1,35 @@
+{
+    "apiVersion": "vlabs",
+    "properties": {
+        "orchestratorProfile": {
+            "orchestratorType": "Kubernetes"
+        },
+        "masterProfile": {
+            "count": 3,
+            "dnsPrefix": "",
+            "vmSize": "Standard_D2_v2"
+        },
+        "agentPoolProfiles": [
+            {
+                "name": "agent",
+                "count": 3,
+                "vmSize": "Standard_D2_v2",
+                "availabilityProfile": "AvailabilitySet"
+            }
+        ],
+        "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "keyData": ""
+                    }
+                ]
+            }
+        },
+        "servicePrincipalProfile": {
+            "clientId": "",
+            "secret": ""
+        }
+    }
+}

--- a/examples/multiple-masters/kubernetes-5-masters.json
+++ b/examples/multiple-masters/kubernetes-5-masters.json
@@ -1,0 +1,35 @@
+{
+    "apiVersion": "vlabs",
+    "properties": {
+        "orchestratorProfile": {
+            "orchestratorType": "Kubernetes"
+        },
+        "masterProfile": {
+            "count": 5,
+            "dnsPrefix": "",
+            "vmSize": "Standard_D2_v2"
+        },
+        "agentPoolProfiles": [
+            {
+                "name": "agent",
+                "count": 3,
+                "vmSize": "Standard_D2_v2",
+                "availabilityProfile": "AvailabilitySet"
+            }
+        ],
+        "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "keyData": ""
+                    }
+                ]
+            }
+        },
+        "servicePrincipalProfile": {
+            "clientId": "",
+            "secret": ""
+        }
+    }
+}

--- a/test/acse-conf/acse-regression.json
+++ b/test/acse-conf/acse-regression.json
@@ -85,10 +85,10 @@
       "cluster_definition": "multiple-masters/kubernetes-3-masters.json",
       "category": "multimaster"
     },
-        {
-          "cluster_definition": "multiple-masters/kubernetes-5-masters.json",
-          "category": "multimaster"
-        },
+    {
+      "cluster_definition": "multiple-masters/kubernetes-5-masters.json",
+      "category": "multimaster"
+    },
     {
       "cluster_definition": "v20170131/swarmmode.json",
       "category": "version"

--- a/test/acse-conf/acse-regression.json
+++ b/test/acse-conf/acse-regression.json
@@ -28,9 +28,9 @@
       "cluster_definition": "disks-managed/kubernetes-vmas.json",
       "category": "managed-disk"
     },
-    { 
-      "cluster_definition": "disks-managed/swarm-preAttachedDisks-vmss.json", 
-      "category": "managed-disk" 
+    {
+      "cluster_definition": "disks-managed/swarm-preAttachedDisks-vmss.json",
+      "category": "managed-disk"
     },
     {
       "cluster_definition": "disks-managed/swarmmode-vmas.json",
@@ -81,6 +81,14 @@
       "cluster_definition": "kubernetes-config/kubernetes-rescheduler.json",
       "category": "config"
     },
+    {
+      "cluster_definition": "multiple-masters/kubernetes-3-masters.json",
+      "category": "multimaster"
+    },
+        {
+          "cluster_definition": "multiple-masters/kubernetes-5-masters.json",
+          "category": "multimaster"
+        },
     {
       "cluster_definition": "v20170131/swarmmode.json",
       "category": "version"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Adds two cluster definitions to regression tests: 3 masters k8s and 5 masters k8s. Useful for catching regressions on upgrade, etcd tls and other features that have a sync between masters.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
