### PR TITLE
Mount in /var/lib/cni from the host.

### DIFF
--- a/parts/k8s/artifacts/kuberneteskubelet.service
+++ b/parts/k8s/artifacts/kuberneteskubelet.service
@@ -9,6 +9,7 @@ EnvironmentFile=/etc/default/kubelet
 SuccessExitStatus=143
 ExecStartPre=/bin/bash /opt/azure/containers/kubelet.sh
 ExecStartPre=/bin/mkdir -p /var/lib/kubelet
+ExecStartPre=/bin/mkdir -p /var/lib/cni
 ExecStartPre=/bin/bash -c "if [ $(mount | grep \"/var/lib/kubelet\" | wc -l) -le 0 ] ; then /bin/mount --bind /var/lib/kubelet /var/lib/kubelet ; fi"
 ExecStartPre=/bin/mount --make-shared /var/lib/kubelet
 # This is a partial workaround to this upstream Kubernetes issue:
@@ -24,6 +25,7 @@ ExecStart=/usr/bin/docker run \
   --volume=/dev:/dev \
   --volume=/sys:/sys:ro \
   --volume=/var/run:/var/run:rw \
+  --volume=/var/lib/cni/:/var/lib/cni:rw \
   --volume=/var/lib/docker/:/var/lib/docker:rw \
   --volume=/var/lib/containers/:/var/lib/containers:rw \
   --volume=/var/lib/kubelet/:/var/lib/kubelet:shared \


### PR DESCRIPTION
**What this PR does / why we need it**:
Without this PR on kubelet restart /var/lib/cni is recreated, this causes kubenet to lose its database and may cause it to hand out duplicate IP addresses.

