### PR TITLE
E2E - use all regions for retries

### DIFF
--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -35,6 +35,8 @@ const (
 	swarmOrchestrator      = "swarm"
 )
 
+var defaultRegions = []string{"eastus", "southcentralus", "westcentralus", "southeastasia", "westus2", "westeurope"}
+
 // ParseConfig will parse needed environment variables for running the tests
 func ParseConfig() (*Config, error) {
 	c := new(Config)
@@ -43,6 +45,12 @@ func ParseConfig() (*Config, error) {
 	}
 	if c.Location == "" {
 		c.ShuffleRegions()
+	} else {
+		regions := make([]string, len(defaultRegions))
+		for i := 0; i < len(regions); i++ {
+			regions[i] = c.Location
+		}
+		c.Regions = regions
 	}
 	return c, nil
 }
@@ -139,7 +147,7 @@ func (c *Config) IsSwarm() bool {
 func (c *Config) ShuffleRegions() {
 	var regions []string
 	if c.Regions == nil {
-		regions = []string{"eastus", "southcentralus", "westcentralus", "southeastasia", "westus2", "westeurope"}
+		regions = defaultRegions
 	} else {
 		regions = c.Regions
 	}

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -143,7 +143,8 @@ func (c *Config) ShuffleRegions() {
 	} else {
 		regions = c.Regions
 	}
-	perm := rand.Perm(len(regions))
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	perm := r.Perm(len(regions))
 	shuffled := make([]string, len(perm))
 	for i, v := range perm {
 		shuffled[v] = regions[i]

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -45,6 +45,9 @@ func ParseConfig() (*Config, error) {
 	}
 	if c.Location == "" {
 		c.ShuffleRegions()
+		if c.Orchestrator == dcosOrchestrator {
+			c.Location = c.Regions[0]
+		}
 	} else {
 		regions := make([]string, len(defaultRegions))
 		for i := 0; i < len(regions); i++ {
@@ -149,6 +152,9 @@ func (c *Config) ShuffleRegions() {
 	if c.Regions == nil {
 		regions = defaultRegions
 	} else {
+		if len(c.Regions) < 1 {
+			log.Fatalf("no regions specified")
+		}
 		regions = c.Regions
 	}
 	r := rand.New(rand.NewSource(time.Now().Unix()))

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -42,22 +42,22 @@ func ParseConfig() (*Config, error) {
 		return nil, err
 	}
 	if c.Location == "" {
-		c.SetRandomRegion()
+		c.ShuffleRegions()
 	}
 	return c, nil
 }
 
-// GetKubeConfig returns the absolute path to the kubeconfig for c.Location
-func (c *Config) GetKubeConfig() string {
-	file := fmt.Sprintf("kubeconfig.%s.json", c.Location)
+// GetKubeConfig returns the absolute path to the kubeconfig for location
+func (c *Config) GetKubeConfig(location string) string {
+	file := fmt.Sprintf("kubeconfig.%s.json", location)
 	kubeconfig := filepath.Join(c.CurrentWorkingDir, "_output", c.Name, "kubeconfig", file)
 	return kubeconfig
 }
 
 // SetKubeConfig will set the KUBECONIFG env var
-func (c *Config) SetKubeConfig() {
-	os.Setenv("KUBECONFIG", c.GetKubeConfig())
-	log.Printf("\nKubeconfig:%s\n", c.GetKubeConfig())
+func (c *Config) SetKubeConfig(location string) {
+	os.Setenv("KUBECONFIG", c.GetKubeConfig(location))
+	log.Printf("\nKubeconfig:%s\n", c.GetKubeConfig(location))
 }
 
 // GetSSHKeyPath will return the absolute path to the ssh private key
@@ -135,17 +135,17 @@ func (c *Config) IsSwarm() bool {
 	return false
 }
 
-// SetRandomRegion sets Location to a random region
-func (c *Config) SetRandomRegion() {
-	var regions []string
+// ShuffleRegions shuffles the order of the Regions slice
+func (c *Config) ShuffleRegions() {
+	var regions, shuffled []string
 	if c.Regions == nil {
 		regions = []string{"eastus", "southcentralus", "westcentralus", "southeastasia", "westus2", "westeurope"}
 	} else {
 		regions = c.Regions
 	}
-	log.Printf("Picking Random Region from list %s\n", regions)
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	c.Location = regions[r.Intn(len(regions))]
-	os.Setenv("LOCATION", c.Location)
-	log.Printf("Picked Random Region:%s\n", c.Location)
+	perm := rand.Perm(len(regions))
+	for i, v := range perm {
+		shuffled[v] = regions[i]
+	}
+	c.Regions = shuffled
 }

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -137,13 +137,14 @@ func (c *Config) IsSwarm() bool {
 
 // ShuffleRegions shuffles the order of the Regions slice
 func (c *Config) ShuffleRegions() {
-	var regions, shuffled []string
+	var regions []string
 	if c.Regions == nil {
 		regions = []string{"eastus", "southcentralus", "westcentralus", "southeastasia", "westus2", "westeurope"}
 	} else {
 		regions = c.Regions
 	}
 	perm := rand.Perm(len(regions))
+	shuffled := make([]string, len(perm))
 	for i, v := range perm {
 		shuffled[v] = regions[i]
 	}

--- a/test/e2e/dcos/dcos.go
+++ b/test/e2e/dcos/dcos.go
@@ -114,7 +114,8 @@ type UnreachableStrategy struct {
 
 // NewCluster returns a new cluster struct
 func NewCluster(cfg *config.Config, eng *engine.Engine) (*Cluster, error) {
-	conn, err := remote.NewConnection(fmt.Sprintf("%s.%s.cloudapp.azure.com", cfg.Name, cfg.Location), "2200", eng.ClusterDefinition.Properties.LinuxProfile.AdminUsername, cfg.GetSSHKeyPath())
+	hostname := fmt.Sprintf("%s.%s.cloudapp.azure.com", cfg.Name, cfg.Location)
+	conn, err := remote.NewConnection(hostname, "2200", eng.ClusterDefinition.Properties.LinuxProfile.AdminUsername, cfg.GetSSHKeyPath())
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/dcos/dcos.go
+++ b/test/e2e/dcos/dcos.go
@@ -113,14 +113,14 @@ type UnreachableStrategy struct {
 }
 
 // NewCluster returns a new cluster struct
-func NewCluster(cfg *config.Config, eng *engine.Engine, location string) (*Cluster, error) {
-	conn, err := remote.NewConnection(fmt.Sprintf("%s.%s.cloudapp.azure.com", cfg.Name, location), "2200", eng.ClusterDefinition.Properties.LinuxProfile.AdminUsername, cfg.GetSSHKeyPath())
+func NewCluster(cfg *config.Config, eng *engine.Engine) (*Cluster, error) {
+	conn, err := remote.NewConnection(fmt.Sprintf("%s.%s.cloudapp.azure.com", cfg.Name, cfg.Location), "2200", eng.ClusterDefinition.Properties.LinuxProfile.AdminUsername, cfg.GetSSHKeyPath())
 	if err != nil {
 		return nil, err
 	}
 	return &Cluster{
 		AdminUsername: eng.ClusterDefinition.Properties.LinuxProfile.AdminUsername,
-		AgentFQDN:     fmt.Sprintf("%s-0.%s.cloudapp.azure.com", cfg.Name, location),
+		AgentFQDN:     fmt.Sprintf("%s-0.%s.cloudapp.azure.com", cfg.Name, cfg.Location),
 		Connection:    conn,
 	}, nil
 }

--- a/test/e2e/dcos/dcos.go
+++ b/test/e2e/dcos/dcos.go
@@ -113,14 +113,14 @@ type UnreachableStrategy struct {
 }
 
 // NewCluster returns a new cluster struct
-func NewCluster(cfg *config.Config, eng *engine.Engine) (*Cluster, error) {
-	conn, err := remote.NewConnection(fmt.Sprintf("%s.%s.cloudapp.azure.com", cfg.Name, cfg.Location), "2200", eng.ClusterDefinition.Properties.LinuxProfile.AdminUsername, cfg.GetSSHKeyPath())
+func NewCluster(cfg *config.Config, eng *engine.Engine, location string) (*Cluster, error) {
+	conn, err := remote.NewConnection(fmt.Sprintf("%s.%s.cloudapp.azure.com", cfg.Name, location), "2200", eng.ClusterDefinition.Properties.LinuxProfile.AdminUsername, cfg.GetSSHKeyPath())
 	if err != nil {
 		return nil, err
 	}
 	return &Cluster{
 		AdminUsername: eng.ClusterDefinition.Properties.LinuxProfile.AdminUsername,
-		AgentFQDN:     fmt.Sprintf("%s-0.%s.cloudapp.azure.com", cfg.Name, cfg.Location),
+		AgentFQDN:     fmt.Sprintf("%s-0.%s.cloudapp.azure.com", cfg.Name, location),
 		Connection:    conn,
 	}, nil
 }

--- a/test/e2e/metrics/metrics.go
+++ b/test/e2e/metrics/metrics.go
@@ -153,6 +153,11 @@ func (p *Point) SetProvisionMetrics(data []byte) {
 
 }
 
+// SetLocation will set ProvisionStart value to time.Now()
+func (p *Point) SetLocation(location string) {
+	p.Tags["location"] = location
+}
+
 func (p *Point) Write() {
 	cfg, err := ParseConfig()
 	if err == nil {

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -69,7 +69,7 @@ func main() {
 		}
 	} else {
 		engCfg, err := engine.ParseConfig(cfg.CurrentWorkingDir, cfg.ClusterDefinition, cfg.Name)
-		cfg.SetKubeConfig()
+		cfg.SetKubeConfig(cfg.Location)
 		if err != nil {
 			teardown()
 			log.Fatalf("Error trying to parse Engine config:%s\n", err)

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -190,7 +190,7 @@ func (cli *CLIProvisioner) waitForNodes(location string) error {
 		log.Printf("SSH Key: %s\n", cli.Config.GetSSHKeyPath())
 		log.Printf("Master Node: %s@%s\n", user, host)
 		log.Printf("SSH Command: ssh -i %s -p 2200 %s@%s", cli.Config.GetSSHKeyPath(), user, host)
-		cluster, err := dcos.NewCluster(cli.Config, cli.Engine)
+		cluster, err := dcos.NewCluster(cli.Config, cli.Engine, location)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -54,7 +54,7 @@ func BuildCLIProvisioner(cfg *config.Config, acct *azure.Account, pt *metrics.Po
 func (cli *CLIProvisioner) Run() error {
 	rgs := make([]string, 0)
 	for i := 1; i <= cli.ProvisionRetries; i++ {
-		location := cli.Config.Regions[i]
+		location := cli.Config.Regions[i-1]
 		cli.Point.SetLocation(location)
 		cli.Point.SetProvisionStart()
 		err := cli.provision(location)

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -190,7 +190,8 @@ func (cli *CLIProvisioner) waitForNodes(location string) error {
 		log.Printf("SSH Key: %s\n", cli.Config.GetSSHKeyPath())
 		log.Printf("Master Node: %s@%s\n", user, host)
 		log.Printf("SSH Command: ssh -i %s -p 2200 %s@%s", cli.Config.GetSSHKeyPath(), user, host)
-		cluster, err := dcos.NewCluster(cli.Config, cli.Engine, location)
+		cli.Config.Location = location
+		cluster, err := dcos.NewCluster(cli.Config, cli.Engine)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: When one regional deployment fails, try another (using the configured "Regions" array). Previous behavior was to randomize to a particular region, and then to pin to that region for retries as well.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
