### PR TITLE
validation error if custom VNET + Windows

### DIFF
--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -819,6 +819,9 @@ func validateVNET(a *Properties) error {
 		}
 	}
 	if isCustomVNET {
+		if a.HasWindows() {
+			return fmt.Errorf("custom VNET not yet supported with Windows-enabled clusters")
+		}
 		subscription, resourcegroup, vnetname, _, e := GetVNETSubnetIDComponents(a.MasterProfile.VnetSubnetID)
 		if e != nil {
 			return e


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: We should throw a validation error if the api model input for generation declares custom VNET + Windows agent pool(s).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
validation error if custom VNET + Windows
```