### PR TITLE
update prometheus-grafana addon

### DIFF
--- a/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml
@@ -17,7 +17,7 @@ alertmanager:
   ##
   image:
     repository: prom/alertmanager
-    tag: v0.9.1
+    tag: v0.13.0
     pullPolicy: IfNotPresent
 
   ## Additional alertmanager container arguments
@@ -163,7 +163,7 @@ configmapReload:
   ##
   image:
     repository: jimmidyson/configmap-reload
-    tag: v0.1
+    tag: v0.2.2
     pullPolicy: IfNotPresent
 
   ## configmap-reload resource requests and limits
@@ -187,7 +187,7 @@ kubeStateMetrics:
   ##
   image:
     repository: k8s-gcrio.azureedge.net/kube-state-metrics
-    tag: v1.1.0-rc.0
+    tag: v1.2.0
     pullPolicy: IfNotPresent
 
   ## Node labels for kube-state-metrics pod assignment
@@ -245,7 +245,7 @@ nodeExporter:
   ##
   image:
     repository: prom/node-exporter
-    tag: v0.15.0
+    tag: v0.15.2
     pullPolicy: IfNotPresent
 
   ## Custom Update Strategy
@@ -324,7 +324,7 @@ server:
   ##
   image:
     repository: prom/prometheus
-    tag: v1.8.1
+    tag: v2.1.0
     pullPolicy: IfNotPresent
 
   ## (optional) alertmanager URL


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the prometheus-grafana-addon

Some parts of the addon install already gets the latest images which means they depend on prometheus 2.x.
Currently it is in a broken state because of this with the following error
`level=error msg="flag provided but not defined: -storage.tsdb.path" source="main.go:74"`
So lets just bump to 2.x and have this working again.

To support 1.9.0 we need a new version fo kube-state-metrics. (v1.2.0)