### PR TITLE
add default audit policy

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -293,6 +293,9 @@ Below is a list of apiserver options that acs-engine will configure by default:
 |---|---|
 |"--admission-control"|"NamespaceLifecycle, LimitRanger, ServiceAccount, DefaultStorageClass, ResourceQuota, DenyEscalatingExec, AlwaysPullImages, SecurityContextDeny"|
 |"--authorization-mode"|"Node", "RBAC" (*the latter if enabledRbac is true*)|
+|"--audit-log-maxage"|"30"|
+|"--audit-log-maxbackup"|"10"|
+|"--audit-log-maxsize"|"100"|
 |"--feature-gates"|No default (can be a comma-separated list)|
 
 
@@ -304,9 +307,6 @@ Below is a list of apiserver options that are *not* currently user-configurable,
 |"--advertise-address"|*calculated value that represents listening URI for API server*|
 |"--allow-privileged"|"true"|
 |"--anonymous-auth"|"false|
-|"--audit-log-maxage"|"30"|
-|"--audit-log-maxbackup"|"10"|
-|"--audit-log-maxsize"|"100"|
 |"--audit-log-path"|"/var/log/apiserver/audit.log"|
 |"--insecure-port"|"8080"|
 |"--secure-port"|"443"|

--- a/parts/k8s/manifests/kubernetesmaster-audit-policy.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-audit-policy.yaml
@@ -1,0 +1,62 @@
+apiVersion: audit.k8s.io/v1beta1 # This is required.
+kind: Policy
+# Don't generate audit events for all requests in RequestReceived stage.
+omitStages:
+  - "RequestReceived"
+rules:
+  # Log pod changes at RequestResponse level
+  - level: RequestResponse
+    resources:
+    - group: ""
+      # Resource "pods" doesn't match requests to any subresource of pods,
+      # which is consistent with the RBAC policy.
+      resources: ["pods"]
+
+  # Log "pods/log", "pods/status" at Metadata level
+  - level: Metadata
+    resources:
+    - group: ""
+      resources: ["pods/log", "pods/status"]
+
+  # Don't log watch requests by the "system:kube-proxy" on endpoints or services
+  - level: None
+    users: ["system:kube-proxy"]
+    verbs: ["watch"]
+    resources:
+    - group: "" # core API group
+      resources: ["endpoints", "services"]
+
+  # Don't log authenticated requests to certain non-resource URL paths.
+  - level: None
+    userGroups: ["system:authenticated"]
+    nonResourceURLs:
+    - "/api*" # Wildcard matching.
+    - "/version"
+
+  # Log the request body of configmap changes in kube-system.
+  - level: Request
+    resources:
+    - group: "" # core API group
+      resources: ["configmaps"]
+    # This rule only applies to resources in the "kube-system" namespace.
+    # The empty string "" can be used to select non-namespaced resources.
+    namespaces: ["kube-system"]
+
+  # Log  the request body of secret changes.
+  - level: Request
+    resources:
+    - group: "" # core API group
+      resources: ["secrets"]
+
+  # Log all other resources in core and extensions at the Request level.
+  - level: Request
+    resources:
+    - group: "" # core API group
+    - group: "extensions" # Version of group should NOT be included.
+
+  # A catch-all rule to log all other requests at the Metadata level.
+  - level: Metadata
+    # Long-running requests like watches that fall under this rule will not
+    # generate an audit event in RequestReceived.
+    omitStages:
+      - "RequestReceived"

--- a/pkg/acsengine/addons.go
+++ b/pkg/acsengine/addons.go
@@ -97,6 +97,11 @@ func kubernetesManifestSettingsInit(profile *api.Properties) []kubernetesFeature
 			helpers.IsTrueBoolPointer(profile.OrchestratorProfile.KubernetesConfig.EnablePodSecurityPolicy),
 		},
 		{
+			"kubernetesmaster-audit-policy.yaml",
+			"audit-policy.yaml",
+			isKubernetesVersionGe(profile.OrchestratorProfile.OrchestratorVersion, "1.8.0"),
+		},
+		{
 			"kubernetesmaster-kube-apiserver.yaml",
 			"kube-apiserver.yaml",
 			true,

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -14,9 +14,6 @@ func setAPIServerConfig(cs *api.ContainerService) {
 		"--advertise-address":          "<kubernetesAPIServerIP>",
 		"--allow-privileged":           "true",
 		"--anonymous-auth":             "false",
-		"--audit-log-maxage":           "30",
-		"--audit-log-maxbackup":        "10",
-		"--audit-log-maxsize":          "100",
 		"--audit-log-path":             "/var/log/audit.log",
 		"--insecure-port":              "8080",
 		"--secure-port":                "443",
@@ -87,8 +84,11 @@ func setAPIServerConfig(cs *api.ContainerService) {
 
 	// Default apiserver config
 	defaultAPIServerConfig := map[string]string{
-		"--admission-control":  "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,DenyEscalatingExec,AlwaysPullImages",
-		"--authorization-mode": "Node",
+		"--admission-control":   "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,DenyEscalatingExec,AlwaysPullImages",
+		"--authorization-mode":  "Node",
+		"--audit-log-maxage":    "30",
+		"--audit-log-maxbackup": "10",
+		"--audit-log-maxsize":   "100",
 	}
 
 	// RBAC configuration

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -17,7 +17,7 @@ func setAPIServerConfig(cs *api.ContainerService) {
 		"--audit-log-maxage":           "30",
 		"--audit-log-maxbackup":        "10",
 		"--audit-log-maxsize":          "100",
-		"--audit-log-path":             "/var/log/apiserver/audit.log",
+		"--audit-log-path":             "/var/log/audit.log",
 		"--insecure-port":              "8080",
 		"--secure-port":                "443",
 		"--service-account-lookup":     "true",
@@ -71,6 +71,11 @@ func setAPIServerConfig(cs *api.ContainerService) {
 			issuerHost = "sts.chinacloudapi.cn"
 		}
 		staticLinuxAPIServerConfig["--oidc-issuer-url"] = "https://" + issuerHost + "/" + cs.Properties.AADProfile.TenantID + "/"
+	}
+
+	// Audit Policy configuration
+	if isKubernetesVersionGe(o.OrchestratorVersion, "1.8.0") {
+		staticLinuxAPIServerConfig["--audit-policy-file"] = "/etc/kubernetes/manifests/audit-policy.yaml"
 	}
 
 	staticWindowsAPIServerConfig := make(map[string]string)


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR adds a default audit policy to enable advanced audit logging as described here: 
https://kubernetes.io/docs/tasks/debug-application-cluster/audit/
