### PR TITLE
pulling down provision logs during e2e runs

### DIFF
--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -363,7 +363,7 @@ runcmd:
 - retrycmd_if_failure curl --cacert /etc/kubernetes/certs/ca.crt --cert /etc/kubernetes/certs/etcdclient.crt --key /etc/kubernetes/certs/etcdclient.key --retry 5 --retry-delay 10 --retry-max-time 30 --max-time 60 "{{WrapAsVerbatim "variables('masterEtcdClientURLs')[copyIndex(variables('masterOffset'))]"}}"/v2/machines
 - retrycmd_if_failure apt-get update
 - retrycmd_if_failure apt-get install -y apt-transport-https ca-certificates
-- retrycmd_if_failure curl --retry 5 --retry-delay 10 --retry-max-time 30 --max-time 60 -fsSL https://aptdocker.azureedge.net/gpg | apt-key add -
+- curl --retry 5 --retry-delay 10 --retry-max-time 30 --max-time 60 -fsSL https://aptdocker.azureedge.net/gpg | apt-key add -
 - echo "deb {{WrapAsVariable "dockerEngineDownloadRepo"}} ubuntu-xenial main" | sudo tee /etc/apt/sources.list.d/docker.list
 - "echo \"Package: docker-engine\nPin: version {{WrapAsVariable "dockerEngineVersion"}}\nPin-Priority: 550\n\" > /etc/apt/preferences.d/docker.pref"
 - retrycmd_if_failure apt-get update

--- a/parts/k8s/kubernetesmastercustomscript.sh
+++ b/parts/k8s/kubernetesmastercustomscript.sh
@@ -720,3 +720,4 @@ fi
 echo `date`,`hostname`, endscript>>/opt/m
 
 mkdir -p /opt/azure/containers && touch /opt/azure/containers/provision.complete
+ps auxfww > /opt/azure/provision-ps.log

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -135,8 +135,8 @@ func teardown() {
 		for _, fp := range []string{"/var/log/azure/cluster-provision.log", "/var/log/cloud-init.log",
 			"/var/log/cloud-init-output.log", "/var/log/syslog", "/var/log/azure/custom-script/handler.log",
 			"/opt/m", "/opt/azure/containers/kubelet.sh", "/opt/azure/containers/mountetcd.sh",
-			"/opt/azure/containers/provision.sh", "/opt/azure/containers/setup-etcd.log",
-			"/opt/azure/containers/setup-etcd.sh", "/opt/azure/provision-ps.log"} {
+			"/opt/azure/containers/provision.sh", "/opt/azure/containers/setup-etcd.sh",
+			"/opt/azure/provision-ps.log"} {
 			data, err := cliProvisioner.FetchProvisioningMetrics(fp)
 			if err != nil {
 				log.Printf("cliProvisioner.FetchProvisioningMetrics error: %s\n", err)

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -199,15 +199,16 @@ func (cli *CLIProvisioner) waitForNodes() error {
 	return nil
 }
 
-func (cli *CLIProvisioner) fetchProvisioningMetrics(path string) error {
-	conn, err := remote.NewConnection(fmt.Sprintf("%s.%s.cloudapp.azure.com", cli.Config.Name, cli.Config.Location), "2200", cli.Engine.ClusterDefinition.Properties.LinuxProfile.AdminUsername, cli.Config.GetSSHKeyPath())
+// FetchProvisioningMetrics gets a file from the master
+func (cli *CLIProvisioner) FetchProvisioningMetrics(path string) ([]byte, error) {
+	hostname := fmt.Sprintf("%s.%s.cloudapp.azure.com", cli.Config.Name, cli.Config.Location)
+	conn, err := remote.NewConnection(hostname, "22", cli.Engine.ClusterDefinition.Properties.LinuxProfile.AdminUsername, cli.Config.GetSSHKeyPath())
 	if err != nil {
-		return err
+		return nil, err
 	}
 	data, err := conn.Read(path)
 	if err != nil {
-		return fmt.Errorf("Error reading file from path (%s):%s", path, err)
+		return nil, fmt.Errorf("Error reading file from path (%s):%s", path, err)
 	}
-	log.Printf("Data:%s\n", data)
-	return nil
+	return data, nil
 }

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -24,7 +24,7 @@ import (
 // CLIProvisioner holds the configuration needed to provision a clusters
 type CLIProvisioner struct {
 	ClusterDefinition string `envconfig:"CLUSTER_DEFINITION" required:"true" default:"examples/kubernetes.json"` // ClusterDefinition is the path on disk to the json template these are normally located in examples/
-	ProvisionRetries  int    `envcofnig:"PROVISION_RETRIES" default:"3"`
+	ProvisionRetries  int    `envconfig:"PROVISION_RETRIES" default:"0"`
 	CreateVNET        bool   `envconfig:"CREATE_VNET" default:"false"`
 	Config            *config.Config
 	Account           *azure.Account
@@ -48,7 +48,7 @@ func BuildCLIProvisioner(cfg *config.Config, acct *azure.Account, pt *metrics.Po
 // Run will provision a cluster using the azure cli
 func (cli *CLIProvisioner) Run() error {
 	rgs := make([]string, 0)
-	for i := 1; i <= cli.ProvisionRetries; i++ {
+	for i := 0; i <= cli.ProvisionRetries; i++ {
 		cli.Point.SetProvisionStart()
 		err := cli.provision()
 		rgs = append(rgs, cli.Config.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

This PR pulls down provision-related log files in to `_logs/`, and disables deployment retries by default.

While running E2E on this PR, because of the logs, I was able to identify a bug, the fix is included in this PR as a demonstration of the power of logs!

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
