### PR TITLE
E2E: don’t abort errors during log gathering

### DIFF
--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -229,7 +229,7 @@ func (cli *CLIProvisioner) FetchProvisioningMetrics(path string, cfg *config.Con
 		for _, fp := range masterFiles {
 			err := conn.CopyRemote(master, fp)
 			if err != nil {
-				return fmt.Errorf("Error reading file from path (%s):%s", path, err)
+				log.Printf("Error reading file from path (%s):%s", path, err)
 			}
 		}
 	}
@@ -238,7 +238,7 @@ func (cli *CLIProvisioner) FetchProvisioningMetrics(path string, cfg *config.Con
 		for _, fp := range agentFiles {
 			err := conn.CopyRemote(agent, fp)
 			if err != nil {
-				return fmt.Errorf("Error reading file from path (%s):%s", path, err)
+				log.Printf("Error reading file from path (%s):%s", path, err)
 			}
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: E2E logs gathering should be resilient to individual scp errors.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
