### PR TITLE
Kubernetes provision script: check for kubectl and docker files

### DIFF
--- a/parts/k8s/kubernetesmastercustomscript.sh
+++ b/parts/k8s/kubernetesmastercustomscript.sh
@@ -573,15 +573,22 @@ function ensureApiserver() {
 }
 
 function ensureEtcd() {
+    etcdIsRunning=1
     for i in {1..600}; do
         curl --cacert /etc/kubernetes/certs/ca.crt --cert /etc/kubernetes/certs/etcdclient.crt --key /etc/kubernetes/certs/etcdclient.key --max-time 60 https://127.0.0.1:2379/v2/machines;
         if [ $? -eq 0 ]
         then
+            etcdIsRunning=0
             echo "Etcd setup successfully, took $i seconds"
             break
         fi
         sleep 1
     done
+    if [ $etcdIsRunning -ne 0 ]
+    then
+        echo "Etcd not accessible after $i seconds"
+        exit 3
+    fi
 }
 
 function ensureEtcdDataDir() {

--- a/parts/k8s/kubernetesmastercustomscript.sh
+++ b/parts/k8s/kubernetesmastercustomscript.sh
@@ -485,7 +485,6 @@ function systemctlEnableAndCheck() {
         echo "$1 could not be enabled by systemctl"
         exit 5
     fi
-    systemctl enable $1
 }
 
 function ensureDocker() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

Adds a generic ensureFilepath function to the provision script. Checking for `/usr/local/bin/kubectl` and `/usr/bin/docker`.

Also addressed a bug in the previous `ensureKubectl` function which would not fail if kubectl was in fact not present.

Also fixes ensureEtcd to fail provision if it fails.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
