### PR TITLE
Kubernetes Tiller Addon: configuration to set max-history

### DIFF
--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -4,7 +4,16 @@
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
-        "clusterSubnet": "10.239.0.0/16"
+        "clusterSubnet": "10.239.0.0/16",
+        "addons": [
+          {
+            "name": "tiller",
+            "enabled" : true,
+            "config": {
+              "max-history": "5"
+            }
+          }
+        ]
       }
     },
     "masterProfile": {

--- a/examples/e2e-tests/kubernetes/windows/definition.json
+++ b/examples/e2e-tests/kubernetes/windows/definition.json
@@ -2,7 +2,18 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
+      "orchestratorType": "Kubernetes",
+      "kubernetesConfig": {
+        "addons": [
+          {
+            "name": "tiller",
+            "enabled" : true,
+            "config": {
+              "max-history": "5"
+            }
+          }
+        ]
+      }
     },
     "masterProfile": {
       "count": 3,

--- a/parts/k8s/addons/kubernetesmasteraddons-tiller-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-tiller-deployment.yaml
@@ -65,6 +65,8 @@ spec:
       - env:
         - name: TILLER_NAMESPACE
           value: kube-system
+        - name: TILLER_HISTORY_MAX
+          value: "<kubernetesTillerMaxHistory>"
         image: <kubernetesTillerSpec>
         livenessProbe:
           httpGet:

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -202,6 +202,7 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
     sed -i "s|<kubernetesTillerMemoryRequests>|{{WrapAsVariable "kubernetesTillerMemoryRequests"}}|g" "/etc/kubernetes/addons/kube-tiller-deployment.yaml"
     sed -i "s|<kubernetesTillerCPULimit>|{{WrapAsVariable "kubernetesTillerCPULimit"}}|g" "/etc/kubernetes/addons/kube-tiller-deployment.yaml"
     sed -i "s|<kubernetesTillerMemoryLimit>|{{WrapAsVariable "kubernetesTillerMemoryLimit"}}|g" "/etc/kubernetes/addons/kube-tiller-deployment.yaml"
+    sed -i "s|<kubernetesTillerMaxHistory>|{{WrapAsVariable "kubernetesTillerMaxHistory"}}|g" "/etc/kubernetes/addons/kube-tiller-deployment.yaml"
 {{end}}
 
 {{if AdminGroupID }}

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -87,6 +87,7 @@
     "kubernetesTillerMemoryRequests": "[parameters('kubernetesTillerMemoryRequests')]",
     "kubernetesTillerCPULimit": "[parameters('kubernetesTillerCPULimit')]",
     "kubernetesTillerMemoryLimit": "[parameters('kubernetesTillerMemoryLimit')]",
+    "kubernetesTillerMaxHistory": "[parameters('kubernetesTillerMaxHistory')]",
     "kubernetesACIConnectorSpec": "[parameters('kubernetesACIConnectorSpec')]",
     "kubernetesACIConnectorClientId": "[parameters('kubernetesACIConnectorClientId')]",
     "kubernetesACIConnectorClientKey": "[parameters('kubernetesACIConnectorClientKey')]",

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -322,6 +322,13 @@
       },
       "type": "string"
     },
+    "kubernetesTillerMaxHistory": {
+      {{PopulateClassicModeDefaultValue "kubernetesTillerMaxHistory"}}
+      "metadata": {
+        "description": "Helm Tiller Max History to Store. '0' for no limit."
+      },
+      "type": "string"
+    },
     "kubernetesACIConnectorSpec": {
       {{PopulateClassicModeDefaultValue "kubernetesACIConnectorSpec"}}
       "metadata": {

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -80,6 +80,8 @@ const (
 	DefaultKubernetesCloudProviderRateLimitBucket = 10
 	// DefaultTillerAddonName is the name of the tiller addon deployment
 	DefaultTillerAddonName = "tiller"
+	// DefaultTillerMaxHistory limits the maximum number of revisions saved per release. Use 0 for no limit.
+	DefaultTillerMaxHistory = 0
 	// DefaultACIConnectorAddonName is the name of the tiller addon deployment
 	DefaultACIConnectorAddonName = "aci-connector"
 	// DefaultDashboardAddonName is the name of the kubernetes-dashboard addon deployment

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/Azure/acs-engine/pkg/api"
@@ -180,6 +181,9 @@ var (
 				CPULimits:      "50m",
 				MemoryLimits:   "150Mi",
 			},
+		},
+		Config: map[string]string{
+			"max-history": strconv.Itoa(DefaultTillerMaxHistory),
 		},
 	}
 

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -552,6 +552,7 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 			addValue(parametersMap, "kubernetesTillerCPULimit", tillerAddon.Containers[c].CPULimits)
 			addValue(parametersMap, "kubernetesTillerMemoryRequests", tillerAddon.Containers[c].MemoryRequests)
 			addValue(parametersMap, "kubernetesTillerMemoryLimit", tillerAddon.Containers[c].MemoryLimits)
+			addValue(parametersMap, "kubernetesTillerMaxHistory", tillerAddon.Config["max-history"])
 			if tillerAddon.Containers[c].Image != "" {
 				addValue(parametersMap, "kubernetesTillerSpec", tillerAddon.Containers[c].Image)
 			} else {
@@ -1487,6 +1488,16 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 						val = tillerAddon.Containers[tC].MemoryLimits
 					} else {
 						val = ""
+					}
+				case "kubernetesTillerMaxHistory":
+					if tC > -1 {
+						if _, ok := tillerAddon.Config["max-history"]; ok {
+							val = tillerAddon.Config["max-history"]
+						} else {
+							val = "0"
+						}
+					} else {
+						val = "0"
 					}
 				case "kubernetesReschedulerSpec":
 					if rC > -1 {

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -134,6 +134,19 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			}
 		})
 
+		It("should have a tiller max-history of 5", func() {
+			if eng.HasTiller() {
+				pods, err := pod.GetAllByPrefix("tiller-deploy", "kube-system")
+				Expect(err).NotTo(HaveOccurred())
+				// There is only one tiller pod and one container in that pod.
+				actualTillerMaxHistory, err := pods[0].Spec.Containers[0].GetEnvironmentVariable("TILLER_HISTORY_MAX")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(actualTillerMaxHistory).To(Equal("5"))
+			} else {
+				Skip("tiller disabled for this cluster, will not test")
+			}
+		})
+
 		It("should be able to access the dashboard from each node", func() {
 			if eng.HasDashboard() {
 				By("Ensuring that the kubernetes-dashboard pod is Running")


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new addon configuration for the kubernetes tiller addon to set the max-history environment variable

Without this configuration, tiller will store an infinite number of revisions for each release. As of Helm 2.7, setting this configuration to a non 0 value will force tiller to clean up old revisions, thus limiting the number of configmaps under its control. This environment variable has no impact on previous versions of Helm.

I also modified the default e2e test to set this configuration and then verify that the correct environment variable ends up on the tiller pod.