### PR TITLE
Updates NVIDIA drivers installation

### DIFF
--- a/docs/kubernetes/gpu.md
+++ b/docs/kubernetes/gpu.md
@@ -19,7 +19,7 @@ If `alpha.kubernetes.io/nvidia-gpu` is `0` and you just created the cluster, you
 When running a GPU container, you will need to specify how many GPU you want to use. If you don't specify a GPU count, kubernetes will asumme you don't require any, and will not map the device into the container.
 You will also need to mount the drivers from the host (the kubernetes agent) into the container.
 
-On the host, the drivers are installed under `/usr/lib/nvidia-384`.
+On the host, the drivers are installed under `/usr/local/nvidia`.
 
 Here is an example template running TensorFlow: 
 
@@ -45,27 +45,13 @@ spec:
           limits:
             alpha.kubernetes.io/nvidia-gpu: 1
         volumeMounts:
-        - mountPath: /usr/local/nvidia/bin
-          name: bin
-        - mountPath: /usr/local/nvidia/lib64
-          name: lib
-        - mountPath: /usr/lib/x86_64-linux-gnu/libcuda.so.1
-          name: libcuda
+        - name: nvidia
+          mountPath: /usr/local/nvidia
       volumes:
-        - name: bin
+        - name: nvidia
           hostPath: 
-            path: /usr/lib/nvidia-384/bin
-        - name: lib
-          hostPath: 
-            path: /usr/lib/nvidia-384
-        - name: libcuda
-          hostPath:
-            path: /usr/lib/x86_64-linux-gnu/libcuda.so.1
+            path: /usr/local/nvidia
 ```
 
 We specify `alpha.kubernetes.io/nvidia-gpu: 1` in the resources limits, and we mount the drivers from the host into the container.
-
-Some libraries, such as `libcuda.so` are installed under `/usr/lib/x86_64-linux-gnu` on the host, you might need to mount them separatly as shown above based on your needs.
-
-
 

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -1671,7 +1671,7 @@ func getPackageGUID(orchestratorType string, orchestratorVersion string, masterC
 func getGPUDriversInstallScript(profile *api.AgentPoolProfile) string {
 
 	// latest version of the drivers. Later this parameter could be bubbled up so that users can choose specific driver versions.
-	dv 								:= "384.111"
+	dv := "384.111"
 	dest := "/usr/local/nvidia"
 
 	/*
@@ -1686,18 +1686,18 @@ func getGPUDriversInstallScript(profile *api.AgentPoolProfile) string {
 - cd %s`, dest, dest)
 
 	/*
-	Download the .run file from NVIDIA.
-	Nvidia libraries are always install in /usr/lib/x86_64-linux-gnu, and there is no option in the run file to change this. 
-	Instead we use Overlayfs to move the newly installed libraries under /usr/local/nvidia/lib64
+		Download the .run file from NVIDIA.
+		Nvidia libraries are always install in /usr/lib/x86_64-linux-gnu, and there is no option in the run file to change this.
+		Instead we use Overlayfs to move the newly installed libraries under /usr/local/nvidia/lib64
 	*/
-  installScript += fmt.Sprintf(`
+	installScript += fmt.Sprintf(`
 - curl -fLS https://us.download.nvidia.com/tesla/%s/NVIDIA-Linux-x86_64-%s.run -o nvidia-drivers-%s
 - mkdir -p lib64 overlay-workdir
 - sudo mount -t overlay -o lowerdir=/usr/lib/x86_64-linux-gnu,upperdir=lib64,workdir=overlay-workdir none /usr/lib/x86_64-linux-gnu`, dv, dv, dv)
 
 	/*
-	Install the drivers and update /etc/ld.so.conf.d/nvidia.conf which will make the libraries discoverable through $LD_LIBRARY_PATH.
-	Run nvidia-smi to test the installation, unmount overlayfs and restard kubelet (GPUs are only discovered when kubelet starts)
+		Install the drivers and update /etc/ld.so.conf.d/nvidia.conf which will make the libraries discoverable through $LD_LIBRARY_PATH.
+		Run nvidia-smi to test the installation, unmount overlayfs and restard kubelet (GPUs are only discovered when kubelet starts)
 	*/
 	installScript += fmt.Sprintf(`
 - sudo sh nvidia-drivers-%s --silent --accept-license --no-drm --utility-prefix="%s" --opengl-prefix="%s"


### PR DESCRIPTION
This PR updates NVIDIA drivers installation.
* Instead of installing the drivers through apt, directly download the official *.run drivers from Nvidia websites. Using the *.run file considerably speeds up the installation of the drivers (from 12 to about 2 minutes)
* The reason we used apt before was because the `.run` file doesn't allow to control where the libraries end up getting installed, they always end up in `/usr/lib/x86_64-linux-gnu`, which cause conflict issues when we then need to mount this folder into a pod.
By using Overlayfs we are able to bypass this issue and have the libraries installed in `/usr/local/nvidia/lib64` instead.
* Currently, with apt, drivers are located in `/usr/lib/nvidia-384`. This is not good because it means the `hostpath` will change depending on the version of the driver installed on the host, potentially breaking templates that used to work before. This PR solves that as well since everything is now installed under `/usr/local/nvidia`


Left to do:
* [x] Update documentation
* [x] Do some more testing
* [x] Lint


Cc @lachie83 @sauryadas 