### PR TITLE
Remove debug binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 acs-engine.exe
 acs-engine
+debug
 _output/
 _input/
 .vscode


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes a `debug` binary that was mistakenly added in #2174

Also adds it to gitignore so that it doesn't happen again.
