### PR TITLE
Fix --auto-suffix cli parameter when dnsPrefix is defined in apimodel json file

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -154,15 +154,13 @@ func autofillApimodel(dc *deployCmd) {
 		if dc.dnsPrefix == "" {
 			log.Fatalf("apimodel: missing masterProfile.dnsPrefix and --dns-prefix was not specified")
 		}
+		log.Warnf("apimodel: missing masterProfile.dnsPrefix will use %q", dc.dnsPrefix)
+		dc.containerService.Properties.MasterProfile.DNSPrefix = dc.dnsPrefix
+	}
 
-		dnsPrefix := dc.dnsPrefix
-		if dc.autoSuffix {
-			suffix := strconv.FormatInt(time.Now().Unix(), 16)
-			dnsPrefix = dnsPrefix + "-" + suffix
-		}
-
-		log.Warnf("apimodel: missing masterProfile.dnsPrefix will use %q", dnsPrefix)
-		dc.containerService.Properties.MasterProfile.DNSPrefix = dnsPrefix
+	if dc.autoSuffix {
+		suffix := strconv.FormatInt(time.Now().Unix(), 16)
+		dc.containerService.Properties.MasterProfile.DNSPrefix += "-" + suffix
 	}
 
 	if dc.outputDirectory == "" {

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -26,9 +26,27 @@ const ExampleAPIModel = `{
 }
 `
 
+const ExampleAPIModelWithDNSPrefix = `{
+	"apiVersion": "vlabs",
+	"properties": {
+		  "orchestratorProfile": { "orchestratorType": "Kubernetes", "kubernetesConfig": { "useManagedIdentity": %s, "etcdVersion" : "2.3.8" } },
+	  "masterProfile": { "count": 1, "dnsPrefix": "mytestcluster", "vmSize": "Standard_D2_v2" },
+	  "agentPoolProfiles": [ { "name": "linuxpool1", "count": 2, "vmSize": "Standard_D2_v2", "availabilityProfile": "AvailabilitySet" } ],
+	  "windowsProfile": { "adminUsername": "azureuser", "adminPassword": "replacepassword1234$" },
+	  "linuxProfile": { "adminUsername": "azureuser", "ssh": { "publicKeys": [ { "keyData": "" } ] }
+	  },
+	  "servicePrincipalProfile": { "clientId": "%s", "secret": "%s" }
+	}
+  }
+  `
+
 func getExampleAPIModel(useManagedIdentity bool, clientID, clientSecret string) string {
+	return getAPIModel(ExampleAPIModel, useManagedIdentity, clientID, clientSecret)
+}
+
+func getAPIModel(baseAPIModel string, useManagedIdentity bool, clientID, clientSecret string) string {
 	return fmt.Sprintf(
-		ExampleAPIModel,
+		baseAPIModel,
 		strconv.FormatBool(useManagedIdentity),
 		clientID,
 		clientSecret)
@@ -44,6 +62,36 @@ func TestAutofillApimodelWithManagedIdentitySkipsCreds(t *testing.T) {
 
 func TestAutofillApimodelAllowsPrespecifiedCreds(t *testing.T) {
 	testAutodeployCredentialHandling(t, false, "clientID", "clientSecret")
+}
+
+func TestAutoSufixWithDnsPrefixInApiModel(t *testing.T) {
+	apiloader := &api.Apiloader{
+		Translator: nil,
+	}
+
+	apimodel := getAPIModel(ExampleAPIModelWithDNSPrefix, false, "clientID", "clientSecret")
+	cs, ver, err := apiloader.DeserializeContainerService([]byte(apimodel), false, false, nil)
+	if err != nil {
+		t.Fatalf("unexpected error deserializing the example apimodel: %s", err)
+	}
+	deployCmd := &deployCmd{
+		apimodelPath:     "./this/is/unused.json",
+		outputDirectory:  "_test_output",
+		location:         "westus",
+		autoSuffix:       true,
+		containerService: cs,
+		apiVersion:       ver,
+
+		client: &armhelpers.MockACSEngineClient{},
+	}
+	autofillApimodel(deployCmd)
+
+	defer os.RemoveAll(deployCmd.outputDirectory)
+
+	if deployCmd.containerService.Properties.MasterProfile.DNSPrefix == "mytestcluster" {
+		t.Fatalf("expected %s-{timestampsuffix} but got %s", "mytestcluster", deployCmd.containerService.Properties.MasterProfile.DNSPrefix)
+	}
+
 }
 
 func testAutodeployCredentialHandling(t *testing.T, useManagedIdentity bool, clientID, clientSecret string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the `--auto-suffix` cli parameter takes effect only when the `dnsPrefix` parameter is also defined as a cli parameter.
If the `dnsPrefix` is defined in the `apimodel.json`, the auto-suffix value is ignored.
This fixes the behaviour and adds a test to verify it. 

**Which issue this PR fixes**
These is no issue associated to this PR, this just resolves the problem that I met during development
