### PR TITLE
Update kuberneteswindowssetup.ps1 for azure cni to remove redundant code

### DIFF
--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -356,6 +356,13 @@ Update-CNIConfig(`$podCIDR, `$masterSubnetGW)
 
 try
 {
+    
+    if (`$global:NetworkPolicy -eq "azure") {
+        Write-Host "NetworkPolicy azure, starting kubelet."
+        $KubeletCommandLine
+        return 0
+    }
+
     `$masterSubnetGW = Get-DefaultGateway `$global:MasterSubnet
     `$podCIDR=Get-PodCIDR
     `$podCidrDiscovered=Test-PodCIDR(`$podCIDR)

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -359,13 +359,6 @@ Update-CNIConfig(`$podCIDR, `$masterSubnetGW)
 
 try
 {
-    
-    if (`$global:NetworkPolicy -eq "azure") {
-        Write-Host "NetworkPolicy azure, starting kubelet."
-        $KubeletCommandLine
-        return 0
-    }
-
     `$masterSubnetGW = Get-DefaultGateway `$global:MasterSubnet
     `$podCIDR=Get-PodCIDR
     `$podCidrDiscovered=Test-PodCIDR(`$podCIDR)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR fixes service IP connectivity issue when using Azure CNI for Windows nodes. Without this PR, the service IP can't be accessed from public network.