### PR TITLE
Fix inconsistent labels for kubernetes components (#2246)

### DIFF
--- a/parts/k8s/addons/1.5/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/1.5/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -3,7 +3,7 @@ kind: DaemonSet
 metadata:
   labels:
     kubernetes.io/cluster-service: "true"
-    component: kube-proxy
+    k8s-app: kube-proxy
     tier: node
   name: kube-proxy
   namespace: kube-system
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       labels:
-        component: kube-proxy
+        k8s-app: kube-proxy
         tier: node
     spec:
       containers:

--- a/parts/k8s/addons/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -3,7 +3,7 @@ kind: DaemonSet
 metadata:
   labels:
     kubernetes.io/cluster-service: "true"
-    component: kube-proxy
+    k8s-app: kube-proxy
     tier: node
   name: kube-proxy
   namespace: kube-system
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       labels:
-        component: kube-proxy
+        k8s-app: kube-proxy
         tier: node
     spec:
       tolerations:

--- a/parts/k8s/manifests/kubernetesmaster-cloud-controller-manager.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-cloud-controller-manager.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     tier: control-plane
-    component: cloud-controller-manager
+    k8s-app: cloud-controller-manager
 spec:
   hostNetwork: true
   containers:

--- a/parts/k8s/manifests/kubernetesmaster-kube-apiserver.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-apiserver.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     tier: control-plane
-    component: kube-apiserver
+    k8s-app: kube-apiserver
 spec:
   hostNetwork: true
   containers:

--- a/parts/k8s/manifests/kubernetesmaster-kube-controller-manager.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-controller-manager.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     tier: control-plane
-    component: kube-controller-manager
+    k8s-app: kube-controller-manager
 spec:
   hostNetwork: true
   containers:

--- a/parts/k8s/manifests/kubernetesmaster-kube-scheduler.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-scheduler.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "kube-system"
   labels:
     tier: control-plane
-    component: kube-scheduler
+    k8s-app: kube-scheduler
 spec:
   hostNetwork: true
   containers:


### PR DESCRIPTION
* change label key component to k8s-app for cloud-controller-manager, kube-apiserver, kube-controller-manager, kube-scheduler, kube-proxy

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
It makes the labels put on kubernetes components like scheduler, kube-dns, controller-manager consistent. Before this PR some components use `component` key and some use `k8s-app`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
#2246 
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
