### PR TITLE
update generateproxycertscript.sh to use secure etcd endpoint/certs

### DIFF
--- a/parts/k8s/kubernetesmastergenerateproxycertscript.sh
+++ b/parts/k8s/kubernetesmastergenerateproxycertscript.sh
@@ -12,6 +12,12 @@ K8S_PROXY_CA_CRT_FILEPATH="${K8S_PROXY_CA_CRT_FILEPATH:=/etc/kubernetes/certs/pr
 K8S_PROXY_KEY_FILEPATH="${K8S_PROXY_KEY_FILEPATH:=/etc/kubernetes/certs/proxy.key}"
 K8S_PROXY_CRT_FILEPATH="${K8S_PROXY_CRT_FILEPATH:=/etc/kubernetes/certs/proxy.crt}"
 
+export ETCDCTL_ENDPOINTS="${ETCDCTL_ENDPOINTS:=https://127.0.0.1:2379}"
+export ETCDCTL_CA_FILE="${ETCDCTL_CA_FILE:=/etc/kubernetes/certs/ca.crt}"
+export ETCDCTL_KEY_FILE="${ETCDCTL_KEY_FILE:=/etc/kubernetes/certs/etcdclient.key}"
+export ETCDCTL_CERT_FILE="${ETCDCTL_CERT_FILE:=/etc/kubernetes/certs/etcdclient.crt}"
+export RANDFILE=$(mktemp)
+
 # generate root CA
 openssl genrsa -out $PROXY_CA_KEY 2048
 openssl req -new -x509 -days 1826 -key $PROXY_CA_KEY -out $PROXY_CRT -subj '/CN=proxyClientCA'


### PR DESCRIPTION


**What this PR does / why we need it**:
When Aggregated API's are enabled with _"enableAggregatedAPIs" : true_ ,  generate-proxy-certs.sh on master performs an etcd healthcheck before creating proxy certs. This etcd healthcheck fails because its calling the pre-0.12.* unsecured etcd endpoint. This PR adds the secure etcd endpoint/cert credentials.


