### PR TITLE
Always deliver an "enabled" value for an addon

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -720,6 +720,9 @@ func getAddonContainersIndexByName(containers []api.KubernetesContainerSpec, nam
 
 // assignDefaultAddonVals will assign default values to addon from defaults, for each property in addon that has a zero value
 func assignDefaultAddonVals(addon, defaults api.KubernetesAddon) api.KubernetesAddon {
+	if addon.Enabled == nil {
+		addon.Enabled = defaults.Enabled
+	}
 	for i := range defaults.Containers {
 		c := getAddonContainersIndexByName(addon.Containers, defaults.Containers[i].Name)
 		if c < 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Explicitly set the `Enabled` value for an addon in the api model.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
