### PR TITLE
enable AggregatedAPI's by default for k8s 1.9.0+

### DIFF
--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -54,7 +54,7 @@ write_files:
   content: |
     {{WrapAsVariable "clientCertificate"}}
 
-{{if .OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs}}
+{{if EnableAggregatedAPIs}}
 - path: "/etc/kubernetes/generate-proxy-certs.sh"
   permissions: "0744"
   encoding: "gzip"
@@ -323,7 +323,7 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
     mkdir -p /etc/kubernetes/manifests
     usermod -aG docker {{WrapAsVariable "username"}}
 
-    {{if .OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs}}
+    {{if EnableAggregatedAPIs}}
     sudo bash /etc/kubernetes/generate-proxy-certs.sh
     {{end}}
 
@@ -376,7 +376,7 @@ runcmd:
 - mkdir -p /etc/kubernetes/manifests
 - usermod -aG docker {{WrapAsVariable "username"}}
 - /usr/lib/apt/apt.systemd.daily
-{{if .OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs}}
+{{if EnableAggregatedAPIs}}
 - bash /etc/kubernetes/generate-proxy-certs.sh
 {{end}}
 - apt-mark unhold walinuxagent

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -42,7 +42,7 @@ func setAPIServerConfig(cs *api.ContainerService) {
 	}
 
 	// Aggregated API configuration
-	if o.KubernetesConfig.EnableAggregatedAPIs {
+	if o.KubernetesConfig.EnableAggregatedAPIs || isKubernetesVersionGe(o.OrchestratorVersion, "1.9.0") {
 		staticLinuxAPIServerConfig["--requestheader-client-ca-file"] = "/etc/kubernetes/certs/proxy-ca.crt"
 		staticLinuxAPIServerConfig["--proxy-client-cert-file"] = "/etc/kubernetes/certs/proxy.crt"
 		staticLinuxAPIServerConfig["--proxy-client-key-file"] = "/etc/kubernetes/certs/proxy.key"

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -1599,6 +1599,14 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"EnableDataEncryptionAtRest": func() bool {
 			return helpers.IsTrueBoolPointer(cs.Properties.OrchestratorProfile.KubernetesConfig.EnableDataEncryptionAtRest)
 		},
+		"EnableAggregatedAPIs": func() bool {
+			if cs.Properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs {
+				return true
+			} else if isKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.9.0") {
+				return true
+			}
+			return false
+		},
 		// inspired by http://stackoverflow.com/questions/18276173/calling-a-template-with-several-pipeline-parameters/18276968#18276968
 		"dict": func(values ...interface{}) (map[string]interface{}, error) {
 			if len(values)%2 != 0 {


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR enables Aggregated API's by default for kubernetes 1.9.0+. 
This is a dependency for the new metrics server needed by HPA as discussed here https://github.com/Azure/acs-engine/issues/2114

