### PR TITLE
- keeping original DeploymentOperationsListResult in DeploymentError

### DIFF
--- a/pkg/armhelpers/deploymentError.go
+++ b/pkg/armhelpers/deploymentError.go
@@ -32,10 +32,7 @@ func (e *DeploymentError) Error() string {
 			continue
 		}
 		for _, operation := range *operationsList.Value {
-			if operation.Properties == nil || *operation.Properties.ProvisioningState != string(api.Failed) {
-				continue
-			}
-			if operation.Properties != nil && operation.Properties.StatusMessage != nil {
+			if operation.Properties != nil && *operation.Properties.ProvisioningState == string(api.Failed) && operation.Properties.StatusMessage != nil {
 				if b, err := json.MarshalIndent(operation.Properties.StatusMessage, "", "  "); err == nil {
 					ops = append(ops, string(b))
 				}

--- a/pkg/armhelpers/deploymentError.go
+++ b/pkg/armhelpers/deploymentError.go
@@ -17,7 +17,7 @@ type DeploymentError struct {
 	StatusCode        int
 	Response          []byte
 	ProvisioningState string
-	Operations        [][]byte
+	OperationsLists   []resources.DeploymentOperationsListResult
 }
 
 // Error implements error interface
@@ -27,11 +27,33 @@ func (e *DeploymentError) Error() string {
 		str = e.TopError.Error()
 	}
 	var ops []string
-	for _, b := range e.Operations {
-		ops = append(ops, string(b))
+	for _, operationsList := range e.OperationsLists {
+		if operationsList.Value == nil {
+			continue
+		}
+		for _, operation := range *operationsList.Value {
+			if operation.Properties == nil || *operation.Properties.ProvisioningState != string(api.Failed) {
+				continue
+			}
+			if operation.Properties != nil && operation.Properties.StatusMessage != nil {
+				if b, err := json.MarshalIndent(operation.Properties.StatusMessage, "", "  "); err == nil {
+					ops = append(ops, string(b))
+				}
+			}
+		}
 	}
 	return fmt.Sprintf("TopError[%s] StatusCode[%d] Response[%s] ProvisioningState[%s] Operations[%s]",
 		str, e.StatusCode, e.Response, e.ProvisioningState, strings.Join(ops, " | "))
+}
+
+// DeploymentValidationError contains validation error
+type DeploymentValidationError struct {
+	Err error
+}
+
+// Error implements error interface
+func (e *DeploymentValidationError) Error() string {
+	return e.Err.Error()
 }
 
 // DeployTemplateSync deploys the template and returns ArmError
@@ -76,7 +98,7 @@ func DeployTemplateSync(az ACSEngineClient, logger *logrus.Entry, resourceGroupN
 		logger.Errorf("unable to list deployment operations %s. error: %v", deploymentName, err)
 		return deploymentErr
 	}
-	getOperationError(res, deploymentErr, logger)
+	deploymentErr.OperationsLists = append(deploymentErr.OperationsLists, res)
 
 	for res.NextLink != nil {
 		res, err = az.ListDeploymentOperationsNextResults(res)
@@ -84,38 +106,7 @@ func DeployTemplateSync(az ACSEngineClient, logger *logrus.Entry, resourceGroupN
 			logger.Warningf("unable to list next deployment operations %s. error: %v", deploymentName, err)
 			break
 		}
-		getOperationError(res, deploymentErr, logger)
+		deploymentErr.OperationsLists = append(deploymentErr.OperationsLists, res)
 	}
 	return deploymentErr
-}
-
-func getOperationError(operationsList resources.DeploymentOperationsListResult, deploymentErr *DeploymentError, logger *logrus.Entry) {
-	if operationsList.Value == nil {
-		return
-	}
-
-	for _, operation := range *operationsList.Value {
-		if operation.Properties == nil || *operation.Properties.ProvisioningState != string(api.Failed) {
-			continue
-		}
-
-		// log the full deployment operation error response
-		if operation.ID != nil && operation.OperationID != nil {
-			b, _ := json.Marshal(operation.Properties)
-			logger.Infof("deployment operation ID %s, operationID %s, prooperties: %s", *operation.ID, *operation.OperationID, b)
-		} else {
-			logger.Error("either deployment ID or operationID is nil")
-		}
-
-		if operation.Properties == nil || operation.Properties.StatusMessage == nil {
-			logger.Error("DeploymentOperation.Properties is not set")
-			continue
-		}
-		b, err := json.MarshalIndent(operation.Properties.StatusMessage, "", "  ")
-		if err != nil {
-			logger.Errorf("Error occurred marshalling JSON: '%v'", err)
-			continue
-		}
-		deploymentErr.Operations = append(deploymentErr.Operations, b)
-	}
 }

--- a/pkg/armhelpers/deploymentError_test.go
+++ b/pkg/armhelpers/deploymentError_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Template deployment tests", func() {
 		Expect(deplErr.TopError.Error()).To(Equal("DeployTemplate failed"))
 		Expect(deplErr.ProvisioningState).To(Equal(""))
 		Expect(deplErr.StatusCode).To(Equal(0))
-		Expect(len(deplErr.Operations)).To(Equal(0))
+		Expect(len(deplErr.OperationsLists)).To(Equal(0))
 	})
 
 	It("Should return QuotaExceeded error code, specified in details", func() {
@@ -45,7 +45,7 @@ var _ = Describe("Template deployment tests", func() {
 		Expect(deplErr.ProvisioningState).To(Equal(""))
 		Expect(deplErr.StatusCode).To(Equal(400))
 		Expect(string(deplErr.Response)).To(ContainSubstring("\"code\":\"QuotaExceeded\""))
-		Expect(len(deplErr.Operations)).To(Equal(0))
+		Expect(len(deplErr.OperationsLists)).To(Equal(0))
 	})
 
 	It("Should return Conflict error code, specified in details", func() {
@@ -61,6 +61,6 @@ var _ = Describe("Template deployment tests", func() {
 		Expect(deplErr.ProvisioningState).To(Equal(""))
 		Expect(deplErr.StatusCode).To(Equal(200))
 		Expect(string(deplErr.Response)).To(ContainSubstring("\"code\":\"Conflict\""))
-		Expect(len(deplErr.Operations)).To(Equal(0))
+		Expect(len(deplErr.OperationsLists)).To(Equal(0))
 	})
 })

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -108,7 +108,7 @@ func (kan *UpgradeAgentNode) Validate(vmName *string) error {
 		select {
 		case <-timeoutTimer.C:
 			retryTimer.Stop()
-			return &armhelpers.DeploymentValidationError{Err: fmt.Errorf("Node was not ready within %v", kan.timeout)}
+			return &armhelpers.DeploymentValidationError{Err: kan.Translator.Errorf("Node was not ready within %v", kan.timeout)}
 		case <-retryTimer.C:
 			agentNode, err := client.GetNode(*vmName)
 			if err != nil {

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -99,7 +99,7 @@ func (kan *UpgradeAgentNode) Validate(vmName *string) error {
 
 	client, err := kan.Client.GetKubernetesClient(masterURL, kan.kubeConfig, interval, kan.timeout)
 	if err != nil {
-		return err
+		return &armhelpers.DeploymentValidationError{Err: err}
 	}
 
 	retryTimer := time.NewTimer(time.Millisecond)
@@ -108,9 +108,7 @@ func (kan *UpgradeAgentNode) Validate(vmName *string) error {
 		select {
 		case <-timeoutTimer.C:
 			retryTimer.Stop()
-			err := fmt.Errorf("Node was not ready within %v", kan.timeout)
-			kan.logger.Errorf(err.Error())
-			return err
+			return &armhelpers.DeploymentValidationError{Err: fmt.Errorf("Node was not ready within %v", kan.timeout)}
 		case <-retryTimer.C:
 			agentNode, err := client.GetNode(*vmName)
 			if err != nil {

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -197,7 +197,7 @@ func (ku *Upgrader) upgradeAgentPools() error {
 		templateMap, parametersMap, err := ku.generateUpgradeTemplate(ku.ClusterTopology.DataModel)
 		if err != nil {
 			ku.logger.Errorf("Error generating upgrade template: %v", err)
-			return ku.Translator.Errorf("error generating upgrade template: %s", err.Error())
+			return ku.Translator.Errorf("Error generating upgrade template: %s", err.Error())
 		}
 
 		ku.logger.Infof("Prepping agent pool '%s' for upgrade...", *agentPool.Name)
@@ -212,7 +212,7 @@ func (ku *Upgrader) upgradeAgentPools() error {
 		}
 		if err := transformer.NormalizeResourcesForK8sAgentUpgrade(ku.logger, templateMap, isMasterManagedDisk, preservePools); err != nil {
 			ku.logger.Errorf(err.Error())
-			return err
+			return ku.Translator.Errorf("Error generating upgrade template: %s", err.Error())
 		}
 
 		var agentCount, agentPoolIndex int


### PR DESCRIPTION
- keeping original DeploymentOperationsListResult in DeploymentError
- add DeploymentValidationError to distinguish validation errors

