### PR TITLE
untangle —authorization-mode from enableSecureKubelet

### DIFF
--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -85,7 +85,6 @@ func setAPIServerConfig(cs *api.ContainerService) {
 	// Default apiserver config
 	defaultAPIServerConfig := map[string]string{
 		"--admission-control":   "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,DenyEscalatingExec,AlwaysPullImages",
-		"--authorization-mode":  "Node",
 		"--audit-log-maxage":    "30",
 		"--audit-log-maxbackup": "10",
 		"--audit-log-maxsize":   "100",
@@ -93,14 +92,10 @@ func setAPIServerConfig(cs *api.ContainerService) {
 
 	// RBAC configuration
 	if helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableRbac) {
-		defaultAPIServerConfig["--authorization-mode"] = "Node,RBAC"
-		if !isKubernetesVersionGe(o.OrchestratorVersion, "1.7.0") || !helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableSecureKubelet) {
+		if isKubernetesVersionGe(o.OrchestratorVersion, "1.7.0") {
+			defaultAPIServerConfig["--authorization-mode"] = "Node,RBAC"
+		} else {
 			defaultAPIServerConfig["--authorization-mode"] = "RBAC"
-		}
-	} else if !isKubernetesVersionGe(o.OrchestratorVersion, "1.7.0") || !helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableSecureKubelet) {
-		// remove authorization-mode for 1.6 clusters without RBAC since Node authorization isn't supported
-		for _, key := range []string{"--authorization-mode"} {
-			delete(defaultAPIServerConfig, key)
 		}
 	}
 

--- a/pkg/acsengine/defaults-apiserver_test.go
+++ b/pkg/acsengine/defaults-apiserver_test.go
@@ -189,7 +189,7 @@ func TestAPIServerConfigEnableRbac(t *testing.T) {
 	setAPIServerConfig(cs)
 	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
 	if _, ok := a["--authorization-mode"]; ok {
-		t.Fatalf("got unexpected '--authorization-mode' kubelet config value for EnableRbac=false: %s",
+		t.Fatalf("got unexpected '--authorization-mode' API server config value for EnableRbac=false: %s",
 			a["--authorization-mode"])
 	}
 

--- a/pkg/acsengine/defaults-apiserver_test.go
+++ b/pkg/acsengine/defaults-apiserver_test.go
@@ -188,8 +188,8 @@ func TestAPIServerConfigEnableRbac(t *testing.T) {
 	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableRbac = pointerToBool(false)
 	setAPIServerConfig(cs)
 	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
-	if a["--authorization-mode"] != "Node" {
-		t.Fatalf("got unexpected '--authorization-mode' API server config value for EnableRbac=false: %s",
+	if _, ok := a["--authorization-mode"]; ok {
+		t.Fatalf("got unexpected '--authorization-mode' kubelet config value for EnableRbac=false: %s",
 			a["--authorization-mode"])
 	}
 

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -82,7 +82,7 @@ func setKubeletConfig(cs *api.ContainerService) {
 
 	// Remove secure kubelet flags, if configured
 	if !helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableSecureKubelet) {
-		for _, key := range []string{"--anonymous-auth", "--authorization-mode", "--client-ca-file"} {
+		for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
 			delete(o.KubernetesConfig.KubeletConfig, key)
 		}
 	}

--- a/pkg/acsengine/defaults-kubelet_test.go
+++ b/pkg/acsengine/defaults-kubelet_test.go
@@ -89,7 +89,7 @@ func TestKubeletConfigEnableSecureKubelet(t *testing.T) {
 	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = pointerToBool(false)
 	setKubeletConfig(cs)
 	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
-	for _, key := range []string{"--anonymous-auth", "--authorization-mode", "--client-ca-file"} {
+	for _, key := range []string{"--anonymous-auth", "--client-ca-file"} {
 		if _, ok := k[key]; ok {
 			t.Fatalf("got unexpected '%s' kubelet config value for EnableSecureKubelet=false: %s",
 				key, k[key])


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Currently simply opting out of Kubernetes RBAC (`enableRbac: false`) doesn't work, because we also ship a cluster w/ apiserver configured for `authorization-mode=Node`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
untangle —authorization-mode from enableSecureKubelet
```