### PR TITLE
Monitoring extension Grafana dashboard update

### DIFF
--- a/extensions/prometheus-grafana-k8s/README.md
+++ b/extensions/prometheus-grafana-k8s/README.md
@@ -89,11 +89,11 @@ $ kubectl port-forward $GF_POD_NAME 3000:3000 &
 |extensionParameters|no|see below|
 |rootURL|optional||
 
-_Note_: the format for `extensionParameters` is the following: `"<namespace>;<prometheus_values_config_url>"`. Each of these placeholders are optional (as is the entire `extensionParameters` itself)
+_Note_: the format for `extensionParameters` is the following: `"<namespace>;<prometheus_values_config_url>;<cadvisor_daemonset_config_url>"`. Each of these placeholders are optional (as is the entire `extensionParameters` itself)
 
 # Example
 ``` javascript
-{ "name": "prometheus-grafana-k8s", "version": "v1", "extensionParameters": "monitoring;" }
+{ "name": "prometheus-grafana-k8s", "version": "v1", "extensionParameters": "monitoring;;" }
 ```
 
 # Supported Orchestrators

--- a/extensions/prometheus-grafana-k8s/v1/cadvisor_daemonset.yml
+++ b/extensions/prometheus-grafana-k8s/v1/cadvisor_daemonset.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: DAEMONSET_API
 kind: DaemonSet
 metadata:
   name: cadvisor

--- a/extensions/prometheus-grafana-k8s/v1/cadvisor_daemonset.yml
+++ b/extensions/prometheus-grafana-k8s/v1/cadvisor_daemonset.yml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cadvisor
+  labels:
+    app: cadvisor
+spec:
+  selector:
+    matchLabels:
+      name: cadvisor
+  template:
+    metadata:
+      labels:
+        name: cadvisor
+    spec:
+      containers:
+        - name: cadvisor
+          image: google/cadvisor:v0.28.3
+          ports:
+            - containerPort: 8080
+              hostPort: 8080
+          volumeMounts:
+            - name: rootfs
+              mountPath: /rootfs
+              readOnly: true
+            - name: varrun
+              mountPath: /var/run
+            - name: sys
+              mountPath: /sys
+              readOnly: true
+            - name: varlibdocker
+              mountPath: /var/lib/docker
+              readOnly: true
+            - name: devdisk
+              mountPath: /dev/disk
+              readOnly: true
+      volumes:
+        - name: rootfs
+          hostPath:
+            path: /
+        - name: varrun
+          hostPath:
+            path: /var/run
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: varlibdocker
+          hostPath:
+            path: /var/lib/docker
+        - name: devdisk
+          hostPath:
+            path: /dev/disk

--- a/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus-grafana-k8s.sh
@@ -389,7 +389,7 @@ chmod u+x sanitize_dashboard.py
 
 DB_RAW=$(cat << EOF
 {
-    "dashboard": $(curl -sL "https://grafana.com/api/dashboards/315/revisions/3/download" | ./sanitize_dashboard.py),
+    "dashboard": $(curl -sL "https://grafana.com/api/dashboards/3119/revisions/2/download" | ./sanitize_dashboard.py),
     "overwrite": false
 }
 EOF

--- a/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml
@@ -1,5 +1,5 @@
 rbac:
-  create: false
+  create: true
 
 alertmanager:
   ## If false, alertmanager will not be installed

--- a/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml
@@ -701,7 +701,7 @@ serverFiles:
 
         # Default to scraping over https. If required, just disable this or change to
         # `http`.
-        scheme: https
+        scheme: http
 
         # This TLS & bearer token file config is used to connect to the actual scrape
         # endpoints for cluster components. This is separate to discovery auth
@@ -726,12 +726,13 @@ serverFiles:
         relabel_configs:
           - action: labelmap
             regex: __meta_kubernetes_node_label_(.+)
-          - target_label: __address__
-            replacement: kubernetes.default.svc:443
-          - source_labels: [__meta_kubernetes_node_name]
-            regex: (.+)
-            target_label: __metrics_path__
-            replacement: /api/v1/nodes/${1}:4194/proxy/metrics
+          - source_labels: [__address__]
+            regex: (.+):(\d+)
+            target_label: __address__
+            replacement: ${1}:8080
+          - source_labels: [__meta_kubernetes_node_label_kubernetes_io_role]
+            regex: master
+            action: drop
 
       # Scrape config for service endpoints.
       #


### PR DESCRIPTION
**What this PR does / why we need it**: in the monitoring extension (prometheus-grafana), the current dashboard that is used does not appear to be even close to Prometheus v2 compatible. With the merging of #2257 which adds support for Prometheus v2, it is important that the plug-and-play Grafana dashboard provides the end user with as good of an experience as possible. With the new dashboard, it has more coverage for Prometheus v2.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use the Grafana Kubernetes Cluster Dashboard from Bitnami (https://grafana.com/dashboards/3119) and refactor cAdvisor metrics away from kubelet and as a standalone daemon set
```
