### PR TITLE
E2E: cleanup legacy kubernetes

### DIFF
--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -12,6 +12,10 @@
             "config": {
               "max-history": "5"
             }
+          },
+          {
+            "name": "rescheduler",
+            "enabled" : true
           }
         ]
       }

--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -32,7 +32,7 @@
         "vmSize": "Standard_D2_v2",
         "OSDiskSizeGB": 200,
         "storageProfile" : "ManagedDisks",
-        "diskSizesGB": [128],
+        "diskSizesGB": [128, 128, 128, 128],
         "availabilityProfile": "AvailabilitySet",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME"
       },

--- a/examples/e2e-tests/kubernetes/windows/hybrid/definition.json
+++ b/examples/e2e-tests/kubernetes/windows/hybrid/definition.json
@@ -11,6 +11,12 @@
     },
     "agentPoolProfiles": [
       {
+        "name": "linuxpool1",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      },
+      {
         "name": "agentwin",
         "count": 2,
         "vmSize": "Standard_D2_v2",

--- a/test/acse-conf/acse-regression.json
+++ b/test/acse-conf/acse-regression.json
@@ -13,14 +13,6 @@
       "category": "managed-disk"
     },
     {
-      "cluster_definition": "disks-managed/kubernetes-preAttachedDisks-vmas.json",
-      "category": "managed-disk"
-    },
-    {
-      "cluster_definition": "disks-managed/kubernetes-vmas.json",
-      "category": "managed-disk"
-    },
-    {
       "cluster_definition": "disks-managed/swarm-preAttachedDisks-vmss.json",
       "category": "managed-disk"
     },
@@ -37,10 +29,6 @@
       "category": "managed-disk"
     },
     {
-      "cluster_definition": "disks-storageaccount/kubernetes.json",
-      "category": "sa-disk"
-    },
-    {
       "cluster_definition": "disks-storageaccount/swarmmode.json",
       "category": "sa-disk"
     },
@@ -50,15 +38,7 @@
       "location": "westus"
     },
     {
-      "cluster_definition": "kubernetes-releases/kubernetes1.8.json",
-      "category": "version"
-    },
-    {
       "cluster_definition": "networkpolicy/kubernetes-calico.json",
-      "category": "network"
-    },
-    {
-      "cluster_definition": "networkpolicy/kubernetes-azure.json",
       "category": "network"
     },
     {
@@ -66,20 +46,8 @@
       "category": "network"
     },
     {
-      "cluster_definition": "kubernetes-config/kubernetes-no-dashboard.json",
-      "category": "config"
-    },
-    {
       "cluster_definition": "kubernetes-config/kubernetes-rescheduler.json",
       "category": "config"
-    },
-    {
-      "cluster_definition": "multiple-masters/kubernetes-3-masters.json",
-      "category": "multimaster"
-    },
-    {
-      "cluster_definition": "multiple-masters/kubernetes-5-masters.json",
-      "category": "multimaster"
     },
     {
       "cluster_definition": "v20170131/swarmmode.json",
@@ -87,10 +55,6 @@
     },
     {
       "cluster_definition": "vnet/dcosvnet.json",
-      "category": "network"
-    },
-    {
-      "cluster_definition": "vnet/kubernetesvnet-azure-cni.json",
       "category": "network"
     },
     {

--- a/test/acse-conf/acse-regression.json
+++ b/test/acse-conf/acse-regression.json
@@ -1,14 +1,6 @@
 {
   "deployments": [
     {
-      "cluster_definition": "windows/kubernetes-hybrid.json",
-      "category": "windows"
-    },
-    {
-      "cluster_definition": "windows/kubernetes.json",
-      "category": "windows"
-    },
-    {
       "cluster_definition": "dcos-releases/dcos1.9.json",
       "category": "version"
     },

--- a/test/acse-conf/acse-regression.json
+++ b/test/acse-conf/acse-regression.json
@@ -42,14 +42,6 @@
       "category": "network"
     },
     {
-      "cluster_definition": "kubernetes-config/kubernetes-clustersubnet.json",
-      "category": "network"
-    },
-    {
-      "cluster_definition": "kubernetes-config/kubernetes-rescheduler.json",
-      "category": "config"
-    },
-    {
       "cluster_definition": "v20170131/swarmmode.json",
       "category": "version"
     },

--- a/test/e2e/kubernetes/service/service.go
+++ b/test/e2e/kubernetes/service/service.go
@@ -136,6 +136,7 @@ func (s *Service) Validate(check string, attempts int, sleep time.Duration) bool
 			if matched == true {
 				return true
 			}
+			log.Printf("Got unexpected URL body, expected to find %s, got:\n%s\n", check, string(body))
 		}
 		time.Sleep(sleep)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Windows hybrid test in `examples/e2e-tests/` directory, remove windows + hybrid from legacy regression suite.

Also added some debugging to service URL match test, because I encountered an error in the tests from this PR and want to see the actual output of the URL mismatch.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
