### PR TITLE
kubelet —cluster-domain is user-overridable

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -161,6 +161,7 @@ Below is a list of kubelet options that acs-engine will configure by default:
 |---|---|
 |"--cloud-config"|"/etc/kubernetes/azure.json"|
 |"--cloud-provider"|"azure"|
+|"--cluster-domain"|"cluster.local"|
 |"--pod-infra-container-image"|"pause-amd64:<version>"|
 |"--max-pods"|"110"|
 |"--eviction-hard"|"memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%"|
@@ -178,7 +179,6 @@ Below is a list of kubelet options that are *not* currently user-configurable, e
 |"--azure-container-registry-config"|"/etc/kubernetes/azure.json"|
 |"--allow-privileged"|"true"|
 |"--pod-manifest-path"|"/etc/kubernetes/manifests"|
-|"--cluster-domain"|"cluster.local"|
 |"--network-plugin"|"cni"|
 |"--node-labels"|(based on Azure node metadata)|
 |"--cgroups-per-qos"|"false"|

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -17,7 +17,6 @@ func setKubeletConfig(cs *api.ContainerService) {
 		"--authorization-mode":              "Webhook",
 		"--client-ca-file":                  "/etc/kubernetes/certs/ca.crt",
 		"--pod-manifest-path":               "/etc/kubernetes/manifests",
-		"--cluster-domain":                  "cluster.local",
 		"--cluster-dns":                     o.KubernetesConfig.DNSServiceIP,
 		"--cgroups-per-qos":                 "false",
 		"--enforce-node-allocatable":        "",
@@ -33,6 +32,7 @@ func setKubeletConfig(cs *api.ContainerService) {
 
 	// Default Kubelet config
 	defaultKubeletConfig := map[string]string{
+		"--cluster-domain":               "cluster.local",
 		"--network-plugin":               "cni",
 		"--pod-infra-container-image":    cloudSpecConfig.KubernetesSpecConfig.KubernetesImageBase + KubeConfigs[o.OrchestratorVersion]["pause"],
 		"--max-pods":                     strconv.Itoa(DefaultKubernetesKubeletMaxPods),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Enables users to override the default `--cluster-domain` kubelet config.

To modify `--cluster-domain`, pass this in w/ your api model:

```
{
<...>
    "kubernetesConfig": {
        "kubeletConfig": {
            "--cluster-domain": "my.custom.domain"
        }
    }
<...>
}
```

Fixes #2269 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
kubelet —cluster-domain is user-overridable
```