### PR TITLE
E2E: service LB validations and pod Ready/NotReady

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -331,12 +331,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				By("Ensuring we can connect to the service")
 				s, err := service.Get(deploymentName, "default")
 				Expect(err).NotTo(HaveOccurred())
-				s, err = s.WaitForExternalIP(cfg.Timeout, 5*time.Second)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(s.Status.LoadBalancer.Ingress).NotTo(BeEmpty())
 
 				By("Ensuring the service root URL returns the expected payload")
-				valid := s.Validate("(Welcome to nginx)", 5, 5*time.Second)
+				valid := s.Validate("(Welcome to nginx)", 5, 5*time.Second, cfg.Timeout)
 				Expect(valid).To(BeTrue())
 
 				By("Ensuring we have outbound internet access from the nginx pods")
@@ -378,11 +375,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 				s, err := service.Get(deploymentName, "default")
 				Expect(err).NotTo(HaveOccurred())
-				s, err = s.WaitForExternalIP(cfg.Timeout, 5*time.Second)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(s.Status.LoadBalancer.Ingress).NotTo(BeEmpty())
 
-				valid := s.Validate("(IIS Windows Server)", 10, 10*time.Second)
+				valid := s.Validate("(IIS Windows Server)", 10, 10*time.Second, cfg.Timeout)
 				Expect(valid).To(BeTrue())
 
 				iisPods, err := iisDeploy.Pods()

--- a/test/e2e/kubernetes/service/service.go
+++ b/test/e2e/kubernetes/service/service.go
@@ -130,17 +130,17 @@ func (s *Service) Validate(check string, attempts int, sleep, wait time.Duration
 	var url string
 	var i int
 	var resp *http.Response
-	_, waitErr := s.WaitForExternalIP(wait, 5*time.Second)
+	svc, waitErr := s.WaitForExternalIP(wait, 5*time.Second)
 	if waitErr != nil {
 		log.Printf("Unable to verify external IP, cannot validate service:%s\n", waitErr)
 		return false
 	}
-	if s.Status.LoadBalancer.Ingress == nil || len(s.Status.LoadBalancer.Ingress) == 0 {
-		log.Printf("Service LB ingress is empty or nil: %#v\n", s.Status.LoadBalancer.Ingress)
+	if svc.Status.LoadBalancer.Ingress == nil || len(svc.Status.LoadBalancer.Ingress) == 0 {
+		log.Printf("Service LB ingress is empty or nil: %#v\n", svc.Status.LoadBalancer.Ingress)
 		return false
 	}
 	for i = 1; i <= attempts; i++ {
-		url = fmt.Sprintf("http://%s", s.Status.LoadBalancer.Ingress[0]["ip"])
+		url = fmt.Sprintf("http://%s", svc.Status.LoadBalancer.Ingress[0]["ip"])
 		resp, err = http.Get(url)
 		if err == nil {
 			body, _ := ioutil.ReadAll(resp.Body)

--- a/test/e2e/kubernetes/service/service.go
+++ b/test/e2e/kubernetes/service/service.go
@@ -129,14 +129,15 @@ func (s *Service) Validate(check string, attempts int, sleep time.Duration) bool
 	var err error
 	var url string
 	var i int
+	var resp *http.Response
 	for i = 1; i <= attempts; i++ {
 		url = fmt.Sprintf("http://%s", s.Status.LoadBalancer.Ingress[0]["ip"])
-		resp, err := http.Get(url)
+		resp, err = http.Get(url)
 		if err == nil {
-			defer resp.Body.Close()
 			body, _ := ioutil.ReadAll(resp.Body)
 			matched, _ := regexp.MatchString(check, string(body))
 			if matched == true {
+				defer resp.Body.Close()
 				return true
 			}
 			log.Printf("Got unexpected URL body, expected to find %s, got:\n%s\n", check, string(body))
@@ -144,5 +145,6 @@ func (s *Service) Validate(check string, attempts int, sleep time.Duration) bool
 		time.Sleep(sleep)
 	}
 	log.Printf("Unable to validate URL %s after %d attempts, err: %#v\n", url, i, err)
+	defer resp.Body.Close()
 	return false
 }

--- a/test/e2e/kubernetes/service/service.go
+++ b/test/e2e/kubernetes/service/service.go
@@ -128,7 +128,8 @@ func (s *Service) WaitForExternalIP(wait, sleep time.Duration) (*Service, error)
 func (s *Service) Validate(check string, attempts int, sleep time.Duration) bool {
 	var err error
 	var url string
-	for i := 0; i < attempts; i++ {
+	var i int
+	for i = 1; i <= attempts; i++ {
 		url = fmt.Sprintf("http://%s", s.Status.LoadBalancer.Ingress[0]["ip"])
 		resp, err := http.Get(url)
 		if err == nil {
@@ -142,6 +143,6 @@ func (s *Service) Validate(check string, attempts int, sleep time.Duration) bool
 		}
 		time.Sleep(sleep)
 	}
-	log.Printf("Unable to validate URL %s, err: %s\n", url, err)
+	log.Printf("Unable to validate URL %s after %d attempts, err: %#v\n", url, i, err)
 	return false
 }

--- a/test/e2e/kubernetes/service/service.go
+++ b/test/e2e/kubernetes/service/service.go
@@ -126,8 +126,10 @@ func (s *Service) WaitForExternalIP(wait, sleep time.Duration) (*Service, error)
 
 // Validate will attempt to run an http.Get against the root service url
 func (s *Service) Validate(check string, attempts int, sleep time.Duration) bool {
+	var err error
+	var url string
 	for i := 0; i < attempts; i++ {
-		url := fmt.Sprintf("http://%s", s.Status.LoadBalancer.Ingress[0]["ip"])
+		url = fmt.Sprintf("http://%s", s.Status.LoadBalancer.Ingress[0]["ip"])
 		resp, err := http.Get(url)
 		if err == nil {
 			defer resp.Body.Close()
@@ -140,5 +142,6 @@ func (s *Service) Validate(check string, attempts int, sleep time.Duration) bool
 		}
 		time.Sleep(sleep)
 	}
+	log.Printf("Unable to validate URL %s, err: %s\n", url, err)
 	return false
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Two improvements:

- Moving service external LB wait test into validate test because the latter is dependent upon the former.
- Being more permissive for transient pod NotReady events (we should allow for *some* transient NotReady states so long as they reconcile to Ready)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
