### PR TITLE
Support multiple AcsEngineClientIDs

### DIFF
--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -31,9 +31,6 @@ import (
 )
 
 const (
-	// AcsEngineClientID is the AAD ClientID for the CLI native application
-	AcsEngineClientID = "76e0feec-6b7f-41f0-81a7-b1b944520261"
-
 	// ApplicationDir is the name of the dir where the token is cached
 	ApplicationDir = ".acsengine"
 )
@@ -74,11 +71,14 @@ func NewAzureClientWithDeviceAuth(env azure.Environment, subscriptionID string) 
 		return nil, err
 	}
 
+	// AcsEngineClientID is the AAD ClientID for the CLI native application
+	acsEngineClientID = getAcsEngineClientId(env.Name)
+
 	home, err := homedir.Dir()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get user home directory to look for cached token: %q", err)
 	}
-	cachePath := filepath.Join(home, ApplicationDir, "cache", fmt.Sprintf("%s_%s.token.json", tenantID, AcsEngineClientID))
+	cachePath := filepath.Join(home, ApplicationDir, "cache", fmt.Sprintf("%s_%s.token.json", tenantID, acsEngineClientID))
 
 	rawToken, err := tryLoadCachedToken(cachePath)
 	if err != nil {
@@ -87,7 +87,7 @@ func NewAzureClientWithDeviceAuth(env azure.Environment, subscriptionID string) 
 
 	var armSpt *adal.ServicePrincipalToken
 	if rawToken != nil {
-		armSpt, err = adal.NewServicePrincipalTokenFromManualToken(*oauthConfig, AcsEngineClientID, env.ServiceManagementEndpoint, *rawToken, tokenCallback(cachePath))
+		armSpt, err = adal.NewServicePrincipalTokenFromManualToken(*oauthConfig, acsEngineClientID, env.ServiceManagementEndpoint, *rawToken, tokenCallback(cachePath))
 		if err != nil {
 			return nil, err
 		}
@@ -95,7 +95,7 @@ func NewAzureClientWithDeviceAuth(env azure.Environment, subscriptionID string) 
 		if err != nil {
 			log.Warnf("Refresh token failed. Will fallback to device auth. %q", err)
 		} else {
-			graphSpt, err := adal.NewServicePrincipalTokenFromManualToken(*oauthConfig, AcsEngineClientID, env.GraphEndpoint, armSpt.Token)
+			graphSpt, err := adal.NewServicePrincipalTokenFromManualToken(*oauthConfig, acsEngineClientID, env.GraphEndpoint, armSpt.Token)
 			if err != nil {
 				return nil, err
 			}
@@ -107,7 +107,7 @@ func NewAzureClientWithDeviceAuth(env azure.Environment, subscriptionID string) 
 
 	client := &autorest.Client{}
 
-	deviceCode, err := adal.InitiateDeviceAuth(client, *oauthConfig, AcsEngineClientID, env.ServiceManagementEndpoint)
+	deviceCode, err := adal.InitiateDeviceAuth(client, *oauthConfig, acsEngineClientID, env.ServiceManagementEndpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func NewAzureClientWithDeviceAuth(env azure.Environment, subscriptionID string) 
 		return nil, err
 	}
 
-	armSpt, err = adal.NewServicePrincipalTokenFromManualToken(*oauthConfig, AcsEngineClientID, env.ServiceManagementEndpoint, *deviceToken, tokenCallback(cachePath))
+	armSpt, err = adal.NewServicePrincipalTokenFromManualToken(*oauthConfig, acsEngineClientID, env.ServiceManagementEndpoint, *deviceToken, tokenCallback(cachePath))
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func NewAzureClientWithDeviceAuth(env azure.Environment, subscriptionID string) 
 
 	adRawToken := armSpt.Token
 	adRawToken.Resource = env.GraphEndpoint
-	graphSpt, err := adal.NewServicePrincipalTokenFromManualToken(*oauthConfig, AcsEngineClientID, env.GraphEndpoint, adRawToken)
+	graphSpt, err := adal.NewServicePrincipalTokenFromManualToken(*oauthConfig, acsEngineClientID, env.GraphEndpoint, adRawToken)
 	if err != nil {
 		return nil, err
 	}
@@ -250,6 +250,16 @@ func getOAuthConfig(env azure.Environment, subscriptionID string) (*adal.OAuthCo
 	}
 
 	return oauthConfig, tenantID, nil
+}
+
+func getAcsEngineClientId(envName string) string {
+	switch envName {
+		case "AzureUSGovernmentCloud":
+			// TODO: Replace with AppId for Azure US Government Cloud
+			return "76e0feec-6b7f-41f0-81a7-b1b944520261"
+		default:
+			return "76e0feec-6b7f-41f0-81a7-b1b944520261"			
+	}
 }
 
 func getClient(env azure.Environment, subscriptionID, tenantID string, armSpt *adal.ServicePrincipalToken, graphSpt *adal.ServicePrincipalToken) *AzureClient {

--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -72,7 +72,7 @@ func NewAzureClientWithDeviceAuth(env azure.Environment, subscriptionID string) 
 	}
 
 	// AcsEngineClientID is the AAD ClientID for the CLI native application
-	acsEngineClientID := getAcsEngineClientId(env.Name)
+	acsEngineClientID := getAcsEngineClientID(env.Name)
 
 	home, err := homedir.Dir()
 	if err != nil {
@@ -252,7 +252,7 @@ func getOAuthConfig(env azure.Environment, subscriptionID string) (*adal.OAuthCo
 	return oauthConfig, tenantID, nil
 }
 
-func getAcsEngineClientId(envName string) string {
+func getAcsEngineClientID(envName string) string {
 	switch envName {
 	case "AzureUSGovernmentCloud":
 		// TODO: Replace with AppId for Azure US Government Cloud

--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -72,7 +72,7 @@ func NewAzureClientWithDeviceAuth(env azure.Environment, subscriptionID string) 
 	}
 
 	// AcsEngineClientID is the AAD ClientID for the CLI native application
-	acsEngineClientID = getAcsEngineClientId(env.Name)
+	acsEngineClientID := getAcsEngineClientId(env.Name)
 
 	home, err := homedir.Dir()
 	if err != nil {

--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -254,11 +254,11 @@ func getOAuthConfig(env azure.Environment, subscriptionID string) (*adal.OAuthCo
 
 func getAcsEngineClientId(envName string) string {
 	switch envName {
-		case "AzureUSGovernmentCloud":
-			// TODO: Replace with AppId for Azure US Government Cloud
-			return "76e0feec-6b7f-41f0-81a7-b1b944520261"
-		default:
-			return "76e0feec-6b7f-41f0-81a7-b1b944520261"			
+	case "AzureUSGovernmentCloud":
+		// TODO: Replace with AppId for Azure US Government Cloud
+		return "76e0feec-6b7f-41f0-81a7-b1b944520261"
+	default:
+		return "76e0feec-6b7f-41f0-81a7-b1b944520261"
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for multiple AcsEngineClientIds. This is necessary in order to support the different Azure Clouds which need a separate Azure AD Service Principal for the commands that interact with ARM Rest APIs (like `acs-engine deploy`, `acs-engine upgrade` and `acs-engine scale`)

**Special notes for your reviewer**:
Fixes #2223 


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
