### PR TITLE
cmd/deploy: Handle error due to missing permissions during deploy

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -215,14 +215,11 @@ func autofillApimodel(dc *deployCmd) {
 			log.Warnf("created application with applicationID (%s) and servicePrincipalObjectID (%s).", applicationID, servicePrincipalObjectID)
 
 			log.Warnln("apimodel: ServicePrincipalProfile was empty, assigning role to application...")
-			for {
-				err = dc.client.CreateRoleAssignmentSimple(dc.resourceGroup, servicePrincipalObjectID)
-				if err != nil {
-					log.Debugf("Failed to create role assignment (will retry): %q", err)
-					time.Sleep(3 * time.Second)
-					continue
-				}
-				break
+
+			err = dc.client.CreateRoleAssignmentSimple(dc.resourceGroup, servicePrincipalObjectID)
+			if err != nil {
+				log.Fatalf("apimodel: could not create or assign ServicePrincipal: %q",err)
+				
 			}
 
 			dc.containerService.Properties.ServicePrincipalProfile = &api.ServicePrincipalProfile{

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -218,8 +218,8 @@ func autofillApimodel(dc *deployCmd) {
 
 			err = dc.client.CreateRoleAssignmentSimple(dc.resourceGroup, servicePrincipalObjectID)
 			if err != nil {
-				log.Fatalf("apimodel: could not create or assign ServicePrincipal: %q",err)
-				
+				log.Fatalf("apimodel: could not create or assign ServicePrincipal: %q", err)
+
 			}
 
 			dc.containerService.Properties.ServicePrincipalProfile = &api.ServicePrincipalProfile{

--- a/pkg/armhelpers/graph.go
+++ b/pkg/armhelpers/graph.go
@@ -2,14 +2,14 @@ package armhelpers
 
 import (
 	"fmt"
-	"time"
-	"regexp"
 	"github.com/Azure/azure-sdk-for-go/arm/authorization"
 	"github.com/Azure/azure-sdk-for-go/arm/graphrbac"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
+	"regexp"
+	"time"
 )
 
 const (
@@ -105,8 +105,8 @@ func (az *AzureClient) CreateRoleAssignmentSimple(resourceGroup, servicePrincipa
 			roleAssignmentParameters,
 		)
 		if err != nil {
-			match:=re.FindStringSubmatch(err.Error())
-			if  match != nil && (match[1] == "403") {
+			match := re.FindStringSubmatch(err.Error())
+			if match != nil && (match[1] == "403") {
 				//insufficient permissions. stop now
 				log.Debugf("Failed to create role assignment (will abort now): %q", err)
 				return err


### PR DESCRIPTION
**What this PR does / why we need it**:
If the user calling acs-engine deploy does not have the authorization to perform action 'Microsoft.Authorization/roleAssignments/write'  acs-engine loops forever. This was fixed:

* CreateRoleAssignmentSimple could already return an error. This error is now used if arm returns status 403 (not enough permissions).
  This is opposed to status 400 that seems to be issued to signal work in progress during service principal generation (by arm).
* autoFillApimodel did duplicate the retry logic of CreateRoleAssignmentSimple, the duplciated code was removed here. This also allows to properly fail if CreateRoleAssignmentSimple returns an error

**Which issue this PR fixes**
might fix #2157 
related to #2281 