### PR TITLE
Don't display "Error: <nil>" on successful deployment

### DIFF
--- a/pkg/armhelpers/deployments.go
+++ b/pkg/armhelpers/deployments.go
@@ -1,6 +1,8 @@
 package armhelpers
 
 import (
+	"fmt"
+
 	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
 	"github.com/Azure/go-autorest/autorest"
 	log "github.com/sirupsen/logrus"
@@ -31,7 +33,11 @@ func (az *AzureClient) DeployTemplate(resourceGroupName, deploymentName string, 
 		return nil, err
 	}
 
-	log.Infof("Finished ARM Deployment (%s). Error: %v", deploymentName, err)
+	outcomeText := "Succeeded"
+	if err != nil {
+		outcomeText = fmt.Sprintf("Error: %v", err)
+	}
+	log.Infof("Finished ARM Deployment (%s). %s", deploymentName, outcomeText)
 
 	return &res, err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Changes `Error: <nil>` on deployment completion to `Succeeded`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2256 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
