### PR TITLE
Update apimodel after upgrade

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -206,5 +206,26 @@ func (uc *upgradeCmd) run(cmd *cobra.Command, args []string) error {
 		log.Fatalf("Error upgrading cluster: %s \n", err.Error())
 	}
 
+	apiloader := &api.Apiloader{
+		Translator: &i18n.Translator{
+			Locale: uc.locale,
+		},
+	}
+	b, e := apiloader.SerializeContainerService(uc.containerService, uc.apiVersion)
+
+	if e != nil {
+		return e
+	}
+
+	f := acsengine.FileSaver{
+		Translator: &i18n.Translator{
+			Locale: uc.locale,
+		},
+	}
+
+	if e = f.SaveFile(uc.deploymentDirectory, "apimodel.json", b); e != nil {
+		return e
+	}
+
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: If a cluster upgraded successfully, the apimodel in the provided deployment dir should be updated to have upgrade changes applied. This is a first step towards fixing second upgrades without manual intervention.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2273 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
