### PR TITLE
Update docs to reflect current kubelet --read-only-port config

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -186,7 +186,6 @@ Below is a list of kubelet options that are *not* currently user-configurable, e
 |"--kubeconfig"|"/var/lib/kubelet/kubeconfig"|
 |"--register-node" (master nodes only)|"true"|
 |"--register-with-taints" (master nodes only)|"node-role.kubernetes.io/master=true:NoSchedule"|
-|"--read-only-port"|"0"|
 |"--keep-terminated-pod-volumes"|"false"|
 
 <a name="feat-controller-manager-config"></a>


### PR DESCRIPTION
we are not actually setting —read-only-port=0 for kubelet

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Update docs to reflect current kubelet --read-only-port config

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```