### PR TITLE
Update Azure Gov ACSEngineClientID

### DIFF
--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -255,8 +255,7 @@ func getOAuthConfig(env azure.Environment, subscriptionID string) (*adal.OAuthCo
 func getAcsEngineClientID(envName string) string {
 	switch envName {
 	case "AzureUSGovernmentCloud":
-		// TODO: Replace with AppId for Azure US Government Cloud
-		return "76e0feec-6b7f-41f0-81a7-b1b944520261"
+		return "e8b7f94b-85c9-47f4-964a-98dafd7fc2d8"
 	default:
 		return "76e0feec-6b7f-41f0-81a7-b1b944520261"
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the AcsEngineClientId for Azure US Government. A separate Azure AD Service Principal is necessary in order to support the commands that interact with ARM Rest APIs (like `acs-engine deploy`, `acs-engine upgrade` and `acs-engine scale`)

**Which issue this PR fixes**: #2223

**Special notes for your reviewer**: None