### PR TITLE
Remove deprecated '--require-kubeconfig' for k8s

### DIFF
--- a/parts/k8s/artifacts/kuberneteskubelet.service
+++ b/parts/k8s/artifacts/kuberneteskubelet.service
@@ -37,7 +37,6 @@ ExecStart=/usr/bin/docker run \
   --volume=/etc/kubernetes/volumeplugins:/etc/kubernetes/volumeplugins:rw \
     ${KUBELET_IMAGE} \
       /hyperkube kubelet \
-        --require-kubeconfig \
         --enable-server \
         --node-labels="${KUBELET_NODE_LABELS}" \
         --v=2 \

--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -103,7 +103,7 @@ write_files:
   permissions: "0644"
   owner: "root"
   content: |
-{{if IsKubernetesVersionLe "1.7.0"}}
+{{if IsKubernetesVersionLt "1.8.0"}}
     KUBELET_OPTS=--require-kubeconfig
 {{else}}
     KUBELET_OPTS=

--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -103,10 +103,14 @@ write_files:
   permissions: "0644"
   owner: "root"
   content: |
+{{if IsKubernetesVersionLe "1.7.0"}}
+    KUBELET_OPTS=--require-kubeconfig
+{{else}}
+    KUBELET_OPTS=
+{{end}}
     KUBELET_CONFIG={{GetKubeletConfigKeyVals .KubernetesConfig }}
     KUBELET_IMAGE={{WrapAsVariable "kubernetesHyperkubeSpec"}}
     DOCKER_OPTS=
-    KUBELET_OPTS=
     KUBELET_REGISTER_SCHEDULABLE=true
     KUBELET_NODE_LABELS={{GetAgentKubernetesLabels . "',variables('labelResourceGroup'),'"}}
 {{if IsKubernetesVersionGe "1.6.0"}}

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -144,7 +144,7 @@ MASTER_ADDONS_CONFIG_PLACEHOLDER
   permissions: "0644"
   owner: "root"
   content: |
-{{if IsKubernetesVersionLe "1.7.0"}}
+{{if IsKubernetesVersionLt "1.8.0"}}
     KUBELET_OPTS=--require-kubeconfig
 {{else}}
     KUBELET_OPTS=

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -144,10 +144,14 @@ MASTER_ADDONS_CONFIG_PLACEHOLDER
   permissions: "0644"
   owner: "root"
   content: |
+{{if IsKubernetesVersionLe "1.7.0"}}
+    KUBELET_OPTS=--require-kubeconfig
+{{else}}
+    KUBELET_OPTS=
+{{end}}
     KUBELET_CONFIG={{GetKubeletConfigKeyVals .MasterProfile.KubernetesConfig}}
     KUBELET_IMAGE={{WrapAsVariable "kubernetesHyperkubeSpec"}}
     DOCKER_OPTS=
-    KUBELET_OPTS=
     KUBELET_NODE_LABELS={{GetMasterKubernetesLabels "',variables('labelResourceGroup'),'"}}
 {{if IsKubernetesVersionGe "1.6.0"}}
   {{if HasLinuxAgents}}

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -834,6 +834,11 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			constraint, _ := semver.NewConstraint(">=" + version)
 			return cs.Properties.OrchestratorProfile.OrchestratorType == api.Kubernetes && constraint.Check(orchestratorVersion)
 		},
+		"IsKubernetesVersionLe": func(version string) bool {
+			orchestratorVersion, _ := semver.NewVersion(cs.Properties.OrchestratorProfile.OrchestratorVersion)
+			constraint, _ := semver.NewConstraint("<=" + version)
+			return cs.Properties.OrchestratorProfile.OrchestratorType == api.Kubernetes && constraint.Check(orchestratorVersion)
+		},
 		"IsKubernetesVersionTilde": func(version string) bool {
 			// examples include
 			// ~2.3 is equivalent to >= 2.3, < 2.4

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -834,9 +834,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			constraint, _ := semver.NewConstraint(">=" + version)
 			return cs.Properties.OrchestratorProfile.OrchestratorType == api.Kubernetes && constraint.Check(orchestratorVersion)
 		},
-		"IsKubernetesVersionLe": func(version string) bool {
+		"IsKubernetesVersionLt": func(version string) bool {
 			orchestratorVersion, _ := semver.NewVersion(cs.Properties.OrchestratorProfile.OrchestratorVersion)
-			constraint, _ := semver.NewConstraint("<=" + version)
+			constraint, _ := semver.NewConstraint("<" + version)
 			return cs.Properties.OrchestratorProfile.OrchestratorType == api.Kubernetes && constraint.Check(orchestratorVersion)
 		},
 		"IsKubernetesVersionTilde": func(version string) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

The option '--require-kubeconfig' option was no longer required and removed in
https://github.com/kubernetes/kubernetes/pull/59306/files

With v1.10.0-beta.0, kubelet will fail to run when call with he option
```
F0301 03:10:48.067923      19 server.go:142] unknown flag: --require-kubeconfig
```

**Which issue this PR fixes**

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
