### PR TITLE
Update startup script to generate CNI config to include DNS Suffix or Search Path 

### DIFF
--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -131,14 +131,33 @@ Install-Package($package)
     Write-Log "$package installed"
 }
 
+function DownloadFileOverHttp($Url, $DestinationPath)
+{
+     $secureProtocols = @()
+     $insecureProtocols = @([System.Net.SecurityProtocolType]::SystemDefault, [System.Net.SecurityProtocolType]::Ssl3)
+
+     foreach ($protocol in [System.Enum]::GetValues([System.Net.SecurityProtocolType]))
+     {
+         if ($insecureProtocols -notcontains $protocol)
+         {
+             $secureProtocols += $protocol
+         }
+     }
+     [System.Net.ServicePointManager]::SecurityProtocol = $secureProtocols
+
+    curl $Url -UseBasicParsing -OutFile $DestinationPath -Verbose
+    Write-Log "$DestinationPath updated"
+}
+function Get-HnsPsm1()
+{
+    DownloadFileOverHttp "https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1" "$global:HNSModule"
+}
+
 function Update-WinCNI()
 {
     $wincni = "wincni.exe"
     $wincniFile = [Io.path]::Combine($global:CNIPath, $wincni)
-    $url = $global:WindowsPackageSASURLBase + $wincni
-    Invoke-WebRequest -Uri $url -OutFile $wincniFile
-
-    Write-Log "$wincni updated"
+    DownloadFileOverHttp "https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/cni/wincni.exe" $wincniFile
 }
 
 function
@@ -153,6 +172,7 @@ Update-WindowsPackages()
     }
 
     Update-WinCNI
+    Get-HnsPsm1
 }
 
 function
@@ -301,6 +321,7 @@ c:\k\kubelet.exe --hostname-override=`$global:AzureHostname --pod-infra-containe
     $kubeStartStr = @"
 `$global:AzureHostname = "$AzureHostname"
 `$global:MasterIP = "$MasterIP"
+`$global:KubeDnsSearchPath = "svc.cluster.local"
 `$global:KubeDnsServiceIp = "$KubeDnsServiceIp"
 `$global:MasterSubnet = "$global:MasterSubnet"
 `$global:KubeClusterCIDR = "$global:KubeClusterCIDR"
@@ -363,7 +384,8 @@ Update-CNIConfig(`$podCIDR, `$masterSubnetGW)
         }]
     },
     ""dns"" : {
-    ""Nameservers"" : [ ""<NameServers>"" ]
+    ""Nameservers"" : [ ""<NameServers>"" ],
+    ""Search"" : [ ""<Cluster DNS Suffix or Search Path>"" ]
     },
     ""AdditionalArgs"" : [
     {
@@ -380,6 +402,7 @@ Update-CNIConfig(`$podCIDR, `$masterSubnetGW)
     `$configJson.ipam.subnet=`$podCIDR
     `$configJson.ipam.routes[0].GW = `$masterSubnetGW
     `$configJson.dns.Nameservers[0] = `$global:KubeDnsServiceIp
+    `$configJson.dns.Search[0] = `$global:KubeDnsSearchPath
 
     `$configJson.AdditionalArgs[0].Value.ExceptionList[0] = `$global:KubeClusterCIDR
     `$configJson.AdditionalArgs[0].Value.ExceptionList[1] = `$global:MasterSubnet
@@ -429,13 +452,23 @@ try
     # startup the service
     `$hnsNetwork = Get-HnsNetwork | ? Name -EQ `$global:NetworkMode.ToLower()
 
-    if (!`$hnsNetwork)
+    if (`$hnsNetwork)
     {
-        Write-Host "No HNS network found, creating a new one..."
-        ipmo `$global:HNSModule
-
-        `$hnsNetwork = New-HNSNetwork -Type `$global:NetworkMode -AddressPrefix `$podCIDR -Gateway `$masterSubnetGW -Name `$global:NetworkMode.ToLower() -Verbose
+        # Kubelet has been restarted with existing network.
+        # Cleanup all containers
+        docker ps -q | foreach {docker rm `$_ -f}
+        # cleanup network
+        Write-Host "Cleaning up old HNS network found"
+        Remove-HnsNetwork `$hnsNetwork
+        Start-Sleep 10
     }
+
+    Write-Host "Creating a new hns Network"
+    ipmo `$global:HNSModule
+
+    `$hnsNetwork = New-HNSNetwork -Type `$global:NetworkMode -AddressPrefix `$podCIDR -Gateway `$masterSubnetGW -Name `$global:NetworkMode.ToLower() -Verbose
+    # New network has been created, Kubeproxy service has to be restarted
+    Restart-Service Kubeproxy   
 
     Start-Sleep 10
     # Add route to all other POD networks
@@ -456,6 +489,7 @@ catch
     $kubeProxyStartStr = @"
 `$env:KUBE_NETWORK = "$global:KubeNetwork"
 `$global:NetworkMode = "$global:NetworkMode"
+`$global:HNSModule = "$global:HNSModule"
 `$hnsNetwork = Get-HnsNetwork | ? Type -EQ `$global:NetworkMode.ToLower()
 while (!`$hnsNetwork)
 {
@@ -463,7 +497,13 @@ while (!`$hnsNetwork)
     `$hnsNetwork = Get-HnsNetwork | ? Type -EQ `$global:NetworkMode.ToLower()
 }
 
-c:\k\kube-proxy.exe --v=3 --proxy-mode=kernelspace --hostname-override=$AzureHostname --kubeconfig=c:\k\config
+#
+# cleanup the persisted policy lists
+#
+ipmo `$global:HNSModule
+Get-HnsPolicyList | Remove-HnsPolicyList
+
+$global:KubeDir\kube-proxy.exe --v=3 --proxy-mode=kernelspace --hostname-override=$AzureHostname --kubeconfig=$global:KubeDir\config
 "@
 
     $kubeProxyStartStr | Out-File -encoding ASCII -filepath $global:KubeProxyStartFile


### PR DESCRIPTION
* Fix the Outbound connection issue that was broken post reboot
  - Cleanup Hns Policy Lists before starting KubeProxy.
  - Recreate HNS Network

* Support for DNS Suffix - Update startup script to generate CNI config to include DNS Suffix or Search Path.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
