### PR TITLE
Pass --location to containerService

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -111,14 +111,20 @@ func (dc *deployCmd) validate(cmd *cobra.Command, args []string) error {
 			Locale: dc.locale,
 		},
 	}
+
+	if dc.location == "" {
+		return fmt.Errorf(fmt.Sprintf("--location must be specified"))
+	}
 	// skip validating the model fields for now
 	dc.containerService, dc.apiVersion, err = apiloader.LoadContainerServiceFromFile(dc.apimodelPath, false, false, nil)
 	if err != nil {
 		return fmt.Errorf(fmt.Sprintf("error parsing the api model: %s", err.Error()))
 	}
 
-	if dc.location == "" {
-		return fmt.Errorf(fmt.Sprintf("--location must be specified"))
+	if dc.containerService.Location == "" {
+		dc.containerService.Location = dc.location
+	} else if dc.containerService.Location != dc.location {
+		return fmt.Errorf(fmt.Sprintf("--location does not match api model location"))
 	}
 
 	dc.client, err = dc.authArgs.getClient()

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -137,6 +137,12 @@ func (sc *scaleCmd) validate(cmd *cobra.Command, args []string) {
 		log.Fatalf("error parsing the api model: %s", err.Error())
 	}
 
+	if sc.containerService.Location == "" {
+		sc.containerService.Location = sc.location
+	} else if sc.containerService.Location != sc.location {
+		log.Fatalf("--location does not match api model location")
+	}
+
 	if sc.agentPoolToScale == "" {
 		agentPoolCount := len(sc.containerService.Properties.AgentPoolProfiles)
 		if agentPoolCount > 1 {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -131,6 +131,12 @@ func (uc *upgradeCmd) validate(cmd *cobra.Command, args []string) {
 		log.Fatalf("error parsing the api model: %s", err.Error())
 	}
 
+	if uc.containerService.Location == "" {
+		uc.containerService.Location = uc.location
+	} else if uc.containerService.Location != uc.location {
+		log.Fatalf("--location does not match api model location")
+	}
+
 	// get available upgrades for container service
 	orchestratorInfo, err := api.GetOrchestratorVersionProfile(uc.containerService.Properties.OrchestratorProfile)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**: This PR is needed to get `deploy`, `scale` and `upgrade` working with sovereign clouds without having to add the location to the apimodel.json file. 

**Which issue this PR fixes**: fixes #2380 

**Special notes for your reviewer**:
Before this PR, the `--location` wasn't being passed down to `deploy.go:templateGenerator.GenerateTemplate`, so  the resulting template would not have the sovereign cloud parameters (e.g. `osImageVersion`, `fqdnEndpointSuffix`, `targetEnvironment`) unless you ALSO specified `"location": "usgovvirginia"` in the `apimodel.json` file.

To fix this, we should pass the value from `--location` into the `containerService` object. There are different ways / places to do this. I'm not a big fan of replicating the check however there's already similar replication across these three commands (deploy, scale and upgrade) already.

I opted for only populating the `containerService.Location` if it didn't have one already, and if it does and it doesn't match the `--location`, error out. I think this is the safest approach.
