### PR TITLE
Update default tiller version to 2.8.1

### DIFF
--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -88,7 +88,7 @@ const (
 	DefaultDashboardAddonName = "kubernetes-dashboard"
 	// DefaultTillerImage defines the Helm Tiller deployment version on Kubernetes Clusters
 	// TODO deprecate this usage, we should be favoring a more frequent upgrade cycle that pins fresh tiller versions to specific k8s versions
-	DefaultTillerImage = "tiller:v2.6.2"
+	DefaultTillerImage = "tiller:v2.8.1"
 	// DefaultACIConnectorImage defines the ACI Connector deployment version on Kubernetes Clusters
 	DefaultACIConnectorImage = "virtual-kubelet:latest"
 	// DefaultKubernetesDNSServiceIP specifies the IP address that kube-dns


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the default helm/tiller version to `2.8.1` from `2.6.2`.