### PR TITLE
auto-jumpbox provisioning for private clusters 

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -41,7 +41,7 @@ Here are the valid values for the orchestrator types:
 |enableRbac|no|Enable [Kubernetes RBAC](https://kubernetes.io/docs/admin/authorization/rbac/) (boolean - default == true) |
 |enableAggregatedAPIs|no|Enable [Kubernetes Aggregated APIs](https://kubernetes.io/docs/concepts/api-extension/apiserver-aggregation/).This is required by [Service Catalog](https://github.com/kubernetes-incubator/service-catalog/blob/master/README.md). (boolean - default == false) |
 |enableDataEncryptionAtRest|no|Enable [kuberetes data encryption at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).This is currently an alpha feature. (boolean - default == false) |
-|privateCluster|no|Build a cluster without public addresses assigned. See `privateClusters` [here](#feat-private-cluster).|
+|privateCluster|no|Build a cluster without public addresses assigned. See `privateClusters` [here](./kubernetes/features.md/#feat-private-cluster).|
 |maxPods|no|The maximum number of pods per node. The minimum valid value, necessary for running kube-system pods, is 5. Default value is 30 when networkPolicy equals azure, 110 otherwise.|
 |gcHighThreshold|no|Sets the --image-gc-high-threshold value on the kublet configuration. Default is 85. [See kubelet Garbage Collection](https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/) |
 |gcLowThreshold|no|Sets the --image-gc-low-threshold value on the kublet configuration. Default is 80. [See kubelet Garbage Collection](https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/) |

--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -41,7 +41,7 @@ Here are the valid values for the orchestrator types:
 |enableRbac|no|Enable [Kubernetes RBAC](https://kubernetes.io/docs/admin/authorization/rbac/) (boolean - default == true) |
 |enableAggregatedAPIs|no|Enable [Kubernetes Aggregated APIs](https://kubernetes.io/docs/concepts/api-extension/apiserver-aggregation/).This is required by [Service Catalog](https://github.com/kubernetes-incubator/service-catalog/blob/master/README.md). (boolean - default == false) |
 |enableDataEncryptionAtRest|no|Enable [kuberetes data encryption at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).This is currently an alpha feature. (boolean - default == false) |
-|enablePrivateCluster|no|Build a cluster without public addresses assigned (boolean - default == false) |
+|privateCluster|no|Build a cluster without public addresses assigned. See `privateClusters` [here](#feat-private-cluster).|
 |maxPods|no|The maximum number of pods per node. The minimum valid value, necessary for running kube-system pods, is 5. Default value is 30 when networkPolicy equals azure, 110 otherwise.|
 |gcHighThreshold|no|Sets the --image-gc-high-threshold value on the kublet configuration. Default is 85. [See kubelet Garbage Collection](https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/) |
 |gcLowThreshold|no|Sets the --image-gc-low-threshold value on the kublet configuration. Default is 80. [See kubelet Garbage Collection](https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/) |

--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -41,7 +41,7 @@ Here are the valid values for the orchestrator types:
 |enableRbac|no|Enable [Kubernetes RBAC](https://kubernetes.io/docs/admin/authorization/rbac/) (boolean - default == true) |
 |enableAggregatedAPIs|no|Enable [Kubernetes Aggregated APIs](https://kubernetes.io/docs/concepts/api-extension/apiserver-aggregation/).This is required by [Service Catalog](https://github.com/kubernetes-incubator/service-catalog/blob/master/README.md). (boolean - default == false) |
 |enableDataEncryptionAtRest|no|Enable [kuberetes data encryption at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).This is currently an alpha feature. (boolean - default == false) |
-|privateCluster|no|Build a cluster without public addresses assigned. See `privateClusters` [here](./kubernetes/features.md/#feat-private-cluster).|
+|privateCluster|no|Build a cluster without public addresses assigned. See `privateClusters` [below](#feat-private-cluster).|
 |maxPods|no|The maximum number of pods per node. The minimum valid value, necessary for running kube-system pods, is 5. Default value is 30 when networkPolicy equals azure, 110 otherwise.|
 |gcHighThreshold|no|Sets the --image-gc-high-threshold value on the kublet configuration. Default is 85. [See kubelet Garbage Collection](https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/) |
 |gcLowThreshold|no|Sets the --image-gc-low-threshold value on the kublet configuration. Default is 80. [See kubelet Garbage Collection](https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/) |
@@ -356,6 +356,29 @@ Below is a list of apiserver options that are *not* currently user-configurable,
 |"--oidc-issuer-url"|*calculated value that represents OID issuer URL* (*if has AADProfile*)|
 
 We consider `kubeletConfig`, `controllerManagerConfig`, and `apiServerConfig` to be generic conveniences that add power/flexibility to cluster deployments. Their usage comes with no operational guarantees! They are manual tuning features that enable low-level configuration of a kubernetes cluster.
+
+<a name="feat-private-cluster"></a>
+#### privateCluster
+
+`privateCluster` defines a cluster without public addresses assigned. It is a child property of `kubernetesConfig`.
+
+|Name|Required|Description|
+|---|---|---|
+|enabled|no|Enable [Private Cluster](./kubernetes/features.md/#feat-private-cluster) (boolean - default == false) |
+|jumpboxProfile|no|Configure and auto-provision a jumpbox to access your private cluster. `jumpboxProfile` is ignored if enabled is `false`. See `jumpboxProfile` below.|
+
+#### jumpboxProfile
+
+`jumpboxProfile` describes the settings for a jumpbox deployed via acs-engine to access a private cluster. It is a child property of `privateCluster`.
+
+|Name|Required|Description|
+|---|---|---|
+|name|yes|This is the unique name for the jumpbox VM. Some resources deployed with the jumpbox are derived from this name.|
+|vmSize|yes|Describes a valid [Azure VM Sizes](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-windows-sizes/).|
+|publicKey|yes|The public SSH key used for authenticating access to the jumpbox.  Here are instructions for [generating a public/private key pair](ssh.md#ssh-key-generation).|
+|osDiskSizeGB|no|Describes the OS Disk Size in GB. Defaults to `30`|
+|storageProfile|no|Specifies the storage profile to use.  Valid values are [StorageAccount](../examples/disks-storageaccount) or [ManagedDisks](../examples/disks-managed). Defaults to `StorageAccount`|
+|username|no|describes the admin username to be used on the jumpbox. Defaults to `azureuser`|
 
 ### masterProfile
 `masterProfile` describes the settings for master configuration.

--- a/docs/kubernetes/features.md
+++ b/docs/kubernetes/features.md
@@ -300,7 +300,7 @@ To auto-provision a jumpbox with your acs-engine deployment use:
       "kubernetesConfig": {
         "privateCluster": {
           "enabled": true,
-          "jumpbox": {
+          "jumpboxProfile": {
             "name": "my-jb",
             "vmSize": "Standard_D4s_v3",
             "diskSizeGB": 30,

--- a/docs/kubernetes/features.md
+++ b/docs/kubernetes/features.md
@@ -304,6 +304,7 @@ To auto-provision a jumpbox with your acs-engine deployment use:
             "name": "my-jb",
             "vmSize": "Standard_D4s_v3",
             "diskSizeGB": 30,
+            "storageProfile": "ManagedDisks",
             "username": "azureuser",
             "publicKey": "xxx"
           }

--- a/docs/kubernetes/features.md
+++ b/docs/kubernetes/features.md
@@ -281,14 +281,31 @@ You can build a private Kubernetes cluster with no public IP addresses assigned 
 
 ```
       "kubernetesConfig": {
-        "enablePrivateCluster": true
+        "privateCluster": {
+          "enabled": true
       }
 ```
 
-In order to access this cluster using kubectl commands, you will need a jumpbox in the same VNET (or onto a peer VNET that routes to the VNET). You can create a new jumpbox (if you don't already have one) in the Azure Portal under "Create a resource > Compute > Ubuntu Server 16.04 LTS VM" or using the [az cli](https://docs.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az_vm_create). You will then be able to:
+In order to access this cluster using kubectl commands, you will need a jumpbox in the same VNET (or onto a peer VNET that routes to the VNET). If you do not already have a jumpbox, you can use acs-engine to provision your jumpbox (see below) or create it manually. You can create a new jumpbox manually in the Azure Portal under "Create a resource > Compute > Ubuntu Server 16.04 LTS VM" or using the [az cli](https://docs.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az_vm_create). You will then be able to:
 - install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on the jumpbox
 - copy the kubeconfig artifact for the right region from the deployment directory to the jumpbox
 - run `export KUBECONFIG=<path to your kubeconfig>`
 - run `kubectl` commands directly on the jumpbox
 
 Alternatively, you may also ssh into your nodes (given that your ssh key is on the jumpbox) and use the admin user kubeconfig on the cluster to run `kubectl` commands directly on the cluster. However, in the case of a multi-master private cluster, the connection will be refused when running commands on a master every time that master gets picked by the load balancer as it will be routing to itself (1 in 3 times for a 3 master cluster, 1 in 5 for 5 masters). This is expected behavior and therefore the method aforementioned of accessing nodes on the jumpbox using the `_output` directory kubeconfig is preferred.
+
+To auto-provision a jumpbox with your acs-engine deployment use:
+
+```
+      "kubernetesConfig": {
+        "privateCluster": {
+          "enabled": true,
+          "jumpbox": {
+            "name": "my-jb",
+            "vmSize": "Standard_D4s_v3",
+            "diskSizeGB": 30,
+            "username": "azureuser",
+            "publicKey": "xxx"
+          }
+      }
+```

--- a/docs/kubernetes/features.md
+++ b/docs/kubernetes/features.md
@@ -303,7 +303,7 @@ To auto-provision a jumpbox with your acs-engine deployment use:
           "jumpboxProfile": {
             "name": "my-jb",
             "vmSize": "Standard_D4s_v3",
-            "diskSizeGB": 30,
+            "osDiskSizeGB": 30,
             "storageProfile": "ManagedDisks",
             "username": "azureuser",
             "publicKey": "xxx"

--- a/examples/e2e-tests/kubernetes/kubernetes-config/private-cluster-single-master.json
+++ b/examples/e2e-tests/kubernetes/kubernetes-config/private-cluster-single-master.json
@@ -14,6 +14,8 @@
             "username": "azureuser",
             "publicKey": ""
           }
+        }
+      }
     },
     "masterProfile": {
       "count": 1,

--- a/examples/e2e-tests/kubernetes/kubernetes-config/private-cluster-single-master.json
+++ b/examples/e2e-tests/kubernetes/kubernetes-config/private-cluster-single-master.json
@@ -4,7 +4,8 @@
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
-        "enablePrivateCluster": true
+        "privateCluster": {
+          "enabled": true
       }
     },
     "masterProfile": {

--- a/examples/e2e-tests/kubernetes/kubernetes-config/private-cluster-single-master.json
+++ b/examples/e2e-tests/kubernetes/kubernetes-config/private-cluster-single-master.json
@@ -5,8 +5,15 @@
       "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "privateCluster": {
-          "enabled": true
-      }
+          "enabled": true,
+          "jumpboxProfile": {
+            "name": "my-jb",
+            "vmSize": "Standard_D2_v2",
+            "diskSizeGB": 30,
+            "storageProfile": "ManagedDisks",
+            "username": "azureuser",
+            "publicKey": ""
+          }
     },
     "masterProfile": {
       "count": 1,

--- a/examples/e2e-tests/kubernetes/kubernetes-config/private-cluster.json
+++ b/examples/e2e-tests/kubernetes/kubernetes-config/private-cluster.json
@@ -14,6 +14,7 @@
             "username": "azureuser",
             "publicKey": ""
           }
+          }
         }
       },
       "masterProfile": {
@@ -44,5 +45,5 @@
         "secret": ""
       },
       "certificateProfile": {}
-    }
   }
+}

--- a/examples/e2e-tests/kubernetes/kubernetes-config/private-cluster.json
+++ b/examples/e2e-tests/kubernetes/kubernetes-config/private-cluster.json
@@ -5,37 +5,44 @@
       "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
         "privateCluster": {
-          "enabled": true
-        }
-      }
-    },
-    "masterProfile": {
-      "count": 3,
-      "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
-    },
-    "agentPoolProfiles": [
-      {
-        "name": "linuxpool1",
-        "count": 3,
-        "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "AvailabilitySet"
-      }
-    ],
-    "linuxProfile": {
-      "adminUsername": "azureuser",
-      "ssh": {
-        "publicKeys": [
-          {
-            "keyData": ""
+          "enabled": true,
+          "jumpboxProfile": {
+            "name": "my-jb",
+            "vmSize": "Standard_D2_v2",
+            "diskSizeGB": 30,
+            "storageProfile": "ManagedDisks",
+            "username": "azureuser",
+            "publicKey": ""
           }
-        ]
-      }
-    },
-    "servicePrincipalProfile": {
-      "clientId": "",
-      "secret": ""
-    },
-    "certificateProfile": {}
+        }
+      },
+      "masterProfile": {
+        "count": 3,
+        "dnsPrefix": "",
+        "vmSize": "Standard_D2_v2"
+      },
+      "agentPoolProfiles": [
+        {
+          "name": "linuxpool1",
+          "count": 3,
+          "vmSize": "Standard_D2_v2",
+          "availabilityProfile": "AvailabilitySet"
+        }
+      ],
+      "linuxProfile": {
+        "adminUsername": "azureuser",
+        "ssh": {
+          "publicKeys": [
+            {
+              "keyData": ""
+            }
+          ]
+        }
+      },
+      "servicePrincipalProfile": {
+        "clientId": "",
+        "secret": ""
+      },
+      "certificateProfile": {}
+    }
   }
-}

--- a/examples/e2e-tests/kubernetes/kubernetes-config/private-cluster.json
+++ b/examples/e2e-tests/kubernetes/kubernetes-config/private-cluster.json
@@ -4,7 +4,9 @@
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
-        "enablePrivateCluster": true
+        "privateCluster": {
+          "enabled": true
+        }
       }
     },
     "masterProfile": {

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -406,12 +406,18 @@
                   "sku": "16.04-LTS",
                   "version": "latest"
               },
-              "osDisk": {
-                  "name": "[variables('jumpboxOSDiskName')]",
-                  "createOption": "fromImage",
-                  "diskSizeGB": "[variables('jumpboxDiskSizeGB')]"
-              },
-              "dataDisks": []
+          "osDisk": { 
+            "diskSizeGB": "[variables('jumpboxDiskSizeGB')]",
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+{{if .MasterProfile.IsStorageAccount}}
+            ,"name": "[variables('jumpboxOSDiskName')]"
+            ,"vhd": {
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/',variables('jumpboxVMName'),'-osdisk.vhd')]"
+            }
+{{end}}
+          },    
+          "dataDisks": []
           },
           "networkProfile": {
               "networkInterfaces": [
@@ -473,6 +479,7 @@
                       "subnet": {
                           "id": "[variables('vnetSubnetID')]"
                       },
+                      "primary": true,
                       "privateIPAllocationMethod": "Dynamic",
                       "publicIpAddress": {
                           "id": "[resourceId('Microsoft.Network/publicIpAddresses', variables('jumpboxPublicIpAddressName'))]"
@@ -626,11 +633,11 @@
               ,"diskSizeGB": "[variables('etcdDiskSizeGB')]"
               ,"lun": 0
               ,"name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-etcddisk')]"
-          {{if .MasterProfile.IsStorageAccount}}
+              {{if .MasterProfile.IsStorageAccount}}
               ,"vhd": {
                 "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/', variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')),'-etcddisk.vhd')]"
               }
-          {{end}}
+              {{end}}
             }
           ],
           "imageReference": {

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -407,11 +407,9 @@
                   "version": "latest"
               },
               "osDisk": {
+                  "name": "[variables('jumpboxOSDiskName')]",
                   "createOption": "fromImage",
-                  "diskSizeGB": "[variables('jumpboxDiskSizeGB')]",
-                  "managedDisk": {
-                      "storageAccountType": "Premium_LRS"
-                  }
+                  "diskSizeGB": "[variables('jumpboxDiskSizeGB')]"
               },
               "dataDisks": []
           },
@@ -421,7 +419,7 @@
                       "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('jumpboxNetworkInterfaceName'))]"
                   }
               ]
-          },
+          }
         },
         "dependsOn": [
             "[concat('Microsoft.Network/networkInterfaces/', variables('jumpboxNetworkInterfaceName'))]"
@@ -464,7 +462,7 @@
     },
     {
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "[variables('networkInterfaceName')]",
+      "name": "[variables('jumpboxNetworkInterfaceName')]",
       "apiVersion": "[variables('apiVersionDefault')]",
       "location": "[variables('location')]",
       "properties": {

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -407,11 +407,11 @@
                   "version": "latest"
               },
           "osDisk": { 
-            "diskSizeGB": "[variables('jumpboxDiskSizeGB')]",
+            "diskSizeGB": "[variables('jumpboxOSDiskSizeGB')]",
             "caching": "ReadWrite",
-            "createOption": "FromImage"
+            "createOption": "FromImage",
+            "name": "[variables('jumpboxOSDiskName')]"
 {{if .MasterProfile.IsStorageAccount}}
-            ,"name": "[variables('jumpboxOSDiskName')]"
             ,"vhd": {
               "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/',variables('jumpboxVMName'),'-osdisk.vhd')]"
             }

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -306,74 +306,192 @@
       "type": "Microsoft.Network/networkInterfaces"
     },
 {{else}}
-    {
-      "apiVersion": "[variables('apiVersionDefault')]",
-      "copy": {
-        "count": "[sub(variables('masterCount'), variables('masterOffset'))]",
-        "name": "nicLoopNode"
-      },
-      "dependsOn": [
-{{if .MasterProfile.IsCustomVNET}}
-        "[variables('nsgID')]"
-{{else}}
-        "[variables('vnetID')]"
-{{end}}
-{{if gt .MasterProfile.Count 1}}
-        ,"[variables('masterInternalLbName')]"
-{{end}}
-      ],
-      "location": "[variables('location')]",
-      "name": "[concat(variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]",
-      "properties": {
-        "ipConfigurations": [
-          {
-            "name": "ipconfig1",
-            "properties": {
-              "loadBalancerBackendAddressPools": [
-{{if gt .MasterProfile.Count 1}}                
-                {
-                   "id": "[concat(variables('masterInternalLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"
+      {
+        "apiVersion": "[variables('apiVersionDefault')]",
+        "copy": {
+          "count": "[sub(variables('masterCount'), variables('masterOffset'))]",
+          "name": "nicLoopNode"
+        },
+        "dependsOn": [
+  {{if .MasterProfile.IsCustomVNET}}
+          "[variables('nsgID')]"
+  {{else}}
+          "[variables('vnetID')]"
+  {{end}}
+  {{if gt .MasterProfile.Count 1}}
+          ,"[variables('masterInternalLbName')]"
+  {{end}}
+        ],
+        "location": "[variables('location')]",
+        "name": "[concat(variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]",
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig1",
+              "properties": {
+                "loadBalancerBackendAddressPools": [
+  {{if gt .MasterProfile.Count 1}}                
+                  {
+                    "id": "[concat(variables('masterInternalLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"
+                  }
+  {{end}}
+                ],
+                "loadBalancerInboundNatRules": [
+                ],
+                "privateIPAddress": "[variables('masterPrivateIpAddrs')[copyIndex(variables('masterOffset'))]]",
+                "primary": true,
+                "privateIPAllocationMethod": "Static",
+                "subnet": {
+                  "id": "[variables('vnetSubnetID')]"
                 }
-{{end}}
-              ],
-              "loadBalancerInboundNatRules": [
-              ],
-              "privateIPAddress": "[variables('masterPrivateIpAddrs')[copyIndex(variables('masterOffset'))]]",
-              "primary": true,
-              "privateIPAllocationMethod": "Static",
-              "subnet": {
-                "id": "[variables('vnetSubnetID')]"
               }
             }
-          }
-{{if IsAzureCNI}}
-          {{range $seq := loop 2 .MasterProfile.IPAddressCount}}
+  {{if IsAzureCNI}}
+            {{range $seq := loop 2 .MasterProfile.IPAddressCount}}
+            ,
+            {
+              "name": "ipconfig{{$seq}}",
+              "properties": {
+                "primary": false,
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "[variables('vnetSubnetID')]"
+                }
+              }
+            }
+            {{end}}
+  {{end}}
+          ]
+  {{if not IsAzureCNI}}
           ,
-          {
-            "name": "ipconfig{{$seq}}",
-            "properties": {
-              "primary": false,
-              "privateIPAllocationMethod": "Dynamic",
-              "subnet": {
-                "id": "[variables('vnetSubnetID')]"
-              }
-            }
+          "enableIPForwarding": true
+  {{end}}
+  {{if .MasterProfile.IsCustomVNET}}
+          ,"networkSecurityGroup": {
+            "id": "[variables('nsgID')]"
           }
-          {{end}}
-{{end}}
-        ]
-{{if not IsAzureCNI}}
-        ,
-        "enableIPForwarding": true
-{{end}}
-{{if .MasterProfile.IsCustomVNET}}
-        ,"networkSecurityGroup": {
-          "id": "[variables('nsgID')]"
-        }
-{{end}}
+  {{end}}
+        },
+        "type": "Microsoft.Network/networkInterfaces"
       },
-      "type": "Microsoft.Network/networkInterfaces"
+  {{if ProvisionJumpbox}}
+    {
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[variables('jumpboxVMName')]",
+      "apiVersion": "[variables('apiVersionDefault')]",
+      "location": "[variables('location')]",
+      "properties": {
+          "osProfile": {
+              "computerName": "[variables('jumpboxVMName')]",
+              "adminUsername": "[variables('jumpboxUsername')]",
+              "linuxConfiguration": {
+                  "disablePasswordAuthentication": "true",
+                  "ssh": {
+                      "publicKeys": [
+                          {
+                              "path": "[concat('/home/', variables('jumpboxUsername'), '/.ssh/authorized_keys')]",
+                              "keyData": "[variables('jumpboxPublicKey')]"
+                          }
+                      ]
+                  }
+              }
+          },
+          "hardwareProfile": {
+              "vmSize": "[variables('jumboxVMSize')]"
+          },
+          "storageProfile": {
+              "imageReference": {
+                  "publisher": "Canonical",
+                  "offer": "UbuntuServer",
+                  "sku": "16.04-LTS",
+                  "version": "latest"
+              },
+              "osDisk": {
+                  "createOption": "fromImage",
+                  "diskSizeGB": "[variables('jumpboxDiskSizeGB')]",
+                  "managedDisk": {
+                      "storageAccountType": "Premium_LRS"
+                  }
+              },
+              "dataDisks": []
+          },
+          "networkProfile": {
+              "networkInterfaces": [
+                  {
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('jumpboxNetworkInterfaceName'))]"
+                  }
+              ]
+          },
+        },
+        "dependsOn": [
+            "[concat('Microsoft.Network/networkInterfaces/', variables('jumpboxNetworkInterfaceName'))]"
+        ]
     },
+    {
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('jumpboxNetworkSecurityGroupName')]",
+      "apiVersion": "[variables('apiVersionDefault')]",
+      "location": "[variables('location')]",
+      "properties": {
+          "securityRules": [
+              {
+                  "name": "default-allow-ssh",
+                  "properties": {
+                      "priority": 1000,
+                      "protocol": "TCP",
+                      "access": "Allow",
+                      "direction": "Inbound",
+                      "sourceAddressPrefix": "*",
+                      "sourcePortRange": "*",
+                      "destinationAddressPrefix": "*",
+                      "destinationPortRange": "22"
+                  }
+              }
+          ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/publicIpAddresses",
+      "sku": {
+          "name": "Basic"
+      },
+      "name": "[variables('jumpboxPublicIpAddressName')]",
+      "apiVersion": "[variables('apiVersionDefault')]",
+      "location": "[variables('location')]",
+      "properties": {
+          "publicIpAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('networkInterfaceName')]",
+      "apiVersion": "[variables('apiVersionDefault')]",
+      "location": "[variables('location')]",
+      "properties": {
+          "ipConfigurations": [
+              {
+                  "name": "ipconfig1",
+                  "properties": {
+                      "subnet": {
+                          "id": "[variables('vnetSubnetID')]"
+                      },
+                      "privateIPAllocationMethod": "Dynamic",
+                      "publicIpAddress": {
+                          "id": "[resourceId('Microsoft.Network/publicIpAddresses', variables('jumpboxPublicIpAddressName'))]"
+                      }
+                  }
+              }
+          ],
+          "networkSecurityGroup": {
+              "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('jumpboxNetworkSecurityGroupName'))]"
+          }
+      },
+        "dependsOn": [
+            "[concat('Microsoft.Network/publicIpAddresses/', variables('jumpboxPublicIpAddressName'))]",
+            "[concat('Microsoft.Network/networkSecurityGroups/', variables('jumpboxNetworkSecurityGroupName'))]"
+        ]
+    },
+  {{end}}
 {{end}}
 {{if gt .MasterProfile.Count 1}}
     {

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -275,7 +275,7 @@
         "kubeconfigServer": "[concat('https://', variables('kubernetesAPIServerIP'), ':443')]",
         "jumpboxVMName": "[parameters('jumpboxVMName')]",
         "jumboxVMSize": "[parameters('jumpboxVMSize')]",
-        "jumpboxDiskSizeGB": "[parameters('jumpboxDiskSizeGB')]",
+        "jumpboxOSDiskSizeGB": "[parameters('jumpboxOSDiskSizeGB')]",
         "jumpboxOSDiskName": "[concat(variables('jumpboxVMName'), '-osdisk')]",
         "jumpboxUsername": "[parameters('jumpboxUsername')]",
         "jumpboxPublicKey": "[parameters('jumpboxPublicKey')]",

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -276,6 +276,7 @@
         "jumpboxVMName": "[concat(variables('resourceGroup'), '-jb')]",
         "jumboxVMSize": "Standard_DS1_v2",
         "jumpboxDiskSizeGB": "30",
+        "jumpboxOSDiskName": "[concat(variables('jumpboxVMName'), '-os-disk')]",
         "jumpboxUsername": "azureuser",
         "jumpboxPublicKey": "sshPublicKeyData",
         "jumpboxPublicIpAddressName": "[concat(variables('jumpboxVMName'), '-ip')]",

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -273,6 +273,14 @@
 {{if not IsHostedMaster }}
     {{if IsPrivateCluster}}
         "kubeconfigServer": "[concat('https://', variables('kubernetesAPIServerIP'), ':443')]",
+        "jumpboxVMName": "[concat(variables('resourceGroup'), '-jb')]",
+        "jumboxVMSize": "Standard_DS1_v2",
+        "jumpboxDiskSizeGB": "30",
+        "jumpboxUsername": "azureuser",
+        "jumpboxPublicKey": "sshPublicKeyData",
+        "jumpboxPublicIpAddressName": "[concat(variables('jumpboxVMName'), '-ip')]",
+        "jumpboxNetworkInterfaceName": "[concat(variables('jumpboxVMName'), '-nic')]",
+        "jumpboxNetworkSecurityGroupName": "[concat(variables('jumpboxVMName'), '-nsg')]",
     {{else}}
         "masterPublicIPAddressName": "[concat(variables('orchestratorName'), '-master-ip-', variables('masterFqdnPrefix'), '-', variables('nameSuffix'))]",
         "masterLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('masterLbName'))]",

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -273,12 +273,12 @@
 {{if not IsHostedMaster }}
     {{if IsPrivateCluster}}
         "kubeconfigServer": "[concat('https://', variables('kubernetesAPIServerIP'), ':443')]",
-        "jumpboxVMName": "[concat(variables('resourceGroup'), '-jb')]",
-        "jumboxVMSize": "Standard_DS1_v2",
-        "jumpboxDiskSizeGB": "30",
-        "jumpboxOSDiskName": "[concat(variables('jumpboxVMName'), '-os-disk')]",
-        "jumpboxUsername": "azureuser",
-        "jumpboxPublicKey": "sshPublicKeyData",
+        "jumpboxVMName": "[parameters('jumpboxVMName')]",
+        "jumboxVMSize": "[parameters('jumpboxVMSize')]",
+        "jumpboxDiskSizeGB": "[parameters('jumpboxDiskSizeGB')]",
+        "jumpboxOSDiskName": "[concat(variables('jumpboxVMName'), '-osdisk')]",
+        "jumpboxUsername": "[parameters('jumpboxUsername')]",
+        "jumpboxPublicKey": "[parameters('jumpboxPublicKey')]",
         "jumpboxPublicIpAddressName": "[concat(variables('jumpboxVMName'), '-ip')]",
         "jumpboxNetworkInterfaceName": "[concat(variables('jumpboxVMName'), '-nic')]",
         "jumpboxNetworkSecurityGroupName": "[concat(variables('jumpboxVMName'), '-nsg')]",

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -274,14 +274,18 @@
     {{if IsPrivateCluster}}
         "kubeconfigServer": "[concat('https://', variables('kubernetesAPIServerIP'), ':443')]",
         "jumpboxVMName": "[parameters('jumpboxVMName')]",
-        "jumboxVMSize": "[parameters('jumpboxVMSize')]",
+        "jumpboxVMSize": "[parameters('jumpboxVMSize')]",
         "jumpboxOSDiskSizeGB": "[parameters('jumpboxOSDiskSizeGB')]",
         "jumpboxOSDiskName": "[concat(variables('jumpboxVMName'), '-osdisk')]",
         "jumpboxUsername": "[parameters('jumpboxUsername')]",
         "jumpboxPublicKey": "[parameters('jumpboxPublicKey')]",
+        "jumpboxStorageProfile": "[parameters('jumpboxStorageProfile')]",
         "jumpboxPublicIpAddressName": "[concat(variables('jumpboxVMName'), '-ip')]",
         "jumpboxNetworkInterfaceName": "[concat(variables('jumpboxVMName'), '-nic')]",
         "jumpboxNetworkSecurityGroupName": "[concat(variables('jumpboxVMName'), '-nsg')]",
+        {{if not JumpboxIsManagedDisks}}
+        "jumpboxStorageAccountName": "[concat(variables('storageAccountBaseName'), 'jb')]",
+        {{end}}
     {{else}}
         "masterPublicIPAddressName": "[concat(variables('orchestratorName'), '-master-ip-', variables('masterFqdnPrefix'), '-', variables('nameSuffix'))]",
         "masterLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('masterLbName'))]",

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -706,8 +706,8 @@
       }, 
       "type": "string"
     },
-    "jumpboxDiskSizeGB": {
-      {{PopulateClassicModeDefaultValue "jumpboxDiskSizeGB"}}
+    "jumpboxOSDiskSizeGB": {
+      {{PopulateClassicModeDefaultValue "jumpboxOSDiskSizeGB"}}
       "metadata": {
         "description": "Size in GB to allocate to the jumpbox VM OS."
       }, 

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -692,3 +692,37 @@
       },
       "type": "string"
     }
+{{if ProvisionJumpbox}}
+    ,"jumpboxVMName": {
+      "metadata": {
+        "description": "jumpbox VM Name"
+      },
+      "type": "string"
+    },
+    "jumpboxVMSize": {
+      {{GetMasterAllowedSizes}}
+      "metadata": {
+        "description": "The size of the Virtual Machine. Required"
+      }, 
+      "type": "string"
+    },
+    "jumpboxDiskSizeGB": {
+      {{PopulateClassicModeDefaultValue "jumpboxDiskSizeGB"}}
+      "metadata": {
+        "description": "Size in GB to allocate to the jumpbox VM OS."
+      }, 
+      "type": "int"
+    },
+    "jumpboxPublicKey": {
+      "metadata": {
+        "description": "SSH public key used for auth to the jumpbox. Required."
+      }, 
+      "type": "string"
+    },
+    "jumpboxUsername": {
+      "metadata": {
+        "description": "Username for the jumpbox. Default is azureuser."
+      }, 
+      "type": "string"
+    }
+{{end}}

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -709,19 +709,25 @@
     "jumpboxOSDiskSizeGB": {
       {{PopulateClassicModeDefaultValue "jumpboxOSDiskSizeGB"}}
       "metadata": {
-        "description": "Size in GB to allocate to the jumpbox VM OS."
+        "description": "Size in GB to allocate to the private cluster jumpbox VM OS."
       }, 
       "type": "int"
     },
     "jumpboxPublicKey": {
       "metadata": {
-        "description": "SSH public key used for auth to the jumpbox. Required."
+        "description": "SSH public key used for auth to the private cluster jumpbox"
       }, 
       "type": "string"
     },
     "jumpboxUsername": {
       "metadata": {
-        "description": "Username for the jumpbox. Default is azureuser."
+        "description": "Username for the private cluster jumpbox"
+      }, 
+      "type": "string"
+    },
+    "jumpboxStorageProfile": {
+      "metadata": {
+        "description": "Storage Profile for the private cluster jumpbox"
       }, 
       "type": "string"
     }

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -125,6 +125,8 @@ const (
 	DefaultKubeletEventQPS = "0"
 	// DefaultKubeletCadvisorPort is 0, see --cadvisor-port at https://kubernetes.io/docs/reference/generated/kubelet/
 	DefaultKubeletCadvisorPort = "0"
+	// DefaultJumpboxDiskSize specifies the default size for private cluster jumpbox OS disk in GB
+	DefaultJumpboxDiskSize = 30
 )
 
 const (

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -127,6 +127,8 @@ const (
 	DefaultKubeletCadvisorPort = "0"
 	// DefaultJumpboxDiskSize specifies the default size for private cluster jumpbox OS disk in GB
 	DefaultJumpboxDiskSize = 30
+	// DefaultJumpboxUsername specifies the default admin username for the private cluster jumpbox
+	DefaultJumpboxUsername = "azureuser"
 )
 
 const (

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -463,6 +463,10 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 			a.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = pointerToBool(api.DefaultSecureKubeletEnabled)
 		}
 
+		if a.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata == nil {
+			a.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = pointerToBool(api.DefaultUseInstanceMetadata)
+		}
+
 		// Configure kubelet
 		setKubeletConfig(cs)
 		// Configure controller-manager

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -443,12 +443,16 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 			a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB = DefaultEtcdDiskSize
 		}
 
-		if a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile != nil && a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB == 0 {
+		if a.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision() && a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB == 0 {
 			a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB = DefaultJumpboxDiskSize
 		}
 
-		if a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile != nil && a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Username == "" {
+		if a.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision() && a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Username == "" {
 			a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Username = DefaultJumpboxUsername
+		}
+
+		if a.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision() && a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.StorageProfile == "" {
+			a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.StorageProfile = api.StorageAccount
 		}
 
 		if a.OrchestratorProfile.KubernetesConfig.EnableRbac == nil {

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -443,8 +443,12 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 			a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB = DefaultEtcdDiskSize
 		}
 
-		if a.OrchestratorProfile.KubernetesConfig.PrivateCluster.Jumpbox != nil && a.OrchestratorProfile.KubernetesConfig.PrivateCluster.Jumpbox.OSDiskSizeGB == 0 {
-			a.OrchestratorProfile.KubernetesConfig.PrivateCluster.Jumpbox.OSDiskSizeGB = DefaultJumpboxDiskSize
+		if a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile != nil && a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB == 0 {
+			a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB = DefaultJumpboxDiskSize
+		}
+
+		if a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile != nil && a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Username == "" {
+			a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Username = DefaultJumpboxUsername
 		}
 
 		if a.OrchestratorProfile.KubernetesConfig.EnableRbac == nil {

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -431,8 +431,20 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 			a.OrchestratorProfile.KubernetesConfig.Addons[m] = assignDefaultAddonVals(a.OrchestratorProfile.KubernetesConfig.Addons[m], DefaultMetricsServerAddonsConfig)
 		}
 
+		if o.KubernetesConfig.PrivateCluster == nil {
+			o.KubernetesConfig.PrivateCluster = &api.PrivateCluster{}
+		}
+
+		if o.KubernetesConfig.PrivateCluster.Enabled == nil {
+			o.KubernetesConfig.PrivateCluster.Enabled = pointerToBool(api.DefaultPrivateClusterEnabled)
+		}
+
 		if "" == a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB {
 			a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB = DefaultEtcdDiskSize
+		}
+
+		if a.OrchestratorProfile.KubernetesConfig.PrivateCluster.Jumpbox != nil && a.OrchestratorProfile.KubernetesConfig.PrivateCluster.Jumpbox.OSDiskSizeGB == 0 {
+			a.OrchestratorProfile.KubernetesConfig.PrivateCluster.Jumpbox.OSDiskSizeGB = DefaultJumpboxDiskSize
 		}
 
 		if a.OrchestratorProfile.KubernetesConfig.EnableRbac == nil {

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -464,7 +464,7 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 		}
 
 		if a.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata == nil {
-			a.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet = pointerToBool(api.DefaultUseInstanceMetadata)
+			a.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata = pointerToBool(api.DefaultUseInstanceMetadata)
 		}
 
 		// Configure kubelet

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -664,12 +664,13 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 		addValue(parametersMap, "etcdDownloadURLBase", cloudSpecConfig.KubernetesSpecConfig.EtcdDownloadURLBase)
 		addValue(parametersMap, "etcdVersion", cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdVersion)
 		addValue(parametersMap, "etcdDiskSizeGB", cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB)
-		if cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile != nil {
+		if cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision() {
 			addValue(parametersMap, "jumpboxVMName", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Name)
 			addValue(parametersMap, "jumpboxVMSize", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.VMSize)
 			addValue(parametersMap, "jumpboxUsername", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Username)
 			addValue(parametersMap, "jumpboxOSDiskSizeGB", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB)
 			addValue(parametersMap, "jumpboxPublicKey", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.PublicKey)
+			addValue(parametersMap, "jumpboxStorageProfile", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.StorageProfile)
 		}
 		var totalNodes int
 		if cs.Properties.MasterProfile != nil {
@@ -947,9 +948,10 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return false
 		},
 		"ProvisionJumpbox": func() bool {
-			if !cs.Properties.OrchestratorProfile.IsKubernetes() {
-				return false
-			} else if *cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled && cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile != nil {
+			return cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision()
+		},
+		"JumpboxIsManagedDisks": func() bool {
+			if cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision() && cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.StorageProfile == api.ManagedDisks {
 				return true
 			}
 			return false

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -932,10 +932,20 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return cs.Properties.OrchestratorProfile.IsAzureCNI()
 		},
 		"IsPrivateCluster": func() bool {
-			return *cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled
+			if !cs.Properties.OrchestratorProfile.IsKubernetes() {
+				return false
+			} else if *cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled {
+				return true
+			}
+			return false
 		},
 		"ProvisionJumpbox": func() bool {
-			return *cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled && cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Jumpbox != nil
+			if !cs.Properties.OrchestratorProfile.IsKubernetes() {
+				return false
+			} else if *cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled && cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Jumpbox != nil {
+				return true
+			}
+			return false
 		},
 		"UseManagedIdentity": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -664,11 +664,13 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 		addValue(parametersMap, "etcdDownloadURLBase", cloudSpecConfig.KubernetesSpecConfig.EtcdDownloadURLBase)
 		addValue(parametersMap, "etcdVersion", cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdVersion)
 		addValue(parametersMap, "etcdDiskSizeGB", cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB)
-		addValue(parametersMap, "jumpboxVMName", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Name)
-		addValue(parametersMap, "jumpboxVMSize", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.VMSize)
-		addValue(parametersMap, "jumpboxUsername", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Username)
-		addValue(parametersMap, "jumpboxOSDiskSizeGB", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB)
-		addValue(parametersMap, "jumpboxPublicKey", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.PublicKey)
+		if cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile != nil {
+			addValue(parametersMap, "jumpboxVMName", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Name)
+			addValue(parametersMap, "jumpboxVMSize", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.VMSize)
+			addValue(parametersMap, "jumpboxUsername", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Username)
+			addValue(parametersMap, "jumpboxOSDiskSizeGB", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB)
+			addValue(parametersMap, "jumpboxPublicKey", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.PublicKey)
+		}
 		var totalNodes int
 		if cs.Properties.MasterProfile != nil {
 			totalNodes = cs.Properties.MasterProfile.Count

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -294,7 +294,7 @@ func GenerateKubeConfig(properties *api.Properties, location string) (string, er
 	kubeconfig := string(b)
 	// variable replacement
 	kubeconfig = strings.Replace(kubeconfig, "{{WrapAsVerbatim \"variables('caCertificate')\"}}", base64.StdEncoding.EncodeToString([]byte(properties.CertificateProfile.CaCertificate)), -1)
-	if helpers.IsTrueBoolPointer(properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled) {
+	if properties.OrchestratorProfile.KubernetesConfig.PrivateCluster != nil && helpers.IsTrueBoolPointer(properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled) {
 		if properties.MasterProfile.Count > 1 {
 			// more than 1 master, use the internal lb IP
 			firstMasterIP := net.ParseIP(properties.MasterProfile.FirstConsecutiveStaticIP).To4()

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -294,7 +294,7 @@ func GenerateKubeConfig(properties *api.Properties, location string) (string, er
 	kubeconfig := string(b)
 	// variable replacement
 	kubeconfig = strings.Replace(kubeconfig, "{{WrapAsVerbatim \"variables('caCertificate')\"}}", base64.StdEncoding.EncodeToString([]byte(properties.CertificateProfile.CaCertificate)), -1)
-	if properties.OrchestratorProfile.KubernetesConfig.EnablePrivateCluster {
+	if *properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled {
 		if properties.MasterProfile.Count > 1 {
 			// more than 1 master, use the internal lb IP
 			firstMasterIP := net.ParseIP(properties.MasterProfile.FirstConsecutiveStaticIP).To4()
@@ -932,10 +932,10 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return cs.Properties.OrchestratorProfile.IsAzureCNI()
 		},
 		"IsPrivateCluster": func() bool {
-			return cs.Properties.OrchestratorProfile.KubernetesConfig != nil && cs.Properties.OrchestratorProfile.KubernetesConfig.EnablePrivateCluster
+			return *cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled
 		},
 		"ProvisionJumpbox": func() bool {
-			return cs.Properties.OrchestratorProfile.KubernetesConfig != nil && cs.Properties.OrchestratorProfile.KubernetesConfig.EnablePrivateCluster && cs.Properties.OrchestratorProfile.KubernetesConfig.ProvisionJumpbox
+			return *cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled && cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Jumpbox != nil
 		},
 		"UseManagedIdentity": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity
@@ -1587,6 +1587,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 					val = cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdVersion
 				case "etcdDiskSizeGB":
 					val = cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB
+				case "jumpboxDiskSizeGB":
+					val = strconv.Itoa(cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Jumpbox.OSDiskSizeGB)
 				default:
 					val = ""
 				}

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -294,7 +294,7 @@ func GenerateKubeConfig(properties *api.Properties, location string) (string, er
 	kubeconfig := string(b)
 	// variable replacement
 	kubeconfig = strings.Replace(kubeconfig, "{{WrapAsVerbatim \"variables('caCertificate')\"}}", base64.StdEncoding.EncodeToString([]byte(properties.CertificateProfile.CaCertificate)), -1)
-	if *properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled {
+	if helpers.IsTrueBoolPointer(properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled) {
 		if properties.MasterProfile.Count > 1 {
 			// more than 1 master, use the internal lb IP
 			firstMasterIP := net.ParseIP(properties.MasterProfile.FirstConsecutiveStaticIP).To4()
@@ -942,10 +942,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"IsPrivateCluster": func() bool {
 			if !cs.Properties.OrchestratorProfile.IsKubernetes() {
 				return false
-			} else if *cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled {
-				return true
 			}
-			return false
+			return helpers.IsTrueBoolPointer(cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled)
 		},
 		"ProvisionJumpbox": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision()
@@ -960,12 +958,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity
 		},
 		"UseInstanceMetadata": func() bool {
-			if cs.Properties.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata == nil {
-				return true
-			} else if *cs.Properties.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata {
-				return true
-			}
-			return false
+			return helpers.IsTrueBoolPointer(cs.Properties.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata)
 		},
 		"GetVNETSubnetDependencies": func() string {
 			return getVNETSubnetDependencies(cs.Properties)

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -664,6 +664,11 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 		addValue(parametersMap, "etcdDownloadURLBase", cloudSpecConfig.KubernetesSpecConfig.EtcdDownloadURLBase)
 		addValue(parametersMap, "etcdVersion", cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdVersion)
 		addValue(parametersMap, "etcdDiskSizeGB", cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB)
+		addValue(parametersMap, "jumpboxVMName", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Name)
+		addValue(parametersMap, "jumpboxVMSize", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.VMSize)
+		addValue(parametersMap, "jumpboxUsername", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Username)
+		addValue(parametersMap, "jumpboxOSDiskSizeGB", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB)
+		addValue(parametersMap, "jumpboxPublicKey", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.PublicKey)
 		var totalNodes int
 		if cs.Properties.MasterProfile != nil {
 			totalNodes = cs.Properties.MasterProfile.Count
@@ -942,7 +947,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"ProvisionJumpbox": func() bool {
 			if !cs.Properties.OrchestratorProfile.IsKubernetes() {
 				return false
-			} else if *cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled && cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Jumpbox != nil {
+			} else if *cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled && cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile != nil {
 				return true
 			}
 			return false
@@ -1597,8 +1602,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 					val = cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdVersion
 				case "etcdDiskSizeGB":
 					val = cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB
-				case "jumpboxDiskSizeGB":
-					val = strconv.Itoa(cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Jumpbox.OSDiskSizeGB)
+				case "jumpboxOSDiskSizeGB":
+					val = strconv.Itoa(cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB)
 				default:
 					val = ""
 				}

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -934,6 +934,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"IsPrivateCluster": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig != nil && cs.Properties.OrchestratorProfile.KubernetesConfig.EnablePrivateCluster
 		},
+		"ProvisionJumpbox": func() bool {
+			return cs.Properties.OrchestratorProfile.KubernetesConfig != nil && cs.Properties.OrchestratorProfile.KubernetesConfig.EnablePrivateCluster && cs.Properties.OrchestratorProfile.KubernetesConfig.ProvisionJumpbox
+		},
 		"UseManagedIdentity": func() bool {
 			return cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity
 		},

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -93,6 +93,8 @@ const (
 	DefaultReschedulerAddonEnabled = false
 	// DefaultRBACEnabled determines the acs-engine provided default for enabling kubernetes RBAC
 	DefaultRBACEnabled = true
+	// DefaultUseInstanceMetadata determines the acs-engine provided default for enabling Azure cloudprovider instance metadata service
+	DefaultUseInstanceMetadata = true
 	// DefaultSecureKubeletEnabled determines the acs-engine provided default for securing kubelet communications
 	DefaultSecureKubeletEnabled = true
 	// DefaultMetricsServerAddonEnabled determines the acs-engine provided default for enabling kubernetes metrics-server addon

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -107,4 +107,6 @@ const (
 	DefaultReschedulerAddonName = "rescheduler"
 	// DefaultMetricsServerAddonName is the name of the kubernetes metrics server addon deployment
 	DefaultMetricsServerAddonName = "metrics-server"
+	// DefaultPrivateClusterEnabled determines the acs-engine provided default for enabling kubernetes Private Cluster
+	DefaultPrivateClusterEnabled = false
 )

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -727,6 +727,7 @@ func convertPrivateJumpboxProfileToVlabs(api *PrivateJumpboxProfile, vlabsProfil
 	vlabsProfile.VMSize = api.VMSize
 	vlabsProfile.PublicKey = api.PublicKey
 	vlabsProfile.Username = api.Username
+	vlabsProfile.StorageProfile = api.StorageProfile
 }
 
 func convertAddonsToVlabs(a *KubernetesConfig, v *vlabs.KubernetesConfig) {

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -668,8 +668,6 @@ func convertKubernetesConfigToVLabs(api *KubernetesConfig, vlabs *vlabs.Kubernet
 	vlabs.EnableRbac = api.EnableRbac
 	vlabs.EnableSecureKubelet = api.EnableSecureKubelet
 	vlabs.EnableAggregatedAPIs = api.EnableAggregatedAPIs
-	vlabs.EnablePrivateCluster = api.EnablePrivateCluster
-	vlabs.ProvisionJumpbox = api.ProvisionJumpbox
 	vlabs.EnableDataEncryptionAtRest = api.EnableDataEncryptionAtRest
 	vlabs.EnablePodSecurityPolicy = api.EnablePodSecurityPolicy
 	vlabs.GCHighThreshold = api.GCHighThreshold
@@ -681,6 +679,7 @@ func convertKubernetesConfigToVLabs(api *KubernetesConfig, vlabs *vlabs.Kubernet
 	convertControllerManagerConfigToVlabs(api, vlabs)
 	convertCloudControllerManagerConfigToVlabs(api, vlabs)
 	convertAPIServerConfigToVlabs(api, vlabs)
+	convertPrivateClusterToVlabs(api, vlabs)
 }
 
 func convertKubeletConfigToVlabs(a *KubernetesConfig, v *vlabs.KubernetesConfig) {
@@ -709,6 +708,24 @@ func convertAPIServerConfigToVlabs(a *KubernetesConfig, v *vlabs.KubernetesConfi
 	for key, val := range a.APIServerConfig {
 		v.APIServerConfig[key] = val
 	}
+}
+
+func convertPrivateClusterToVlabs(a *KubernetesConfig, v *vlabs.KubernetesConfig) {
+	if a.PrivateCluster != nil {
+		v.PrivateCluster = &vlabs.PrivateCluster{}
+		v.PrivateCluster.Enabled = a.PrivateCluster.Enabled
+		if a.PrivateCluster.Jumpbox != nil {
+			v.PrivateCluster.Jumpbox = &vlabs.PrivateJumpboxProfile{}
+			convertPrivateJumpboxProfileToVlabs(a.PrivateCluster.Jumpbox, v.PrivateCluster.Jumpbox)
+		}
+	}
+}
+
+func convertPrivateJumpboxProfileToVlabs(api *PrivateJumpboxProfile, vlabsProfile *vlabs.PrivateJumpboxProfile) {
+	vlabsProfile.Name = api.Name
+	vlabsProfile.OSDiskSizeGB = api.OSDiskSizeGB
+	vlabsProfile.VMSize = api.VMSize
+	vlabsProfile.PublicKey = api.PublicKey
 }
 
 func convertAddonsToVlabs(a *KubernetesConfig, v *vlabs.KubernetesConfig) {

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -714,9 +714,9 @@ func convertPrivateClusterToVlabs(a *KubernetesConfig, v *vlabs.KubernetesConfig
 	if a.PrivateCluster != nil {
 		v.PrivateCluster = &vlabs.PrivateCluster{}
 		v.PrivateCluster.Enabled = a.PrivateCluster.Enabled
-		if a.PrivateCluster.Jumpbox != nil {
-			v.PrivateCluster.Jumpbox = &vlabs.PrivateJumpboxProfile{}
-			convertPrivateJumpboxProfileToVlabs(a.PrivateCluster.Jumpbox, v.PrivateCluster.Jumpbox)
+		if a.PrivateCluster.JumpboxProfile != nil {
+			v.PrivateCluster.JumpboxProfile = &vlabs.PrivateJumpboxProfile{}
+			convertPrivateJumpboxProfileToVlabs(a.PrivateCluster.JumpboxProfile, v.PrivateCluster.JumpboxProfile)
 		}
 	}
 }
@@ -726,6 +726,7 @@ func convertPrivateJumpboxProfileToVlabs(api *PrivateJumpboxProfile, vlabsProfil
 	vlabsProfile.OSDiskSizeGB = api.OSDiskSizeGB
 	vlabsProfile.VMSize = api.VMSize
 	vlabsProfile.PublicKey = api.PublicKey
+	vlabsProfile.Username = api.Username
 }
 
 func convertAddonsToVlabs(a *KubernetesConfig, v *vlabs.KubernetesConfig) {

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -669,6 +669,7 @@ func convertKubernetesConfigToVLabs(api *KubernetesConfig, vlabs *vlabs.Kubernet
 	vlabs.EnableSecureKubelet = api.EnableSecureKubelet
 	vlabs.EnableAggregatedAPIs = api.EnableAggregatedAPIs
 	vlabs.EnablePrivateCluster = api.EnablePrivateCluster
+	vlabs.ProvisionJumpbox = api.ProvisionJumpbox
 	vlabs.EnableDataEncryptionAtRest = api.EnableDataEncryptionAtRest
 	vlabs.EnablePodSecurityPolicy = api.EnablePodSecurityPolicy
 	vlabs.GCHighThreshold = api.GCHighThreshold

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -712,6 +712,7 @@ func convertPrivateJumpboxProfileToAPI(v *vlabs.PrivateJumpboxProfile, a *Privat
 	a.VMSize = v.VMSize
 	a.PublicKey = v.PublicKey
 	a.Username = v.Username
+	a.StorageProfile = v.StorageProfile
 }
 
 func convertV20160930MasterProfile(v20160930 *v20160930.MasterProfile, api *MasterProfile) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -699,9 +699,9 @@ func convertPrivateClusterToAPI(v *vlabs.KubernetesConfig, a *KubernetesConfig) 
 	if v.PrivateCluster != nil {
 		a.PrivateCluster = &PrivateCluster{}
 		a.PrivateCluster.Enabled = v.PrivateCluster.Enabled
-		if v.PrivateCluster.Jumpbox != nil {
-			a.PrivateCluster.Jumpbox = &PrivateJumpboxProfile{}
-			convertPrivateJumpboxProfileToAPI(v.PrivateCluster.Jumpbox, a.PrivateCluster.Jumpbox)
+		if v.PrivateCluster.JumpboxProfile != nil {
+			a.PrivateCluster.JumpboxProfile = &PrivateJumpboxProfile{}
+			convertPrivateJumpboxProfileToAPI(v.PrivateCluster.JumpboxProfile, a.PrivateCluster.JumpboxProfile)
 		}
 	}
 }
@@ -711,6 +711,7 @@ func convertPrivateJumpboxProfileToAPI(v *vlabs.PrivateJumpboxProfile, a *Privat
 	a.OSDiskSizeGB = v.OSDiskSizeGB
 	a.VMSize = v.VMSize
 	a.PublicKey = v.PublicKey
+	a.Username = v.Username
 }
 
 func convertV20160930MasterProfile(v20160930 *v20160930.MasterProfile, api *MasterProfile) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -613,8 +613,6 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 	api.EnableRbac = vlabs.EnableRbac
 	api.EnableSecureKubelet = vlabs.EnableSecureKubelet
 	api.EnableAggregatedAPIs = vlabs.EnableAggregatedAPIs
-	api.EnablePrivateCluster = vlabs.EnablePrivateCluster
-	api.ProvisionJumpbox = vlabs.ProvisionJumpbox
 	api.EnableDataEncryptionAtRest = vlabs.EnableDataEncryptionAtRest
 	api.EnablePodSecurityPolicy = vlabs.EnablePodSecurityPolicy
 	api.GCHighThreshold = vlabs.GCHighThreshold
@@ -626,6 +624,7 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 	convertControllerManagerConfigToAPI(vlabs, api)
 	convertCloudControllerManagerConfigToAPI(vlabs, api)
 	convertAPIServerConfigToAPI(vlabs, api)
+	convertPrivateClusterToAPI(vlabs, api)
 }
 
 func setVlabsKubernetesDefaults(vp *vlabs.Properties, api *OrchestratorProfile) {
@@ -694,6 +693,24 @@ func convertAPIServerConfigToAPI(v *vlabs.KubernetesConfig, a *KubernetesConfig)
 	for key, val := range v.APIServerConfig {
 		a.APIServerConfig[key] = val
 	}
+}
+
+func convertPrivateClusterToAPI(v *vlabs.KubernetesConfig, a *KubernetesConfig) {
+	if v.PrivateCluster != nil {
+		a.PrivateCluster = &PrivateCluster{}
+		a.PrivateCluster.Enabled = v.PrivateCluster.Enabled
+		if v.PrivateCluster.Jumpbox != nil {
+			a.PrivateCluster.Jumpbox = &PrivateJumpboxProfile{}
+			convertPrivateJumpboxProfileToAPI(v.PrivateCluster.Jumpbox, a.PrivateCluster.Jumpbox)
+		}
+	}
+}
+
+func convertPrivateJumpboxProfileToAPI(v *vlabs.PrivateJumpboxProfile, a *PrivateJumpboxProfile) {
+	a.Name = v.Name
+	a.OSDiskSizeGB = v.OSDiskSizeGB
+	a.VMSize = v.VMSize
+	a.PublicKey = v.PublicKey
 }
 
 func convertV20160930MasterProfile(v20160930 *v20160930.MasterProfile, api *MasterProfile) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -614,6 +614,7 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 	api.EnableSecureKubelet = vlabs.EnableSecureKubelet
 	api.EnableAggregatedAPIs = vlabs.EnableAggregatedAPIs
 	api.EnablePrivateCluster = vlabs.EnablePrivateCluster
+	api.ProvisionJumpbox = vlabs.ProvisionJumpbox
 	api.EnableDataEncryptionAtRest = vlabs.EnableDataEncryptionAtRest
 	api.EnablePodSecurityPolicy = vlabs.EnablePodSecurityPolicy
 	api.GCHighThreshold = vlabs.GCHighThreshold

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -195,6 +195,21 @@ func (a *KubernetesAddon) IsEnabled(ifNil bool) bool {
 	return *a.Enabled
 }
 
+// PrivateCluster defines the configuration for a private cluster
+type PrivateCluster struct {
+	Enabled *bool                  `json:"enabled,omitempty"`
+	Jumpbox *PrivateJumpboxProfile `json:"jumpboxProfile,omitempty"`
+}
+
+// PrivateJumpboxProfile represents a jumpbox definition
+type PrivateJumpboxProfile struct {
+	Name         string `json:"name" validate:"required"`
+	VMSize       string `json:"vmSize" validate:"required"`
+	OSDiskSizeGB int    `json:"diskSizeGB,omitempty" validate:"min=0,max=1023"`
+	Username     string `json:"username,omitempty"`
+	PublicKey    string `json:"publicKey" validate:"required"`
+}
+
 // CloudProviderConfig contains the KubernetesConfig properties specific to the Cloud Provider
 // TODO use this when strict JSON checking accommodates struct embedding
 type CloudProviderConfig struct {
@@ -239,8 +254,7 @@ type KubernetesConfig struct {
 	EnableRbac                       *bool             `json:"enableRbac,omitempty"`
 	EnableSecureKubelet              *bool             `json:"enableSecureKubelet,omitempty"`
 	EnableAggregatedAPIs             bool              `json:"enableAggregatedAPIs,omitempty"`
-	EnablePrivateCluster             bool              `json:"enablePrivateCluster,omitempty"`
-	ProvisionJumpbox                 bool              `json:"provisionJumpbox,omitempty"`
+	PrivateCluster                   *PrivateCluster   `json:"privateCluster,omitempty"`
 	GCHighThreshold                  int               `json:"gchighthreshold,omitempty"`
 	GCLowThreshold                   int               `json:"gclowthreshold,omitempty"`
 	EtcdVersion                      string            `json:"etcdVersion,omitempty"`

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -240,6 +240,7 @@ type KubernetesConfig struct {
 	EnableSecureKubelet              *bool             `json:"enableSecureKubelet,omitempty"`
 	EnableAggregatedAPIs             bool              `json:"enableAggregatedAPIs,omitempty"`
 	EnablePrivateCluster             bool              `json:"enablePrivateCluster,omitempty"`
+	ProvisionJumpbox                 bool              `json:"provisionJumpbox,omitempty"`
 	GCHighThreshold                  int               `json:"gchighthreshold,omitempty"`
 	GCLowThreshold                   int               `json:"gclowthreshold,omitempty"`
 	EtcdVersion                      string            `json:"etcdVersion,omitempty"`

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -197,8 +197,8 @@ func (a *KubernetesAddon) IsEnabled(ifNil bool) bool {
 
 // PrivateCluster defines the configuration for a private cluster
 type PrivateCluster struct {
-	Enabled *bool                  `json:"enabled,omitempty"`
-	Jumpbox *PrivateJumpboxProfile `json:"jumpboxProfile,omitempty"`
+	Enabled        *bool                  `json:"enabled,omitempty"`
+	JumpboxProfile *PrivateJumpboxProfile `json:"jumpboxProfile,omitempty"`
 }
 
 // PrivateJumpboxProfile represents a jumpbox definition

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -205,7 +205,7 @@ type PrivateCluster struct {
 type PrivateJumpboxProfile struct {
 	Name           string `json:"name" validate:"required"`
 	VMSize         string `json:"vmSize" validate:"required"`
-	OSDiskSizeGB   int    `json:"diskSizeGB,omitempty" validate:"min=0,max=1023"`
+	OSDiskSizeGB   int    `json:"osDiskSizeGB,omitempty" validate:"min=0,max=1023"`
 	Username       string `json:"username,omitempty"`
 	PublicKey      string `json:"publicKey" validate:"required"`
 	StorageProfile string `json:"storageProfile,omitempty"`

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -247,6 +247,7 @@ type KubernetesConfig struct {
 	EnableSecureKubelet          *bool             `json:"enableSecureKubelet,omitempty"`
 	EnableAggregatedAPIs         bool              `json:"enableAggregatedAPIs,omitempty"`
 	EnablePrivateCluster         bool              `json:"enablePrivateCluster,omitempty"`
+	ProvisionJumpbox             bool              `json:"provisionJumpbox,omitempty"`
 	GCHighThreshold              int               `json:"gchighthreshold,omitempty"`
 	GCLowThreshold               int               `json:"gclowthreshold,omitempty"`
 	EtcdVersion                  string            `json:"etcdVersion,omitempty"`

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -221,11 +221,12 @@ type PrivateCluster struct {
 
 // PrivateJumpboxProfile represents a jumpbox definition
 type PrivateJumpboxProfile struct {
-	Name         string `json:"name" validate:"required"`
-	VMSize       string `json:"vmSize" validate:"required"`
-	OSDiskSizeGB int    `json:"diskSizeGB,omitempty" validate:"min=0,max=1023"`
-	Username     string `json:"username,omitempty"`
-	PublicKey    string `json:"publicKey" validate:"required"`
+	Name           string `json:"name" validate:"required"`
+	VMSize         string `json:"vmSize" validate:"required"`
+	OSDiskSizeGB   int    `json:"diskSizeGB,omitempty" validate:"min=0,max=1023"`
+	Username       string `json:"username,omitempty"`
+	PublicKey      string `json:"publicKey" validate:"required"`
+	StorageProfile string `json:"storageProfile,omitempty"`
 }
 
 // CloudProviderConfig contains the KubernetesConfig parameters specific to the Cloud Provider

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -215,8 +215,8 @@ func (a *KubernetesAddon) IsEnabled(ifNil bool) bool {
 
 // PrivateCluster defines the configuration for a private cluster
 type PrivateCluster struct {
-	Enabled *bool                  `json:"enabled,omitempty"`
-	Jumpbox *PrivateJumpboxProfile `json:"jumpboxProfile,omitempty"`
+	Enabled        *bool                  `json:"enabled,omitempty"`
+	JumpboxProfile *PrivateJumpboxProfile `json:"jumpboxProfile,omitempty"`
 }
 
 // PrivateJumpboxProfile represents a jumpbox definition

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -223,7 +223,7 @@ type PrivateCluster struct {
 type PrivateJumpboxProfile struct {
 	Name           string `json:"name" validate:"required"`
 	VMSize         string `json:"vmSize" validate:"required"`
-	OSDiskSizeGB   int    `json:"diskSizeGB,omitempty" validate:"min=0,max=1023"`
+	OSDiskSizeGB   int    `json:"osDiskSizeGB,omitempty" validate:"min=0,max=1023"`
 	Username       string `json:"username,omitempty"`
 	PublicKey      string `json:"publicKey" validate:"required"`
 	StorageProfile string `json:"storageProfile,omitempty"`

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -213,6 +213,21 @@ func (a *KubernetesAddon) IsEnabled(ifNil bool) bool {
 	return *a.Enabled
 }
 
+// PrivateCluster defines the configuration for a private cluster
+type PrivateCluster struct {
+	Enabled *bool                  `json:"enabled,omitempty"`
+	Jumpbox *PrivateJumpboxProfile `json:"jumpboxProfile,omitempty"`
+}
+
+// PrivateJumpboxProfile represents a jumpbox definition
+type PrivateJumpboxProfile struct {
+	Name         string `json:"name" validate:"required"`
+	VMSize       string `json:"vmSize" validate:"required"`
+	OSDiskSizeGB int    `json:"diskSizeGB,omitempty" validate:"min=0,max=1023"`
+	Username     string `json:"username,omitempty"`
+	PublicKey    string `json:"publicKey" validate:"required"`
+}
+
 // CloudProviderConfig contains the KubernetesConfig parameters specific to the Cloud Provider
 // TODO use this when strict JSON checking accommodates struct embedding
 type CloudProviderConfig struct {
@@ -246,8 +261,7 @@ type KubernetesConfig struct {
 	EnableRbac                   *bool             `json:"enableRbac,omitempty"`
 	EnableSecureKubelet          *bool             `json:"enableSecureKubelet,omitempty"`
 	EnableAggregatedAPIs         bool              `json:"enableAggregatedAPIs,omitempty"`
-	EnablePrivateCluster         bool              `json:"enablePrivateCluster,omitempty"`
-	ProvisionJumpbox             bool              `json:"provisionJumpbox,omitempty"`
+	PrivateCluster               *PrivateCluster   `json:"privateCluster,omitempty"`
 	GCHighThreshold              int               `json:"gchighthreshold,omitempty"`
 	GCLowThreshold               int               `json:"gclowthreshold,omitempty"`
 	EtcdVersion                  string            `json:"etcdVersion,omitempty"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: adds option to provision a jumpbox when enabling the private cluster. Some redesign of the private cluster config object.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #221 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note

This PR changes the cluster definition for private clusters to:

      "kubernetesConfig": {
        "privateCluster": {
          "enabled": true,
          "jumpbox": {
            "name": "my-jb",
            "vmSize": "Standard_D4s_v3",
            "diskSizeGB": 30,
            "storageProfile": "ManagedDisks",
            "username": "azureuser",
            "publicKey": "xxx"
          }
      }
```
