### PR TITLE
fix disk unavailable issue when mounting multiple azure disks due to dev name change

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-managed-azure-storage-classes.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-managed-azure-storage-classes.yaml
@@ -10,6 +10,7 @@ provisioner: kubernetes.io/azure-disk
 parameters:
   kind: Managed
   storageaccounttype: Standard_LRS
+  cachingmode: None
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
@@ -22,6 +23,7 @@ provisioner: kubernetes.io/azure-disk
 parameters:
   kind: Managed
   storageaccounttype: Premium_LRS
+  cachingmode: None
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
@@ -34,6 +36,7 @@ provisioner: kubernetes.io/azure-disk
 parameters:
   kind: Managed
   storageaccounttype: Standard_LRS
+  cachingmode: None
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1

--- a/parts/k8s/addons/kubernetesmasteraddons-unmanaged-azure-storage-classes.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-unmanaged-azure-storage-classes.yaml
@@ -7,6 +7,8 @@ metadata:
   labels:
     kubernetes.io/cluster-service: "true"
 provisioner: kubernetes.io/azure-disk
+parameters:
+  cachingmode: None
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
@@ -19,6 +21,7 @@ provisioner: kubernetes.io/azure-disk
 parameters:
   kind: Managed
   storageaccounttype: Premium_LRS
+  cachingmode: None
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
@@ -31,6 +34,7 @@ provisioner: kubernetes.io/azure-disk
 parameters:
   kind: Managed
   storageaccounttype: Standard_LRS
+  cachingmode: None
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
fix disk unavailable issue when mounting multiple azure disks due to dev name change

When User mount the 6th azure data disk on an D2_V2 VM, other azure disk would be unavailable due to device name change. This PR set the default `cachingmode` as `None` to fix this issue.
You could find more details in this upstream PR: https://github.com/kubernetes/kubernetes/pull/60346

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1918

**Special notes for your reviewer**:
@jackfrancis @JiangtianLi This is a critical bug fix, we have changed the default `cachingmode` value as `None` in upstream code, while as a simple workaround, we could change the  `cachingmode` value to `None` in azure disk storage class. Could you fix it in AKS also? Thanks.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
fix disk unavailable issue when mounting multiple azure disks
```