### PR TITLE
Kubernetes E2E cleanup: handle errors

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -338,13 +338,10 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					cleanupStuffs([]*deployment.Deployment{phpApacheDeploy, loadTestDeploy}, []*service.Service{s}, []*job.Job{})
 				}
 				Expect(err).NotTo(HaveOccurred())
-				// We should have > 1 pods after autoscale effects
-				if len(phpPods) <= 1 {
-					cleanupStuffs([]*deployment.Deployment{phpApacheDeploy, loadTestDeploy}, []*service.Service{s}, []*job.Job{})
-				}
-				Fail("autoscale did not take effect")
-
 				cleanupStuffs([]*deployment.Deployment{phpApacheDeploy, loadTestDeploy}, []*service.Service{s}, []*job.Job{})
+				// We should have > 1 pods after autoscale effects
+				Expect(len(phpPods) > 1).To(BeTrue())
+
 			} else {
 				Skip("This flavor/version of Kubernetes doesn't support hpa autoscale")
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: k8s resource cleanup during E2E error runs

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
