### PR TITLE
Kubernetes v1.9 clusters use addon-resizer 1.7

### DIFF
--- a/pkg/acsengine/k8s_versions.go
+++ b/pkg/acsengine/k8s_versions.go
@@ -12,7 +12,7 @@ var k8sComponentVersions = map[string]map[string]string{
 		"dockerEngine":    "1.13.*",
 		"dashboard":       "kubernetes-dashboard-amd64:v1.8.3",
 		"exechealthz":     "exechealthz-amd64:1.2",
-		"addon-resizer":   "addon-resizer:1.8.1",
+		"addon-resizer":   "addon-resizer:1.7",
 		"heapster":        "heapster-amd64:v1.5.1",
 		"metrics-server":  "metrics-server-amd64:v0.2.1",
 		"kube-dns":        "k8s-dns-kube-dns-amd64:1.14.8",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: revert previous rev to 1.8.1

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Kubernetes v1.9 clusters use addon-resizer 1.7
```