### PR TITLE
Sync flags with azure cli shorthands

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -74,8 +74,8 @@ func newDeployCmd() *cobra.Command {
 	f.StringVar(&dc.outputDirectory, "output-directory", "", "output directory (derived from FQDN if absent)")
 	f.StringVar(&dc.caCertificatePath, "ca-certificate-path", "", "path to the CA certificate to use for Kubernetes PKI assets")
 	f.StringVar(&dc.caPrivateKeyPath, "ca-private-key-path", "", "path to the CA private key to use for Kubernetes PKI assets")
-	f.StringVar(&dc.resourceGroup, "resource-group", "", "resource group to deploy to")
-	f.StringVar(&dc.location, "location", "", "location to deploy to")
+	f.StringVarP(&dc.resourceGroup, "resource-group", "g", "", "resource group to deploy to")
+	f.StringVarP(&dc.location, "location", "l", "", "location to deploy to")
 
 	addAuthFlags(&dc.authArgs, f)
 

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -68,8 +68,8 @@ func newScaleCmd() *cobra.Command {
 	}
 
 	f := scaleCmd.Flags()
-	f.StringVar(&sc.location, "location", "", "location the cluster is deployed in")
-	f.StringVar(&sc.resourceGroupName, "resource-group", "", "the resource group where the cluster is deployed")
+	f.StringVarP(&sc.location, "location", "l", "", "location the cluster is deployed in")
+	f.StringVarP(&sc.resourceGroupName, "resource-group", "g", "", "the resource group where the cluster is deployed")
 	f.StringVar(&sc.deploymentDirectory, "deployment-dir", "", "the location of the output from `generate`")
 	f.IntVar(&sc.newDesiredAgentCount, "new-node-count", 0, "desired number of nodes")
 	f.BoolVar(&sc.classicMode, "classic-mode", false, "enable classic parameters and outputs")

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -59,8 +59,8 @@ func newUpgradeCmd() *cobra.Command {
 	}
 
 	f := upgradeCmd.Flags()
-	f.StringVar(&uc.location, "location", "", "location the cluster is deployed in")
-	f.StringVar(&uc.resourceGroupName, "resource-group", "", "the resource group where the cluster is deployed")
+	f.StringVarP(&uc.location, "location", "l", "", "location the cluster is deployed in")
+	f.StringVarP(&uc.resourceGroupName, "resource-group", "g", "", "the resource group where the cluster is deployed")
 	f.StringVar(&uc.deploymentDirectory, "deployment-dir", "", "the location of the output from `generate`")
 	f.StringVar(&uc.upgradeVersion, "upgrade-version", "", "desired kubernetes version")
 	f.IntVar(&uc.timeoutInMinutes, "vm-timeout", -1, "how long to wait for each vm to be upgraded in minutes")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Sync shorthand flags between `acs-engine` and `az`. Convenient when jumping from one tool to the other. I may have missed other flags that are the same between the commands but these two (`location`, `resource-group`) seem to be used most often (at least by myself so far). 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
