### PR TITLE
rationalize "is greater than 1.9" implementation to deal with 1.10-beta*

### DIFF
--- a/pkg/acsengine/addons.go
+++ b/pkg/acsengine/addons.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Azure/acs-engine/pkg/api"
+	"github.com/Azure/acs-engine/pkg/api/common"
 	"github.com/Azure/acs-engine/pkg/helpers"
 )
 
@@ -109,7 +110,7 @@ func kubernetesManifestSettingsInit(profile *api.Properties) []kubernetesFeature
 		{
 			"kubernetesmaster-audit-policy.yaml",
 			"audit-policy.yaml",
-			isKubernetesVersionGe(profile.OrchestratorProfile.OrchestratorVersion, "1.8.0"),
+			common.IsKubernetesVersionGe(profile.OrchestratorProfile.OrchestratorVersion, "1.8.0"),
 		},
 		{
 			"kubernetesmaster-kube-apiserver.yaml",

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/Azure/acs-engine/pkg/api"
+	"github.com/Azure/acs-engine/pkg/api/common"
 	"github.com/Azure/acs-engine/pkg/helpers"
 )
 
@@ -42,7 +43,7 @@ func setAPIServerConfig(cs *api.ContainerService) {
 	}
 
 	// Aggregated API configuration
-	if o.KubernetesConfig.EnableAggregatedAPIs || isKubernetesVersionGe(o.OrchestratorVersion, "1.9.0") {
+	if o.KubernetesConfig.EnableAggregatedAPIs || common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.9.0") {
 		staticLinuxAPIServerConfig["--requestheader-client-ca-file"] = "/etc/kubernetes/certs/proxy-ca.crt"
 		staticLinuxAPIServerConfig["--proxy-client-cert-file"] = "/etc/kubernetes/certs/proxy.crt"
 		staticLinuxAPIServerConfig["--proxy-client-key-file"] = "/etc/kubernetes/certs/proxy.key"
@@ -71,7 +72,7 @@ func setAPIServerConfig(cs *api.ContainerService) {
 	}
 
 	// Audit Policy configuration
-	if isKubernetesVersionGe(o.OrchestratorVersion, "1.8.0") {
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.8.0") {
 		staticLinuxAPIServerConfig["--audit-policy-file"] = "/etc/kubernetes/manifests/audit-policy.yaml"
 	}
 
@@ -92,7 +93,7 @@ func setAPIServerConfig(cs *api.ContainerService) {
 
 	// RBAC configuration
 	if helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableRbac) {
-		if isKubernetesVersionGe(o.OrchestratorVersion, "1.7.0") {
+		if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.7.0") {
 			defaultAPIServerConfig["--authorization-mode"] = "Node,RBAC"
 		} else {
 			defaultAPIServerConfig["--authorization-mode"] = "RBAC"

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/Azure/acs-engine/pkg/api"
+	"github.com/Azure/acs-engine/pkg/api/common"
 	"github.com/Azure/acs-engine/pkg/helpers"
 )
 
@@ -74,7 +75,7 @@ func setKubeletConfig(cs *api.ContainerService) {
 	}
 
 	// Get rid of values not supported in v1.5 clusters
-	if !isKubernetesVersionGe(o.OrchestratorVersion, "1.6.0") {
+	if !common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.6.0") {
 		for _, key := range []string{"--non-masquerade-cidr", "--cgroups-per-qos", "--enforce-node-allocatable"} {
 			delete(o.KubernetesConfig.KubeletConfig, key)
 		}

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -839,17 +839,11 @@ func pointerToBool(b bool) *bool {
 	return &p
 }
 
-func isKubernetesVersionGe(actualVersion, version string) bool {
-	orchestratorVersion, _ := semver.NewVersion(actualVersion)
-	constraint, _ := semver.NewConstraint(">=" + version)
-	return constraint.Check(orchestratorVersion)
-}
-
 // combine user-provided --feature-gates vals with defaults
 // a minimum k8s version may be declared as required for defaults assignment
 func addDefaultFeatureGates(m map[string]string, version string, minVersion string, defaults string) {
 	if minVersion != "" {
-		if isKubernetesVersionGe(version, minVersion) {
+		if common.IsKubernetesVersionGe(version, minVersion) {
 			m["--feature-gates"] = combineValues(m["--feature-gates"], defaults)
 		} else {
 			m["--feature-gates"] = combineValues(m["--feature-gates"], "")
@@ -900,7 +894,5 @@ func enforceK8sVersionAddonOverrides(addons []api.KubernetesAddon, o *api.Orches
 }
 
 func k8sVersionMetricsServerAddonEnabled(o *api.OrchestratorProfile) *bool {
-	k8sSemVer, _ := semver.NewVersion(strings.Split(o.OrchestratorVersion, "-")[0]) // to account for -alpha and -beta suffixes
-	metricsServerConstraint, _ := semver.NewConstraint(">= 1.9.0")
-	return pointerToBool(metricsServerConstraint.Check(k8sSemVer))
+	return pointerToBool(common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.9.0"))
 }

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -22,6 +22,7 @@ import (
 
 	//log "github.com/sirupsen/logrus"
 	"github.com/Azure/acs-engine/pkg/api"
+	"github.com/Azure/acs-engine/pkg/api/common"
 	"github.com/Azure/acs-engine/pkg/helpers"
 	"github.com/Azure/acs-engine/pkg/i18n"
 	"github.com/Masterminds/semver"
@@ -1619,7 +1620,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"EnableAggregatedAPIs": func() bool {
 			if cs.Properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs {
 				return true
-			} else if isKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.9.0") {
+			} else if common.IsKubernetesVersionGe(cs.Properties.OrchestratorProfile.OrchestratorVersion, "1.9.0") {
 				return true
 			}
 			return false

--- a/pkg/api/common/helper.go
+++ b/pkg/api/common/helper.go
@@ -151,3 +151,10 @@ func RationalizeReleaseAndVersion(orchType, orchRel, orchVer string) (version st
 	}
 	return version
 }
+
+// IsKubernetesVersionGe returns if a semver string is >= to a compare-against semver string (suppport "-" suffixes)
+func IsKubernetesVersionGe(actualVersion, version string) bool {
+	orchestratorVersion, _ := semver.NewVersion(strings.Split(actualVersion, "-")[0]) // to account for -alpha and -beta suffixes
+	constraint, _ := semver.NewConstraint(">=" + version)
+	return constraint.Check(orchestratorVersion)
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -4,6 +4,7 @@ import (
 	neturl "net/url"
 
 	"github.com/Azure/acs-engine/pkg/api/agentPoolOnlyApi/v20170831"
+	"github.com/Azure/acs-engine/pkg/api/common"
 	"github.com/Azure/acs-engine/pkg/api/v20160330"
 	"github.com/Azure/acs-engine/pkg/api/v20160930"
 	"github.com/Azure/acs-engine/pkg/api/v20170131"
@@ -680,7 +681,7 @@ func (o *OrchestratorProfile) IsMetricsServerEnabled() bool {
 			metricsServerAddon = k.Addons[i]
 		}
 	}
-	return metricsServerAddon.IsEnabled(DefaultMetricsServerAddonEnabled)
+	return metricsServerAddon.IsEnabled(DefaultMetricsServerAddonEnabled || common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.9.0"))
 }
 
 // IsTillerEnabled checks if the tiller addon is enabled


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This should make 1.10-beta.2 clusters operational

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Enable aggregated API by default for 1.10-beta.2
```
