### PR TITLE
add e2e validation for k8s ILB routing

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -375,6 +375,26 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Skip("No linux agent was provisioned for this Cluster Definition")
 			}
 		})
+
+		It("should be able to produce a working ILB connection", func() {
+			if eng.HasLinuxAgents() {
+				By("Creating a nginx deployment")
+				r := rand.New(rand.NewSource(time.Now().UnixNano()))
+				serviceName := "ingress-nginx"
+				deploymentName := fmt.Sprintf("ingress-nginx-%s-%v", cfg.Name, r.Intn(99999))
+				_, err := deployment.CreateLinuxDeploy("library/nginx:latest", deploymentName, "default", "--labels=app="+serviceName)
+				Expect(err).NotTo(HaveOccurred())
+
+				s, err := service.CreateServiceFromFile(filepath.Join(WorkloadDir, "ingress-nginx-ilb.yaml"), serviceName, "default")
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Ensuring the service root URL returns the expected payload")
+				valid := s.Validate("(Welcome to nginx)", 5, 30*time.Second, cfg.Timeout)
+				Expect(valid).To(BeTrue())
+			} else {
+				Skip("No linux agent was provisioned for this Cluster Definition")
+			}
+		})
 	})
 
 	Describe("with a GPU-enabled agent pool", func() {

--- a/test/e2e/kubernetes/service/service.go
+++ b/test/e2e/kubernetes/service/service.go
@@ -159,3 +159,20 @@ func (s *Service) Validate(check string, attempts int, sleep, wait time.Duration
 	}
 	return false
 }
+
+// CreateServiceFromFile will create a Service from file with a name
+func CreateServiceFromFile(filename, name, namespace string) (*Service, error) {
+	cmd := exec.Command("kubectl", "create", "-f", filename)
+	util.PrintCommand(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Error trying to create Service %s:%s\n", name, string(out))
+		return nil, err
+	}
+	svc, err := Get(name, namespace)
+	if err != nil {
+		log.Printf("Error while trying to fetch Service %s:%s\n", name, err)
+		return nil, err
+	}
+	return svc, nil
+}

--- a/test/e2e/kubernetes/workloads/ingress-nginx-ilb.yaml
+++ b/test/e2e/kubernetes/workloads/ingress-nginx-ilb.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+spec:
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+    protocol: TCP
+  - name: https
+    port: 443
+    targetPort: 443
+    protocol: TCP
+  selector:
+    app: ingress-nginx


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: We want to verify that 1.9 clusters don't route ILBs properly out of the gate. @khenidak @lachie83 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
