### PR TITLE
Deregister node in api server during cordon-and-drain

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -398,7 +398,7 @@ func (sc *scaleCmd) drainNodes(vmsToDelete []string) error {
 	for _, vmName := range vmsToDelete {
 		go func(vmName string) {
 			e := operations.SafelyDrainNode(sc.client, sc.logger,
-				masterURL, kubeConfig, vmName, time.Duration(60)*time.Minute)
+				masterURL, kubeConfig, vmName, false, time.Duration(60)*time.Minute)
 			if e != nil {
 				log.Errorf("Failed to drain node %s, got error %s", vmName, e.Error())
 				errChan <- &operations.VMScalingErrorDetails{Error: e, Name: vmName}

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -398,7 +398,7 @@ func (sc *scaleCmd) drainNodes(vmsToDelete []string) error {
 	for _, vmName := range vmsToDelete {
 		go func(vmName string) {
 			e := operations.SafelyDrainNode(sc.client, sc.logger,
-				masterURL, kubeConfig, vmName, false, time.Duration(60)*time.Minute)
+				masterURL, kubeConfig, vmName, time.Duration(60)*time.Minute)
 			if e != nil {
 				log.Errorf("Failed to drain node %s, got error %s", vmName, e.Error())
 				errChan <- &operations.VMScalingErrorDetails{Error: e, Name: vmName}

--- a/pkg/armhelpers/interfaces.go
+++ b/pkg/armhelpers/interfaces.go
@@ -102,6 +102,8 @@ type KubernetesClient interface {
 	GetNode(name string) (*v1.Node, error)
 	//UpdateNode updates the node in the api server with the passed in info
 	UpdateNode(node *v1.Node) (*v1.Node, error)
+	//DeleteNode deregisters node in the api server
+	DeleteNode(name string) error
 	//SupportEviction queries the api server to discover if it supports eviction, and returns supported type if it is supported
 	SupportEviction() (string, error)
 	//DeletePod deletes the passed in pod

--- a/pkg/armhelpers/kubeclient.go
+++ b/pkg/armhelpers/kubeclient.go
@@ -56,6 +56,11 @@ func (c *KubernetesClientSetClient) UpdateNode(node *v1.Node) (*v1.Node, error) 
 	return c.clientset.Nodes().Update(node)
 }
 
+//DeleteNode deregisters the node in the api server
+func (c *KubernetesClientSetClient) DeleteNode(name string) error {
+	return c.clientset.Nodes().Delete(name, &metav1.DeleteOptions{})
+}
+
 //SupportEviction queries the api server to discover if it supports eviction, and returns supported type if it is supported
 func (c *KubernetesClientSetClient) SupportEviction() (string, error) {
 	discoveryClient := c.clientset.Discovery()

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -44,6 +44,7 @@ type MockKubernetesClient struct {
 	FailGetNode           bool
 	UpdateNodeFunc        func(*v1.Node) (*v1.Node, error)
 	FailUpdateNode        bool
+	FailDeleteNode        bool
 	FailSupportEviction   bool
 	FailDeletePod         bool
 	FailEvictPod          bool
@@ -82,6 +83,14 @@ func (mkc *MockKubernetesClient) UpdateNode(node *v1.Node) (*v1.Node, error) {
 		return nil, fmt.Errorf("UpdateNode failed")
 	}
 	return node, nil
+}
+
+//DeleteNode deregisters node in the api server
+func (mkc *MockKubernetesClient) DeleteNode(name string) error {
+	if mkc.FailDeleteNode {
+		return fmt.Errorf("DeleteNode failed")
+	}
+	return nil
 }
 
 //SupportEviction queries the api server to discover if it supports eviction, and returns supported type if it is supported

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -49,7 +49,7 @@ func (kan *UpgradeAgentNode) DeleteNode(vmName *string, drain bool) error {
 			kubeAPIServerURL = kan.UpgradeContainerService.Properties.MasterProfile.FQDN
 		}
 
-		err := operations.SafelyDrainNode(kan.Client, kan.logger, kubeAPIServerURL, kan.kubeConfig, *vmName, time.Minute)
+		err := operations.SafelyDrainNode(kan.Client, kan.logger, kubeAPIServerURL, kan.kubeConfig, *vmName, true, time.Minute)
 		if err != nil {
 			kan.logger.Warningf("Error draining agent VM %s. Proceeding with deletion. Error: %v", *vmName, err)
 			// Proceed with deletion anyways


### PR DESCRIPTION
After upgrade operation, the api server sometimes lists already deleted nodes.
Adding explicit call to deregister nodes during cordon-and-drain.