### PR TITLE
Adding Support for DC/OS 1.11.0

### DIFF
--- a/docs/contributing-dcos.md
+++ b/docs/contributing-dcos.md
@@ -15,6 +15,9 @@ We now need to find the package GUID of each variant.
 In each template you should find a string that looks like: `dcos-config--setup_<Some GUID>`, this GUID is what we are looking for.
 Extract the GUIDs from the 3 differents templates, and them in `engine.go/getPackageGUID` for your specific DC/OS version.
 
+In DC/OS 1.11 and greater, you should find a the contents for `/etc/mesosphere/setup-flags/repository-url` in each 3 ARM templates (1, 3 and 5 masters variants).
+Extract the GUIDs from the 3 differents templates, and them in `dcos/dcoscustomdataXXX.t` for your specific DC/OS version.
+
 
 ## 3. Extract the cloud-config data from the template
 

--- a/parts/dcos/dcoscustomdata111.t
+++ b/parts/dcos/dcoscustomdata111.t
@@ -165,9 +165,8 @@ write_files:
   owner: root
   path: /etc/mesosphere/setup-flags/repository-url
   permissions: '0644'
-- content: '302987609a34f07c206da1791c5a553141416ad8
-
-'
+- content: |-
+        ', if(equals(variables('masterCount'), 1), 'eee6337ea89c74ba58986406d24e373bdeae8012', if(equals(variables('masterCount'), 3), '248a66388bba1adbcb14a52fd3b7b424ab06fa76', if(equals(variables('masterCount'), 5), '302987609a34f07c206da1791c5a553141416ad8', 'noMasterMatch'))), '
   owner: root
   path: /etc/mesosphere/setup-flags/cluster-package-list
   permissions: '0644'

--- a/parts/dcos/dcoscustomdata111.t
+++ b/parts/dcos/dcoscustomdata111.t
@@ -1,0 +1,311 @@
+bootcmd:
+- bash -c "if [ ! -f /var/lib/sdb-gpt ];then echo DCOS-5890;parted -s /dev/sdb mklabel
+  gpt;touch /var/lib/sdb-gpt;fi"
+- bash -c "if [ ! -f /var/lib/sdc-gpt ];then echo DCOS-5890;parted -s /dev/sdc mklabel
+  gpt&&touch /var/lib/sdc-gpt;fi"
+- bash -c "if [ ! -f /var/lib/sdd-gpt ];then echo DCOS-5890;parted -s /dev/sdd mklabel
+  gpt&&touch /var/lib/sdd-gpt;fi"
+- bash -c "if [ ! -f /var/lib/sde-gpt ];then echo DCOS-5890;parted -s /dev/sde mklabel
+  gpt&&touch /var/lib/sde-gpt;fi"
+- bash -c "if [ ! -f /var/lib/sdf-gpt ];then echo DCOS-5890;parted -s /dev/sdf mklabel
+  gpt&&touch /var/lib/sdf-gpt;fi"
+- bash -c "mkdir -p /dcos/volume{0,1,2,3}"
+disk_setup:
+  ephemeral0:
+    layout:
+    - 45
+    - 45
+    - 10
+    overwrite: true
+    table_type: gpt
+  /dev/sdc:
+    layout: true
+    overwrite: true
+    table_type: gpt
+  /dev/sdd:
+    layout: true
+    overwrite: true
+    table_type: gpt
+  /dev/sde:
+    layout: true
+    overwrite: true
+    table_type: gpt
+  /dev/sdf:
+    layout: true
+    overwrite: true
+    table_type: gpt
+fs_setup:
+- device: ephemeral0.1
+  filesystem: ext4
+  overwrite: true
+- device: ephemeral0.2
+  filesystem: ext4
+  overwrite: true
+- device: ephemeral0.3
+  filesystem: ext4
+  overwrite: true
+- device: /dev/sdc1
+  filesystem: ext4
+  overwrite: true
+- device: /dev/sdd1
+  filesystem: ext4
+  overwrite: true
+- device: /dev/sde1
+  filesystem: ext4
+  overwrite: true
+- device: /dev/sdf1
+  filesystem: ext4
+  overwrite: true
+mounts:
+- - ephemeral0.1
+  - /var/lib/mesos
+- - ephemeral0.2
+  - /var/lib/docker
+- - ephemeral0.3
+  - /var/tmp
+- - /dev/sdc1
+  - /dcos/volume0
+- - /dev/sdd1
+  - /dcos/volume1
+- - /dev/sde1
+  - /dcos/volume2
+- - /dev/sdf1
+  - /dcos/volume3
+runcmd: PREPROVISION_EXTENSION
+- - ln
+  - -s
+  - /bin/rm
+  - /usr/bin/rm
+- - ln
+  - -s
+  - /bin/mkdir
+  - /usr/bin/mkdir
+- - ln
+  - -s
+  - /bin/tar
+  - /usr/bin/tar
+- - ln
+  - -s
+  - /bin/ln
+  - /usr/bin/ln
+- - ln
+  - -s
+  - /bin/cp
+  - /usr/bin/cp
+- - ln
+  - -s
+  - /bin/systemctl
+  - /usr/bin/systemctl
+- - ln
+  - -s
+  - /bin/mount
+  - /usr/bin/mount
+- - ln
+  - -s
+  - /bin/bash
+  - /usr/bin/bash
+- - ln
+  - -s
+  - /usr/sbin/useradd
+  - /usr/bin/useradd
+- - systemctl
+  - disable
+  - --now
+  - resolvconf.service
+- - systemctl
+  - mask
+  - --now
+  - lxc-net.service
+- - systemctl
+  - disable
+  - --now
+  - unscd.service
+- - systemctl
+  - stop
+  - --now
+  - unscd.service
+- /opt/azure/containers/provision.sh
+- - cp
+  - -p
+  - /etc/resolv.conf
+  - /tmp/resolv.conf
+- - rm
+  - -f
+  - /etc/resolv.conf
+- - cp
+  - -p
+  - /tmp/resolv.conf
+  - /etc/resolv.conf
+- - systemctl
+  - start
+  - dcos-docker-install.service
+- - systemctl
+  - start
+  - dcos-config-writer.service
+- - systemctl
+  - restart
+  - systemd-journald.service
+- - systemctl
+  - restart
+  - docker.service
+- - systemctl
+  - start
+  - dcos-link-env.service
+- - systemctl
+  - enable
+  - dcos-setup.service
+- - systemctl
+  - --no-block
+  - start
+  - dcos-setup.service
+write_files:
+- content: 'https://dcosio.azureedge.net/dcos/stable/1.11.0
+
+'
+  owner: root
+  path: /etc/mesosphere/setup-flags/repository-url
+  permissions: '0644'
+- content: '302987609a34f07c206da1791c5a553141416ad8
+
+'
+  owner: root
+  path: /etc/mesosphere/setup-flags/cluster-package-list
+  permissions: '0644'
+- content: |
+    [Journal]
+    MaxLevelConsole=warning
+    RateLimitInterval=1s
+    RateLimitBurst=20000
+  owner: root
+  path: /etc/systemd/journald.conf.d/dcos.conf
+  permissions: '0644'
+- content: |
+    rexray:
+      loglevel: info
+      modules:
+        default-docker:
+          disabled: true
+      service: vfs
+  path: /etc/rexray/config.yml
+  permissions: '0644'
+- content: |
+    [Unit]
+    After=network-online.target
+    Wants=network-online.target
+    [Service]
+    Type=oneshot
+    Environment=DEBIAN_FRONTEND=noninteractive
+    StandardOutput=journal+console
+    StandardError=journal+console
+    ExecStartPre=/usr/bin/curl -fLsSv --retry 20 -Y 100000 -y 60 -o /var/tmp/d.deb https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_17.09.0~ce-0~ubuntu_amd64.deb
+    ExecStart=/usr/bin/bash -c "try=1;until dpkg -D3 -i /var/tmp/d.deb || ((try>9));do echo retry $((try++));sleep $((try*try));done;systemctl --now start docker;systemctl restart docker.socket"
+  path: /etc/systemd/system/dcos-docker-install.service
+  permissions: '0644'
+- content: |
+    [Service]
+    Restart=always
+    StartLimitInterval=0
+    RestartSec=15
+    ExecStartPre=-/sbin/ip link del docker0
+    ExecStart=
+    ExecStart=/usr/bin/dockerd --storage-driver=overlay
+  path: /etc/systemd/system/docker.service.d/execstart.conf
+  permissions: '0644'
+- content: |
+    [Unit]
+    PartOf=docker.service
+    [Socket]
+    ListenStream=/var/run/docker.sock
+    SocketMode=0660
+    SocketUser=root
+    SocketGroup=docker
+    ListenStream=2375
+    BindIPv6Only=both
+    [Install]
+    WantedBy=sockets.target
+  path: /etc/systemd/system/docker.socket
+  permissions: '0644'
+- content: |
+      [Unit]
+      Requires=dcos-setup.service
+      After=dcos-setup.service
+      [Service]
+      Type=oneshot
+      EnvironmentFile=/etc/environment
+      EnvironmentFile=/opt/mesosphere/environment
+      ExecStart=/usr/bin/bash -c "echo $(detect_ip) $(hostname) > /etc/hosts"
+  path: /etc/systemd/system/dcos-config-writer.service
+  permissions: '0644'
+- content: |
+    "bound_values":
+      "adminrouter_auth_enabled": |-
+        {{{oauthEnabled}}}
+      "cluster_name": |-
+        {{{masterPublicIPAddressName}}}
+      "exhibitor_azure_account_key": |-
+        ', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('masterStorageAccountExhibitorName')), '2015-06-15').key1, '
+      "exhibitor_azure_account_name": |-
+        {{{masterStorageAccountExhibitorName}}}
+      "exhibitor_azure_prefix": |-
+        {{{masterPublicIPAddressName}}}
+      "master_list": |-
+        ["', DCOSCUSTOMDATAPUBLICIPSTR'"]
+      "oauth_enabled": |-
+        {{{oauthEnabled}}}
+    "late_bound_package_id": |-
+      dcos-provider-DCOSGUID-azure--setup
+  owner: root
+  path: /etc/mesosphere/setup-flags/late-config.yaml
+  permissions: '0644'
+- content: |
+    [Unit]
+    Before=dcos.target
+    [Service]
+    Type=oneshot
+    StandardOutput=journal+console
+    StandardError=journal+console
+    ExecStartPre=/usr/bin/mkdir -p /etc/profile.d
+    ExecStart=/usr/bin/ln -sf /opt/mesosphere/bin/add_dcos_path.sh /etc/profile.d/dcos.sh
+  path: /etc/systemd/system/dcos-link-env.service
+  permissions: '0644'
+- content: |
+    [Unit]
+    Description=Pkgpanda: Download DC/OS to this host.
+    After=network-online.target
+    Wants=network-online.target
+    ConditionPathExists=!/opt/mesosphere/
+    [Service]
+    Type=oneshot
+    StandardOutput=journal+console
+    StandardError=journal+console
+    ExecStartPre=/usr/bin/curl --keepalive-time 2 -fLsSv --retry 20 -Y 100000 -y 60 -o //var/tmp/bootstrap.tar.xz https://dcosio.azureedge.net/dcos/stable/1.11.0/bootstrap/a0654657903fb68dff60f6e522a7f241c1bfbf0f.bootstrap.tar.xz
+    ExecStartPre=/usr/bin/mkdir -p /opt/mesosphere
+    ExecStart=/usr/bin/tar -axf //var/tmp/bootstrap.tar.xz -C /opt/mesosphere
+    ExecStartPost=-/usr/bin/rm -f //var/tmp/bootstrap.tar.xz
+  path: /etc/systemd/system/dcos-download.service
+  permissions: '0644'
+- content: |
+    [Unit]
+    Description=Pkgpanda: Specialize DC/OS for this host.
+    Requires=dcos-download.service
+    After=dcos-download.service
+    [Service]
+    Type=oneshot
+    StandardOutput=journal+console
+    StandardError=journal+console
+    EnvironmentFile=/opt/mesosphere/environment
+    ExecStart=/opt/mesosphere/bin/pkgpanda setup --no-block-systemd
+    [Install]
+    WantedBy=multi-user.target
+  path: /etc/systemd/system/dcos-setup.service
+  permissions: '0644'
+- content: ''
+  path: /etc/mesosphere/roles/azure
+- path: /var/lib/dcos/mesos-slave-common
+  content: 'ATTRIBUTES_STR'
+  permissions: "0644"
+  owner: "root"
+- content: 'PROVISION_STR'
+  path: /opt/azure/containers/provision.sh
+  permissions: "0744"
+  owner: "root"

--- a/parts/dcos/dcosmasterresources.t
+++ b/parts/dcos/dcosmasterresources.t
@@ -207,7 +207,7 @@
       "name": "[variables('masterNSGName')]",
       "properties": {
         "securityRules": [
-{{if IsDCOS19}} 
+{{if IsDCOS19}}
             {
                 "properties": {
                     "priority": 201,

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -43,6 +43,7 @@ var (
 		DCOS188BootstrapDownloadURL:     fmt.Sprintf(AzureEdgeDCOSBootstrapDownloadURL, "stable", "5df43052907c021eeb5de145419a3da1898c58a5"),
 		DCOS190BootstrapDownloadURL:     fmt.Sprintf(AzureEdgeDCOSBootstrapDownloadURL, "stable", "58fd0833ce81b6244fc73bf65b5deb43217b0bd7"),
 		DCOS110BootstrapDownloadURL:     fmt.Sprintf(AzureEdgeDCOSBootstrapDownloadURL, "stable", "e38ab2aa282077c8eb7bf103c6fff7b0f08db1a4"),
+		DCOS111BootstrapDownloadURL:     fmt.Sprintf(AzureEdgeDCOSBootstrapDownloadURL, "stable", "b6d6ad4722600877fde2860122f870031d109da3"),
 		DCOSWindowsBootstrapDownloadURL: "http://dcos-win.westus.cloudapp.azure.com/dcos-windows/stable/",
 	}
 

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -43,6 +43,7 @@ const (
 	dcosCustomData188    = "dcos/dcoscustomdata188.t"
 	dcosCustomData190    = "dcos/dcoscustomdata190.t"
 	dcosCustomData110    = "dcos/dcoscustomdata110.t"
+	dcosCustomData111    = "dcos/dcoscustomdata111.t"
 	dcosProvision        = "dcos/dcosprovision.sh"
 	dcosWindowsProvision = "dcos/dcosWindowsProvision.ps1"
 )
@@ -716,6 +717,8 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 				dcosBootstrapURL = cloudSpecConfig.DCOSSpecConfig.DCOS190BootstrapDownloadURL
 			case api.DCOSVersion1Dot10Dot0:
 				dcosBootstrapURL = cloudSpecConfig.DCOSSpecConfig.DCOS110BootstrapDownloadURL
+			case api.DCOSVersion1Dot11Dot0:
+				dcosBootstrapURL = cloudSpecConfig.DCOSSpecConfig.DCOS111BootstrapDownloadURL
 			}
 		}
 
@@ -857,6 +860,10 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"IsDCOS110": func() bool {
 			return cs.Properties.OrchestratorProfile.OrchestratorType == api.DCOS &&
 				cs.Properties.OrchestratorProfile.OrchestratorVersion == api.DCOSVersion1Dot10Dot0
+		},
+		"IsDCOS111": func() bool {
+			return cs.Properties.OrchestratorProfile.OrchestratorType == api.DCOS &&
+				cs.Properties.OrchestratorProfile.OrchestratorVersion == api.DCOSVersion1Dot11Dot0
 		},
 		"IsKubernetesVersionGe": func(version string) bool {
 			orchestratorVersion, _ := semver.NewVersion(cs.Properties.OrchestratorProfile.OrchestratorVersion)
@@ -1733,6 +1740,15 @@ func getDCOSWindowsAgentPreprovisionParameters(cs *api.ContainerService, profile
 func getPackageGUID(orchestratorType string, orchestratorVersion string, masterCount int) string {
 	if orchestratorType == api.DCOS {
 		switch orchestratorVersion {
+		case api.DCOSVersion1Dot11Dot0:
+			switch masterCount {
+			case 1:
+				return "5a6b7b92820dc4a7825c84f0a96e012e0fcc8a6b"
+			case 3:
+				return "327392a609d77d411886216d431e00581a8612f7"
+			case 5:
+				return "fd24e32755e7868841a3fafd21b2d2cce0aa4154"
+			}
 		case api.DCOSVersion1Dot10Dot0:
 			switch masterCount {
 			case 1:
@@ -2219,6 +2235,8 @@ func getSingleLineDCOSCustomData(orchestratorType, orchestratorVersion string,
 			yamlFilename = dcosCustomData190
 		case api.DCOSVersion1Dot10Dot0:
 			yamlFilename = dcosCustomData110
+		case api.DCOSVersion1Dot11Dot0:
+			yamlFilename = dcosCustomData111
 		}
 	default:
 		// it is a bug to get here

--- a/pkg/acsengine/types.go
+++ b/pkg/acsengine/types.go
@@ -37,6 +37,7 @@ type DCOSSpecConfig struct {
 	DCOS188BootstrapDownloadURL     string
 	DCOS190BootstrapDownloadURL     string
 	DCOS110BootstrapDownloadURL     string
+	DCOS111BootstrapDownloadURL     string
 	DCOSWindowsBootstrapDownloadURL string
 }
 

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -184,6 +184,8 @@ var AllKubernetesWindowsSupportedVersions = map[string]bool{
 }
 
 const (
+	// DCOSVersion1Dot11Dot0 is the major.minor.patch string for 1.11.0 versions of DCOS
+	DCOSVersion1Dot11Dot0 string = "1.11.0"
 	// DCOSVersion1Dot10Dot0 is the major.minor.patch string for 1.10.0 versions of DCOS
 	DCOSVersion1Dot10Dot0 string = "1.10.0"
 	// DCOSVersion1Dot9Dot0 is the major.minor.patch string for 1.9.0 versions of DCOS
@@ -191,11 +193,12 @@ const (
 	// DCOSVersion1Dot8Dot8 is the major.minor.patch string for 1.8.8 versions of DCOS
 	DCOSVersion1Dot8Dot8 string = "1.8.8"
 	// DCOSDefaultVersion is the default major.minor.patch version for DCOS
-	DCOSDefaultVersion string = DCOSVersion1Dot9Dot0
+	DCOSDefaultVersion string = DCOSVersion1Dot11Dot0
 )
 
 // AllDCOSSupportedVersions maintain a list of available dcos versions in acs-engine
 var AllDCOSSupportedVersions = []string{
+	DCOSVersion1Dot11Dot0,
 	DCOSVersion1Dot10Dot0,
 	DCOSVersion1Dot9Dot0,
 	DCOSVersion1Dot8Dot8,

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -69,6 +69,8 @@ const (
 )
 
 const (
+	// DCOSVersion1Dot11Dot0 is the major.minor.patch string for 1.11.0 versions of DCOS
+	DCOSVersion1Dot11Dot0 string = "1.11.0"
 	// DCOSVersion1Dot10Dot0 is the major.minor.patch string for 1.10.0 versions of DCOS
 	DCOSVersion1Dot10Dot0 string = "1.10.0"
 	// DCOSVersion1Dot9Dot0 is the major.minor.patch string for 1.9.0 versions of DCOS
@@ -76,7 +78,7 @@ const (
 	// DCOSVersion1Dot8Dot8 is the major.minor.patch string for 1.8.8 versions of DCOS
 	DCOSVersion1Dot8Dot8 string = "1.8.8"
 	// DCOSDefaultVersion is the default major.minor.patch version for DCOS
-	DCOSDefaultVersion string = DCOSVersion1Dot9Dot0
+	DCOSDefaultVersion string = DCOSVersion1Dot11Dot0
 )
 
 // To identify programmatically generated public agent pools

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -546,7 +546,7 @@ func convertV20170701OrchestratorProfile(v20170701cs *v20170701.OrchestratorProf
 		api.OrchestratorVersion = common.GetSupportedKubernetesVersion(v20170701cs.OrchestratorVersion)
 	case DCOS:
 		switch v20170701cs.OrchestratorVersion {
-		case DCOSVersion1Dot10Dot0, DCOSVersion1Dot9Dot0, DCOSVersion1Dot8Dot8:
+		case DCOSVersion1Dot11Dot0, DCOSVersion1Dot10Dot0, DCOSVersion1Dot9Dot0, DCOSVersion1Dot8Dot8:
 			api.OrchestratorVersion = v20170701cs.OrchestratorVersion
 		default:
 			api.OrchestratorVersion = DCOSDefaultVersion

--- a/pkg/api/v20170701/validate.go
+++ b/pkg/api/v20170701/validate.go
@@ -30,6 +30,7 @@ func (o *OrchestratorProfile) Validate(isUpdate bool) error {
 		case Swarm:
 		case DCOS:
 			switch o.OrchestratorVersion {
+			case common.DCOSVersion1Dot11Dot0:
 			case common.DCOSVersion1Dot10Dot0:
 			case common.DCOSVersion1Dot9Dot0:
 			case common.DCOSVersion1Dot8Dot8:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR adds support for the latest DC/OS version 1.11.0

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)

2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.

NONE
-->
```release-note
* Added DC/OS 1.11.0 version
* Tested and confirmed that the cluster launches and runs successfully.
* Updated documentation to include newer internal changes that are required for anyone who wants to update to a newer version in the future. 
```
