### PR TITLE
don’t restart systemctl where it is already set to Restart=on-failure

### DIFF
--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -368,7 +368,7 @@ runcmd:
 - /bin/chown -R etcd:etcd /var/lib/etcddisk
 - retrycmd_if_failure 5 5 timeout 30s systemctl stop etcd
 - retrycmd_if_failure 5 5 timeout 60s systemctl daemon-reload
-- retrycmd_if_failure 5 5 timeout 60s systemctl restart etcd
+- systemctl restart etcd
 - MEMBER="$(sudo etcdctl member list | grep -E {{WrapAsVerbatim "variables('masterVMNames')[copyIndex(variables('masterOffset'))]"}} | cut -d{{WrapAsVariable "singleQuote"}}:{{WrapAsVariable "singleQuote"}} -f 1)"
 - sudo etcdctl member update ${MEMBER} {{WrapAsVerbatim "variables('masterEtcdPeerURLs')[copyIndex(variables('masterOffset'))]"}}
 - retrycmd_if_failure 5 5 curl --cacert /etc/kubernetes/certs/ca.crt --cert /etc/kubernetes/certs/etcdclient.crt --key /etc/kubernetes/certs/etcdclient.key --retry 5 --retry-delay 10 --retry-max-time 30 --max-time 60 "{{WrapAsVerbatim "variables('masterEtcdClientURLs')[copyIndex(variables('masterOffset'))]"}}"/v2/machines

--- a/parts/k8s/kubernetesmastercustomscript.sh
+++ b/parts/k8s/kubernetesmastercustomscript.sh
@@ -513,7 +513,7 @@ function ensureKubelet() {
     systemctlEnableAndCheck kubelet
     # only start if a reboot is not required
     if ! $REBOOTREQUIRED; then
-        retrycmd_if_failure 5 5 timeout 60s systemctl restart kubelet
+        systemctl restart kubelet
     fi
 }
 
@@ -521,7 +521,7 @@ function extractKubectl(){
     systemctlEnableAndCheck kubectl-extract
     # only start if a reboot is not required
     if ! $REBOOTREQUIRED; then
-        retrycmd_if_failure 5 5 timeout 60s systemctl restart kubectl-extract
+        systemctl restart kubectl-extract
     fi
 }
 
@@ -534,7 +534,7 @@ function ensureJournal(){
     echo "ForwardToSyslog=no" >> /etc/systemd/journald.conf
     # only start if a reboot is not required
     if ! $REBOOTREQUIRED; then
-        retrycmd_if_failure 5 5 timeout 60s systemctl restart systemd-journald.service
+        systemctl restart systemd-journald.service
     fi
 }
 

--- a/parts/k8s/kubernetesmastercustomscript.sh
+++ b/parts/k8s/kubernetesmastercustomscript.sh
@@ -513,7 +513,7 @@ function ensureKubelet() {
     systemctlEnableAndCheck kubelet
     # only start if a reboot is not required
     if ! $REBOOTREQUIRED; then
-        systemctl restart kubelet
+        retrycmd_if_failure 20 10 timeout 60s systemctl restart kubelet
     fi
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: dial back timeout restarts a bit

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
