### PR TITLE
Revert "don’t restart systemctl where it is already set to Restart=on-failure"

### DIFF
--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -368,7 +368,7 @@ runcmd:
 - /bin/chown -R etcd:etcd /var/lib/etcddisk
 - retrycmd_if_failure 5 5 timeout 30s systemctl stop etcd
 - retrycmd_if_failure 5 5 timeout 60s systemctl daemon-reload
-- systemctl restart etcd
+- retrycmd_if_failure 5 5 timeout 60s systemctl restart etcd
 - MEMBER="$(sudo etcdctl member list | grep -E {{WrapAsVerbatim "variables('masterVMNames')[copyIndex(variables('masterOffset'))]"}} | cut -d{{WrapAsVariable "singleQuote"}}:{{WrapAsVariable "singleQuote"}} -f 1)"
 - sudo etcdctl member update ${MEMBER} {{WrapAsVerbatim "variables('masterEtcdPeerURLs')[copyIndex(variables('masterOffset'))]"}}
 - retrycmd_if_failure 5 5 curl --cacert /etc/kubernetes/certs/ca.crt --cert /etc/kubernetes/certs/etcdclient.crt --key /etc/kubernetes/certs/etcdclient.key --retry 5 --retry-delay 10 --retry-max-time 30 --max-time 60 "{{WrapAsVerbatim "variables('masterEtcdClientURLs')[copyIndex(variables('masterOffset'))]"}}"/v2/machines

--- a/parts/k8s/kubernetesmastercustomscript.sh
+++ b/parts/k8s/kubernetesmastercustomscript.sh
@@ -513,7 +513,7 @@ function ensureKubelet() {
     systemctlEnableAndCheck kubelet
     # only start if a reboot is not required
     if ! $REBOOTREQUIRED; then
-        retrycmd_if_failure 20 10 timeout 60s systemctl restart kubelet
+        retrycmd_if_failure 5 5 timeout 60s systemctl restart kubelet
     fi
 }
 
@@ -521,7 +521,7 @@ function extractKubectl(){
     systemctlEnableAndCheck kubectl-extract
     # only start if a reboot is not required
     if ! $REBOOTREQUIRED; then
-        systemctl restart kubectl-extract
+        retrycmd_if_failure 5 5 timeout 60s systemctl restart kubectl-extract
     fi
 }
 
@@ -534,7 +534,7 @@ function ensureJournal(){
     echo "ForwardToSyslog=no" >> /etc/systemd/journald.conf
     # only start if a reboot is not required
     if ! $REBOOTREQUIRED; then
-        systemctl restart systemd-journald.service
+        retrycmd_if_failure 5 5 timeout 60s systemctl restart systemd-journald.service
     fi
 }
 


### PR DESCRIPTION
Reverts Azure/acs-engine#2444