### PR TITLE
Upgrade support for 1.10.0-beta.2

### DIFF
--- a/pkg/api/orchestrators.go
+++ b/pkg/api/orchestrators.go
@@ -184,6 +184,9 @@ func kubernetesUpgrades(csOrch *OrchestratorProfile) ([]*OrchestratorProfile, er
 	case currentMajor == 1 && currentMinor == 8:
 		nextMajor = 1
 		nextMinor = 9
+	case currentMajor == 1 && currentMinor == 9:
+		nextMajor = 1
+		nextMinor = 10
 	}
 	for ver, supported := range common.AllKubernetesSupportedVersions {
 		if !supported {

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -99,6 +99,11 @@ func (uc *UpgradeCluster) UpgradeCluster(subscriptionID uuid.UUID, kubeConfig, r
 		upgrader19.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout)
 		upgrader = upgrader19
 
+	case strings.HasPrefix(upgradeVersion, "1.10."):
+		upgrader110 := &Upgrader{}
+		upgrader110.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout)
+		upgrader = upgrader110
+
 	default:
 		return uc.Translator.Errorf("Upgrade to Kubernetes version %s is not supported", upgradeVersion)
 	}


### PR DESCRIPTION
The upgrade scenario was not working (yet). These changes enabled me to upgrade my 1.9.3. cluster to 1.10.0-beta.2

```
NAME                     STATUS    ROLES     AGE       VERSION
k8s-default-39042091-0   Ready     agent     22h       v1.9.3
k8s-master-39042091-0    Ready     master    22h       v1.10.0-beta.2

```

```

NAME                     STATUS    ROLES     AGE       VERSION
k8s-default-39042091-1   Ready     agent     5m        v1.10.0-beta.2
k8s-master-39042091-0    Ready     master    22h       v1.10.0-beta.2

```

Listing available upgrades for 1.10.0-beta.2 :

```{
  "orchestrators": [
    {
      "orchestratorType": "Kubernetes",
      "orchestratorVersion": "1.10.0-beta.2",
      "upgrades": [
        {
          "orchestratorType": "",
          "orchestratorVersion": "1.10.0-beta.3"
        }
      ]
    }
  ]
}
```

/cc @jackfrancis 