### PR TITLE
orchestratorRelease by platform in vlabs

### DIFF
--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -183,6 +183,15 @@ var AllKubernetesWindowsSupportedVersions = map[string]bool{
 	KubernetesVersion1Dot10Dot0: false,
 }
 
+// GetAllSupportedKubernetesVersionsWindows returns a slice of all supported Kubernetes versions on Windows
+func GetAllSupportedKubernetesVersionsWindows() []string {
+	versions := make([]string, 0, len(AllKubernetesWindowsSupportedVersions))
+	for k := range AllKubernetesWindowsSupportedVersions {
+		versions = append(versions, k)
+	}
+	return versions
+}
+
 const (
 	// DCOSVersion1Dot10Dot0 is the major.minor.patch string for 1.10.0 versions of DCOS
 	DCOSVersion1Dot10Dot0 string = "1.10.0"

--- a/pkg/api/common/helper.go
+++ b/pkg/api/common/helper.go
@@ -55,10 +55,14 @@ func HandleValidationErrors(e validator.ValidationErrors) error {
 }
 
 // GetSupportedVersions get supported version list for a certain orchestrator
-func GetSupportedVersions(orchType string) (versions []string, defaultVersion string) {
+func GetSupportedVersions(orchType string, hasWindows bool) (versions []string, defaultVersion string) {
 	switch orchType {
 	case Kubernetes:
+		if hasWindows {
+			return GetAllSupportedKubernetesVersionsWindows(), string(KubernetesDefaultVersion)
+		}
 		return GetAllSupportedKubernetesVersions(), string(KubernetesDefaultVersion)
+
 	case DCOS:
 		return AllDCOSSupportedVersions, DCOSDefaultVersion
 	default:
@@ -72,14 +76,16 @@ func GetValidPatchVersion(orchType, orchVer string) string {
 		return RationalizeReleaseAndVersion(
 			orchType,
 			"",
-			"")
+			"",
+			false)
 	}
 
 	// check if the current version is valid, this allows us to have multiple supported patch versions in the future if we need it
 	version := RationalizeReleaseAndVersion(
 		orchType,
 		"",
-		orchVer)
+		orchVer,
+		false)
 
 	if version == "" {
 		sv, err := semver.NewVersion(orchVer)
@@ -91,17 +97,18 @@ func GetValidPatchVersion(orchType, orchVer string) string {
 		version = RationalizeReleaseAndVersion(
 			orchType,
 			sr,
-			"")
+			"",
+			false)
 	}
 	return version
 }
 
 // RationalizeReleaseAndVersion return a version when it can be rationalized from the input, otherwise ""
-func RationalizeReleaseAndVersion(orchType, orchRel, orchVer string) (version string) {
+func RationalizeReleaseAndVersion(orchType, orchRel, orchVer string, hasWindows bool) (version string) {
 	// ignore "v" prefix in orchestrator version and release: "v1.8.0" is equivalent to "1.8.0", "v1.9" is equivalent to "1.9"
 	orchVer = strings.TrimPrefix(orchVer, "v")
 	orchRel = strings.TrimPrefix(orchRel, "v")
-	supportedVersions, defaultVersion := GetSupportedVersions(orchType)
+	supportedVersions, defaultVersion := GetSupportedVersions(orchType, hasWindows)
 	if supportedVersions == nil {
 		return ""
 	}
@@ -112,21 +119,7 @@ func RationalizeReleaseAndVersion(orchType, orchRel, orchVer string) (version st
 
 	if orchVer == "" {
 		// Try to get latest version matching the release
-		version = ""
-		for _, ver := range supportedVersions {
-			sv, _ := semver.NewVersion(ver)
-			sr := fmt.Sprintf("%d.%d", sv.Major(), sv.Minor())
-			if sr == orchRel {
-				if version == "" {
-					version = ver
-				} else {
-					cons, _ := semver.NewConstraint(">" + version)
-					if cons.Check(sv) {
-						version = ver
-					}
-				}
-			}
-		}
+		version = GetLatestPatchVersion(orchRel, supportedVersions)
 		return version
 	} else if orchRel == "" {
 		// Try to get version the same with orchVer
@@ -157,4 +150,25 @@ func IsKubernetesVersionGe(actualVersion, version string) bool {
 	orchestratorVersion, _ := semver.NewVersion(strings.Split(actualVersion, "-")[0]) // to account for -alpha and -beta suffixes
 	constraint, _ := semver.NewConstraint(">=" + version)
 	return constraint.Check(orchestratorVersion)
+}
+
+// GetLatestPatchVersion gets the most recent patch version from a list of semver versions given a major.minor string
+func GetLatestPatchVersion(majorMinor string, versionsList []string) (version string) {
+	// Try to get latest version matching the release
+	version = ""
+	for _, ver := range versionsList {
+		sv, _ := semver.NewVersion(ver)
+		sr := fmt.Sprintf("%d.%d", sv.Major(), sv.Minor())
+		if sr == majorMinor {
+			if version == "" {
+				version = ver
+			} else {
+				cons, _ := semver.NewConstraint(">" + version)
+				if cons.Check(sv) {
+					version = ver
+				}
+			}
+		}
+	}
+	return version
 }

--- a/pkg/api/common/helper_test.go
+++ b/pkg/api/common/helper_test.go
@@ -35,52 +35,52 @@ func Test_GetValidPatchVersion(t *testing.T) {
 }
 
 func Test_RationalizeReleaseAndVersion(t *testing.T) {
-	version := RationalizeReleaseAndVersion(Kubernetes, "", "")
+	version := RationalizeReleaseAndVersion(Kubernetes, "", "", false)
 	if version != KubernetesDefaultVersion {
 		t.Errorf("It is not the default Kubernetes version")
 	}
 
-	version = RationalizeReleaseAndVersion(Kubernetes, "1.6", "")
+	version = RationalizeReleaseAndVersion(Kubernetes, "1.6", "", false)
 	if version != KubernetesVersion1Dot6Dot13 {
 		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot6Dot13)
 	}
 
-	version = RationalizeReleaseAndVersion(Kubernetes, "1.9", "")
+	version = RationalizeReleaseAndVersion(Kubernetes, "1.9", "", false)
 	if version != KubernetesVersion1Dot9Dot3 {
 		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot9Dot3)
 	}
 
-	version = RationalizeReleaseAndVersion(Kubernetes, "", "1.6.11")
+	version = RationalizeReleaseAndVersion(Kubernetes, "", "1.6.11", false)
 	if version != KubernetesVersion1Dot6Dot11 {
 		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot6Dot11)
 	}
 
-	version = RationalizeReleaseAndVersion(Kubernetes, "1.6", "1.6.11")
+	version = RationalizeReleaseAndVersion(Kubernetes, "1.6", "1.6.11", false)
 	if version != KubernetesVersion1Dot6Dot11 {
 		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot6Dot11)
 	}
 
-	version = RationalizeReleaseAndVersion(Kubernetes, "", "1.6.7")
+	version = RationalizeReleaseAndVersion(Kubernetes, "", "1.6.7", false)
 	if version != "" {
 		t.Errorf("It is not empty string")
 	}
 
-	version = RationalizeReleaseAndVersion(Kubernetes, "1.1", "")
+	version = RationalizeReleaseAndVersion(Kubernetes, "1.1", "", false)
 	if version != "" {
 		t.Errorf("It is not empty string")
 	}
 
-	version = RationalizeReleaseAndVersion(Kubernetes, "1.1", "1.6.6")
+	version = RationalizeReleaseAndVersion(Kubernetes, "1.1", "1.6.6", false)
 	if version != "" {
 		t.Errorf("It is not empty string")
 	}
 
-	version = RationalizeReleaseAndVersion(Kubernetes, "", "v1.8.8")
+	version = RationalizeReleaseAndVersion(Kubernetes, "", "v1.8.8", false)
 	if version != KubernetesVersion1Dot8Dot8 {
 		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot8Dot8)
 	}
 
-	version = RationalizeReleaseAndVersion(Kubernetes, "v1.9", "")
+	version = RationalizeReleaseAndVersion(Kubernetes, "v1.9", "", false)
 	if version != KubernetesVersion1Dot9Dot3 {
 		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot9Dot3)
 	}

--- a/pkg/api/common/helper_test.go
+++ b/pkg/api/common/helper_test.go
@@ -32,6 +32,44 @@ func Test_GetValidPatchVersion(t *testing.T) {
 	if version != KubernetesVersion1Dot9Dot2 {
 		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot9Dot2)
 	}
+
+	version = GetValidPatchVersion(Kubernetes, "1.10.0")
+	if version != KubernetesVersion1Dot10Dot0 {
+		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot10Dot0)
+	}
+}
+
+func TestGetLatestPatchVersion(t *testing.T) {
+	version := GetLatestPatchVersion("1.6", GetAllSupportedKubernetesVersions())
+	if version != KubernetesVersion1Dot6Dot13 {
+		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot9Dot3)
+	}
+
+	version = GetLatestPatchVersion("1.7", GetAllSupportedKubernetesVersions())
+	if version != KubernetesVersion1Dot7Dot13 {
+		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot9Dot3)
+	}
+
+	version = GetLatestPatchVersion("1.8", GetAllSupportedKubernetesVersions())
+	if version != KubernetesVersion1Dot8Dot8 {
+		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot9Dot3)
+	}
+
+	version = GetLatestPatchVersion("1.9", GetAllSupportedKubernetesVersions())
+	if version != KubernetesVersion1Dot9Dot3 {
+		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot9Dot3)
+	}
+
+	version = GetLatestPatchVersion("1.10", GetAllSupportedKubernetesVersions())
+	if version != KubernetesVersion1Dot10Dot0 {
+		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot10Dot0)
+	}
+
+	expected := "99.1.2"
+	version = GetLatestPatchVersion("99.1", []string{"99.1.1", "99.1.2-beta.5", expected})
+	if version != expected {
+		t.Errorf("GetLatestPatchVersion returned the wrong latest version, expected %s", expected)
+	}
 }
 
 func Test_RationalizeReleaseAndVersion(t *testing.T) {
@@ -83,5 +121,10 @@ func Test_RationalizeReleaseAndVersion(t *testing.T) {
 	version = RationalizeReleaseAndVersion(Kubernetes, "v1.9", "", false)
 	if version != KubernetesVersion1Dot9Dot3 {
 		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot9Dot3)
+	}
+
+	version = RationalizeReleaseAndVersion(Kubernetes, "1.10", "", false)
+	if version != KubernetesVersion1Dot10Dot0 {
+		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot10Dot0)
 	}
 }

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -569,7 +569,8 @@ func convertVLabsOrchestratorProfile(vp *vlabs.Properties, api *OrchestratorProf
 		api.OrchestratorVersion = common.RationalizeReleaseAndVersion(
 			vlabscs.OrchestratorType,
 			vlabscs.OrchestratorRelease,
-			vlabscs.OrchestratorVersion)
+			vlabscs.OrchestratorVersion,
+			vp.HasWindows())
 	case DCOS:
 		if vlabscs.DcosConfig != nil {
 			api.DcosConfig = &DcosConfig{}
@@ -578,7 +579,8 @@ func convertVLabsOrchestratorProfile(vp *vlabs.Properties, api *OrchestratorProf
 		api.OrchestratorVersion = common.RationalizeReleaseAndVersion(
 			vlabscs.OrchestratorType,
 			vlabscs.OrchestratorRelease,
-			vlabscs.OrchestratorVersion)
+			vlabscs.OrchestratorVersion,
+			false)
 	}
 }
 

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -65,7 +65,8 @@ func (o *OrchestratorProfile) Validate(isUpdate bool) error {
 			version := common.RationalizeReleaseAndVersion(
 				o.OrchestratorType,
 				o.OrchestratorRelease,
-				o.OrchestratorVersion)
+				o.OrchestratorVersion,
+				false)
 			if version == "" {
 				return fmt.Errorf("OrchestratorProfile is not able to be rationalized, check supported Release or Version")
 			}
@@ -75,7 +76,8 @@ func (o *OrchestratorProfile) Validate(isUpdate bool) error {
 			version := common.RationalizeReleaseAndVersion(
 				o.OrchestratorType,
 				o.OrchestratorRelease,
-				o.OrchestratorVersion)
+				o.OrchestratorVersion,
+				false)
 			if version == "" {
 				return fmt.Errorf("OrchestratorProfile is not able to be rationalized, check supported Release or Version")
 			}
@@ -142,7 +144,8 @@ func (o *OrchestratorProfile) Validate(isUpdate bool) error {
 			version := common.RationalizeReleaseAndVersion(
 				o.OrchestratorType,
 				o.OrchestratorRelease,
-				o.OrchestratorVersion)
+				o.OrchestratorVersion,
+				false)
 			if version == "" {
 				patchVersion := common.GetValidPatchVersion(o.OrchestratorType, o.OrchestratorVersion)
 				// if there isn't a supported patch version for this version fail
@@ -433,14 +436,24 @@ func (a *Properties) Validate(isUpdate bool) error {
 			case Swarm:
 			case SwarmMode:
 			case Kubernetes:
-				version := common.RationalizeReleaseAndVersion(
-					a.OrchestratorProfile.OrchestratorType,
-					a.OrchestratorProfile.OrchestratorRelease,
-					a.OrchestratorProfile.OrchestratorVersion)
+				var version string
+				if a.HasWindows() {
+					version = common.RationalizeReleaseAndVersion(
+						a.OrchestratorProfile.OrchestratorType,
+						a.OrchestratorProfile.OrchestratorRelease,
+						a.OrchestratorProfile.OrchestratorVersion,
+						true)
+				} else {
+					version = common.RationalizeReleaseAndVersion(
+						a.OrchestratorProfile.OrchestratorType,
+						a.OrchestratorProfile.OrchestratorRelease,
+						a.OrchestratorProfile.OrchestratorVersion,
+						false)
+				}
 				if version == "" {
 					return fmt.Errorf("OrchestratorProfile is not able to be rationalized, check supported Release or Version")
 				}
-				if _, ok := common.AllKubernetesWindowsSupportedVersions[version]; !ok {
+				if supported, ok := common.AllKubernetesWindowsSupportedVersions[version]; !ok || !supported {
 					return fmt.Errorf("Orchestrator %s version %s does not support Windows", a.OrchestratorProfile.OrchestratorType, version)
 				}
 			default:

--- a/test/e2e/dcos/dcos_test.go
+++ b/test/e2e/dcos/dcos_test.go
@@ -58,7 +58,8 @@ var _ = Describe("Azure Container Cluster using the DCOS Orchestrator", func() {
 			expectedVersion := common.RationalizeReleaseAndVersion(
 				eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorType,
 				eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorRelease,
-				eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorVersion)
+				eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorVersion,
+				false)
 			Expect(version).To(Equal(expectedVersion))
 		})
 

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -74,12 +74,14 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				expectedVersion = common.RationalizeReleaseAndVersion(
 					common.Kubernetes,
 					eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorRelease,
-					eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorVersion)
+					eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorVersion,
+					false)
 			} else {
 				expectedVersion = common.RationalizeReleaseAndVersion(
 					common.Kubernetes,
 					eng.Config.OrchestratorRelease,
-					eng.Config.OrchestratorVersion)
+					eng.Config.OrchestratorVersion,
+					false)
 			}
 			expectedVersionRationalized := strings.Split(expectedVersion, "-")[0] // to account for -alpha and -beta suffixes
 			Expect(version).To(Equal("v" + expectedVersionRationalized))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Allows us to support `orchestratorRelease` for Windows and Linux while delivering distinct "latest" versions (e.g., `v1.9.4` for Linux and `v1.9.3` for Windows)

The current use-case requirement we have is: `"orchestratorRelease": "1.9"` should yield a `v1.9.4` cluster for Linux and `v1.9.3` for Windows. This PR will allow us to fulfill that in PR #2405 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
