### PR TITLE
fix jumpbox custom vnet missing variables

### DIFF
--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -516,7 +516,7 @@
       "dependsOn": [
           "[concat('Microsoft.Network/publicIpAddresses/', variables('jumpboxPublicIpAddressName'))]",
           "[concat('Microsoft.Network/networkSecurityGroups/', variables('jumpboxNetworkSecurityGroupName'))]"
-          {{if .MasterProfile.IsCustomVNET}}
+          {{if not .MasterProfile.IsCustomVNET}}
             ,"[variables('vnetID')]"
           {{end}}
       ]

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -515,8 +515,10 @@
       },
       "dependsOn": [
           "[concat('Microsoft.Network/publicIpAddresses/', variables('jumpboxPublicIpAddressName'))]",
-          "[concat('Microsoft.Network/networkSecurityGroups/', variables('jumpboxNetworkSecurityGroupName'))]",
-          "[variables('vnetID')]"
+          "[concat('Microsoft.Network/networkSecurityGroups/', variables('jumpboxNetworkSecurityGroupName'))]"
+          {{if .MasterProfile.IsCustomVNET}}
+            ,"[variables('vnetID')]"
+          {{end}}
       ]
     },
   {{end}}

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -288,6 +288,9 @@
             {{if not JumpboxIsManagedDisks}}
             "jumpboxStorageAccountName": "[concat(variables('storageAccountBaseName'), 'jb')]",
             {{end}}
+            {{if not .HasStorageAccountDisks}}
+            {{GetSizeMap}},
+            {{end}}
         {{end}}
     {{else}}
         "masterPublicIPAddressName": "[concat(variables('orchestratorName'), '-master-ip-', variables('masterFqdnPrefix'), '-', variables('nameSuffix'))]",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: private cluster jumpbox is not compatible with custom vnets because the vm depends on the vnetID. Remove this dependency for clusters w/ custom vnets. The vmSizesMap is missing when the cluster does not have storage accounts so add it for deployments with a jumpbox. Thanks @stefanstranger for reporting the issue!

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2474 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
