### PR TITLE
Remove unnecessary etcd systemd Alias directive

### DIFF
--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -301,7 +301,6 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
     Restart=always
     [Install]
     WantedBy=multi-user.target
-    Alias=etcd.service
 
 - path: "/opt/azure/containers/setup-etcd.sh"
   permissions: "0744"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the `Alias` directive from the systemd unit file for etcd. Since the specified alias is the same as the name of the unit itself, `systemd enable etcd` fails.

**Which issue this PR fixes** 
fixes #2282 (although it is already marked as fixed...)

**Special notes for your reviewer**:
No

**Release note**:
```release-note
Fix etcd systemd unit
```
