### PR TITLE
Add possibility to fine tune masters managament endpoints NSG rules

### DIFF
--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -90,7 +90,7 @@
               "direction": "Inbound", 
               "priority": 102, 
               "protocol": "Tcp", 
-              "sourceAddressPrefix": "*", 
+              "sourceAddressPrefix": "[parameters('managementIPWhitelist')]",
               "sourcePortRange": "*"
             }
           },
@@ -105,7 +105,7 @@
               "direction": "Inbound",
               "priority": 101,
               "protocol": "Tcp",
-              "sourceAddressPrefix": "*",
+              "sourceAddressPrefix": "[parameters('managementIPWhitelist')]",
               "sourcePortRange": "*"
             }
           },
@@ -119,7 +119,7 @@
               "direction": "Inbound",
               "priority": 100,
               "protocol": "Tcp",
-              "sourceAddressPrefix": "*",
+              "sourceAddressPrefix": "[parameters('managementIPWhitelist')]",
               "sourcePortRange": "*"
             }
           }

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -733,3 +733,10 @@
       "type": "string"
     }
 {{end}}
+    ,"managementIPWhitelist": {
+      "defaultValue": "*",
+      "metadata": {
+        "description": "List of CIDR allowed to SSH and HTTPS to the masters"
+      },
+      "type": "string"
+    }

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -472,6 +472,7 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 		}
 		addValue(parametersMap, "firstConsecutiveStaticIP", properties.MasterProfile.FirstConsecutiveStaticIP)
 		addValue(parametersMap, "masterVMSize", properties.MasterProfile.VMSize)
+		addValue(parametersMap, "managementIPWhitelist", properties.MasterProfile.ManagementIPWhitelist)
 		if isClassicMode {
 			addValue(parametersMap, "masterCount", properties.MasterProfile.Count)
 		}

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -813,6 +813,7 @@ func convertMasterProfileToVLabs(api *MasterProfile, vlabsProfile *vlabs.MasterP
 	vlabsProfile.SetSubnet(api.Subnet)
 	vlabsProfile.FQDN = api.FQDN
 	vlabsProfile.StorageProfile = api.StorageProfile
+	vlabsProfile.ManagementIPWhitelist = api.ManagementIPWhitelist
 	if api.PreprovisionExtension != nil {
 		vlabsExtension := &vlabs.Extension{}
 		convertExtensionToVLabs(api.PreprovisionExtension, vlabsExtension)

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -787,6 +787,7 @@ func convertVLabsMasterProfile(vlabs *vlabs.MasterProfile, api *MasterProfile) {
 	api.StorageProfile = vlabs.StorageProfile
 	api.HTTPSourceAddressPrefix = vlabs.HTTPSourceAddressPrefix
 	api.OAuthEnabled = vlabs.OAuthEnabled
+	api.ManagementIPWhitelist = vlabs.ManagementIPWhitelist
 	// by default vlabs will use managed disks as it has encryption at rest
 	if len(api.StorageProfile) == 0 {
 		api.StorageProfile = ManagedDisks

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -319,6 +319,7 @@ type MasterProfile struct {
 	Extensions               []Extension       `json:"extensions"`
 	Distro                   Distro            `json:"distro,omitempty"`
 	KubernetesConfig         *KubernetesConfig `json:"kubernetesConfig,omitempty"`
+	ManagementIPWhitelist    string            `json:"managementIPWhitelist,omitempty"`
 
 	// Master LB public endpoint/FQDN with port
 	// The format will be FQDN:2376

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -310,6 +310,7 @@ type MasterProfile struct {
 	Extensions               []Extension       `json:"extensions"`
 	Distro                   Distro            `json:"distro,omitempty"`
 	KubernetesConfig         *KubernetesConfig `json:"kubernetesConfig,omitempty"`
+	ManagementIPWhitelist    string            `json:"managementIPWhitelist,omitempty"`
 
 	// subnet is internal
 	subnet string


### PR DESCRIPTION
Not a fan of allowing Internet to accesss the SSH and kube TLS ports of the masters.