### PR TITLE
WIP: Renaming resources to something more meaningful 

### DIFF
--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -12,7 +12,7 @@
 {{end}}
       ],
       "location": "[variables('location')]",
-      "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-nic1')]",
+      "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-nic0')]",
       "properties": {
 {{if .IsCustomVNET}}
         "networkSecurityGroup": {
@@ -126,7 +126,7 @@
         "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
   {{end}}
 {{end}}
-        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-nic1')]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-nic0')]",
         "[concat('Microsoft.Compute/availabilitySets/', variables('{{.Name}}AvailabilitySet'))]"
       ],
       "tags":
@@ -153,7 +153,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-nic1'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-nic0'))]"
             }
           ]
         },

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -132,7 +132,7 @@
       "tags":
       {
         "creationSource" : "[concat(variables('generatorCode'), '-', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
-        "resourceNameSuffix" : "[variables('nameSuffix')]",
+        "clusterName" : "[variables('clusterName')]",
         "orchestrator" : "[variables('orchestratorNameVersionTag')]",
         "poolName" : "{{.Name}}"
       },

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -12,7 +12,7 @@
 {{end}}
       ],
       "location": "[variables('location')]",
-      "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
+      "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-nic1')]",
       "properties": {
 {{if .IsCustomVNET}}
         "networkSecurityGroup": {
@@ -126,7 +126,7 @@
         "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
   {{end}}
 {{end}}
-        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-nic1')]",
         "[concat('Microsoft.Compute/availabilitySets/', variables('{{.Name}}AvailabilitySet'))]"
       ],
       "tags":
@@ -153,7 +153,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset'))))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-nic1'))]"
             }
           ]
         },

--- a/parts/k8s/kubernetesagentvars.t
+++ b/parts/k8s/kubernetesagentvars.t
@@ -4,12 +4,12 @@
 {{end}}
     "{{.Name}}Count": "[parameters('{{.Name}}Count')]",
     "{{.Name}}Offset": "[parameters('{{.Name}}Offset')]",
-    "{{.Name}}AvailabilitySet": "[concat('{{.Name}}-availabilitySet-', variables('nameSuffix'))]",
+    "{{.Name}}AvailabilitySet": "[concat(parameters('clusterName'), '-{{.Name}}-availabilitySet')]",
 {{if .IsWindows}}
     "winResourceNamePrefix" : "[substring(variables('nameSuffix'), 0, 5)]",
-    "{{.Name}}VMNamePrefix": "[concat(variables('winResourceNamePrefix'), variables('orchestratorName'), add(900,variables('{{.Name}}Index')))]",
+    "{{.Name}}VMNamePrefix": "[concat(variables('winResourceNamePrefix'), parameters('clusterName'), add(900,variables('{{.Name}}Index')))]",
 {{else}}
-    "{{.Name}}VMNamePrefix": "[concat(variables('orchestratorName'), '-{{.Name}}-', variables('nameSuffix'), '-')]",
+    "{{.Name}}VMNamePrefix": "[concat(parameters('clusterName'), '-{{.Name}}-')]",
 {{end}}
     "{{.Name}}VMSize": "[parameters('{{.Name}}VMSize')]",
 {{if .IsCustomVNET}}

--- a/parts/k8s/kubernetesagentvars.t
+++ b/parts/k8s/kubernetesagentvars.t
@@ -4,12 +4,12 @@
 {{end}}
     "{{.Name}}Count": "[parameters('{{.Name}}Count')]",
     "{{.Name}}Offset": "[parameters('{{.Name}}Offset')]",
-    "{{.Name}}AvailabilitySet": "[concat(parameters('clusterName'), '-{{.Name}}-availabilityset')]",
+    "{{.Name}}AvailabilitySet": "[concat(variables('clusterName'), '-{{.Name}}-availabilityset')]",
 {{if .IsWindows}}
     "winResourceNamePrefix" : "[substring(variables('nameSuffix'), 0, 5)]",
-    "{{.Name}}VMNamePrefix": "[concat(variables('winResourceNamePrefix'), parameters('clusterName'), add(900,variables('{{.Name}}Index')))]",
+    "{{.Name}}VMNamePrefix": "[concat(variables('winResourceNamePrefix'), variables('clusterName'), add(900,variables('{{.Name}}Index')))]",
 {{else}}
-    "{{.Name}}VMNamePrefix": "[concat(parameters('clusterName'), '-{{.Name}}-')]",
+    "{{.Name}}VMNamePrefix": "[concat(variables('clusterName'), '-{{.Name}}-')]",
 {{end}}
     "{{.Name}}VMSize": "[parameters('{{.Name}}VMSize')]",
 {{if .IsCustomVNET}}

--- a/parts/k8s/kubernetesagentvars.t
+++ b/parts/k8s/kubernetesagentvars.t
@@ -4,7 +4,7 @@
 {{end}}
     "{{.Name}}Count": "[parameters('{{.Name}}Count')]",
     "{{.Name}}Offset": "[parameters('{{.Name}}Offset')]",
-    "{{.Name}}AvailabilitySet": "[concat(parameters('clusterName'), '-{{.Name}}-availabilitySet')]",
+    "{{.Name}}AvailabilitySet": "[concat(parameters('clusterName'), '-{{.Name}}-availabilityset')]",
 {{if .IsWindows}}
     "winResourceNamePrefix" : "[substring(variables('nameSuffix'), 0, 5)]",
     "{{.Name}}VMNamePrefix": "[concat(variables('winResourceNamePrefix'), parameters('clusterName'), add(900,variables('{{.Name}}Index')))]",

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -247,7 +247,7 @@
 {{end}}
       ],
       "location": "[variables('location')]",
-      "name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic1')]",
+      "name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic0')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -323,7 +323,7 @@
   {{end}}
         ],
         "location": "[variables('location')]",
-        "name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic1')]",
+        "name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic0')]",
         "properties": {
           "ipConfigurations": [
             {
@@ -597,7 +597,7 @@
         "name": "vmLoopNode"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic1')]"
+        "[concat('Microsoft.Network/networkInterfaces/', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic0')]"
         ,"[concat('Microsoft.Compute/availabilitySets/',variables('masterAvailabilitySet'))]"
 {{if .MasterProfile.IsStorageAccount}}
         ,"[variables('masterStorageAccountName')]"
@@ -627,7 +627,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic1'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic0'))]"
             }
           ]
         },

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -247,7 +247,7 @@
 {{end}}
       ],
       "location": "[variables('location')]",
-      "name": "[concat(variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]",
+      "name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic1')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -323,7 +323,7 @@
   {{end}}
         ],
         "location": "[variables('location')]",
-        "name": "[concat(variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]",
+        "name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic1')]",
         "properties": {
           "ipConfigurations": [
             {
@@ -597,7 +597,7 @@
         "name": "vmLoopNode"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]"
+        "[concat('Microsoft.Network/networkInterfaces/', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic1')]"
         ,"[concat('Microsoft.Compute/availabilitySets/',variables('masterAvailabilitySet'))]"
 {{if .MasterProfile.IsStorageAccount}}
         ,"[variables('masterStorageAccountName')]"
@@ -627,7 +627,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('masterVMNamePrefix'),'nic-', copyIndex(variables('masterOffset'))))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '-nic1'))]"
             }
           ]
         },

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -606,7 +606,7 @@
       "tags":
       {
         "creationSource" : "[concat(variables('generatorCode'), '-', variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')))]",
-        "resourceNameSuffix" : "[variables('nameSuffix')]",
+        "clusterName" : "[variables('clusterName')]",
         "orchestrator" : "[variables('orchestratorNameVersionTag')]",
         "poolName" : "master"
       },

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -657,7 +657,7 @@
               "createOption": "Empty"
               ,"diskSizeGB": "[variables('etcdDiskSizeGB')]"
               ,"lun": 0
-              ,"name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-etcddisk')]"
+              ,"name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'_EtcdDisk')]"
               {{if .MasterProfile.IsStorageAccount}}
               ,"vhd": {
                 "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/', variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')),'-etcddisk.vhd')]"

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -166,9 +166,10 @@
          "[parameters('location')]"
     ],
     "location": "[variables('locations')[mod(add(2,length(parameters('location'))),add(1,length(parameters('location'))))]]",
-    "masterAvailabilitySet": "[concat(parameters('clusterName'), '-master-availabilityset')]",
+    "masterAvailabilitySet": "[concat(variables('clusterName'), '-master-availabilityset')]",
     "nameSuffix": "[parameters('nameSuffix')]",
     "orchestratorName": "[parameters('orchestratorName')]",
+    "clusterName": "[if(not(equals(parameters('clusterName'), '')), parameters('clusterName'), concat(variables('orchestratorName'), '-', variables('nameSuffix')))]",
     "generatorCode": "[parameters('generatorCode')]",
     "fqdnEndpointSuffix":"[parameters('fqdnEndpointSuffix')]",
     "osImageOffer": "[parameters('osImageOffer')]",
@@ -236,19 +237,19 @@
     "virtualNetworkResourceGroupName": "[split(parameters('masterVnetSubnetID'), '/')[variables('vnetResourceGroupNameResourceSegmentIndex')]]",
   {{else}}
     "subnet": "[parameters('masterSubnet')]",
-    "subnetName": "[concat(parameters('clusterName'), '-subnet')]",
+    "subnetName": "[concat(variables('clusterName'), '-subnet')]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "vnetSubnetID": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "[concat(parameters('clusterName'), '-vnet')]",
+    "virtualNetworkName": "[concat(variables('clusterName'), '-vnet')]",
     "virtualNetworkResourceGroupName": "''",
   {{end}}
 {{else}}
     "subnet": "[parameters('masterSubnet')]",
-    "subnetName": "[concat(parameters('clusterName'), '-subnet')]",
-    "virtualNetworkName": "[concat(parameters('clusterName'), '-vnet')]",
+    "subnetName": "[concat(variables('clusterName'), '-subnet')]",
+    "virtualNetworkName": "[concat(variables('clusterName'), '-vnet')]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "vnetSubnetID": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "[concat(parameters('clusterName'), '-vnet')]",
+    "virtualNetworkName": "[concat(variables('clusterName'), '-vnet')]",
     "virtualNetworkResourceGroupName": "''",
 {{end}}
     "vnetCidr": "[parameters('vnetCidr')]",
@@ -295,29 +296,29 @@
             {{end}}
         {{end}}
     {{else}}
-        "masterPublicIPAddressName": "[concat(parameters('clusterName'), '-master-ip-', variables('masterFqdnPrefix'))]",
+        "masterPublicIPAddressName": "[concat(variables('clusterName'), '-master-ip-', variables('masterFqdnPrefix'))]",
         "masterLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('masterLbName'))]",
         "masterLbIPConfigID": "[concat(variables('masterLbID'),'/frontendIPConfigurations/', variables('masterLbIPConfigName'))]",
-        "masterLbIPConfigName": "[concat(parameters('clusterName'), '-master-lbFrontEnd')]",
-        "masterLbName": "[concat(parameters('clusterName'), '-master-lb')]",
+        "masterLbIPConfigName": "[concat(variables('clusterName'), '-master-lbFrontEnd')]",
+        "masterLbName": "[concat(variables('clusterName'), '-master-lb')]",
         "kubeconfigServer": "[concat('https://', variables('masterFqdnPrefix'), '.', variables('location'), '.', variables('fqdnEndpointSuffix'))]",
     {{end}}
 {{if gt .MasterProfile.Count 1}}
-    "masterInternalLbName": "[concat(parameters('clusterName'), '-master-internal-lb')]",
+    "masterInternalLbName": "[concat(variables('clusterName'), '-master-internal-lb')]",
     "masterInternalLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('masterInternalLbName'))]",
-    "masterInternalLbIPConfigName": "[concat(parameters('clusterName'), '-master-internal-lbFrontEnd')]",
+    "masterInternalLbIPConfigName": "[concat(variables('clusterName'), '-master-internal-lbFrontEnd')]",
     "masterInternalLbIPConfigID": "[concat(variables('masterInternalLbID'),'/frontendIPConfigurations/', variables('masterInternalLbIPConfigName'))]",
     "masterInternalLbIPOffset": {{GetDefaultInternalLbStaticIPOffset}},
     "kubernetesAPIServerIP": "[concat(variables('masterFirstAddrPrefix'), add(variables('masterInternalLbIPOffset'), int(variables('masterFirstAddrOctet4'))))]",
 {{else}}
     "kubernetesAPIServerIP": "[parameters('firstConsecutiveStaticIP')]",
 {{end}}
-    "masterLbBackendPoolName": "[concat(parameters('clusterName'), '-master-pool')]",
+    "masterLbBackendPoolName": "[concat(variables('clusterName'), '-master-pool')]",
     "masterFirstAddrComment": "these MasterFirstAddrComment are used to place multiple masters consecutively in the address space",
     "masterFirstAddrOctets": "[split(parameters('firstConsecutiveStaticIP'),'.')]",
     "masterFirstAddrOctet4": "[variables('masterFirstAddrOctets')[3]]",
     "masterFirstAddrPrefix": "[concat(variables('masterFirstAddrOctets')[0],'.',variables('masterFirstAddrOctets')[1],'.',variables('masterFirstAddrOctets')[2],'.')]",
-    "masterVMNamePrefix": "[concat(parameters('clusterName'), '-master-')]",
+    "masterVMNamePrefix": "[concat(variables('clusterName'), '-master-')]",
     "masterVMNames": [
       "[concat(variables('masterVMNamePrefix'), '0')]",
       "[concat(variables('masterVMNamePrefix'), '1')]",
@@ -355,7 +356,7 @@
     ],
 {{else}}
     "kubernetesAPIServerIP": "[parameters('kubernetesEndpoint')]",
-    "agentNamePrefix": "[concat(parameters('clusterName'), '-agentpool-')]",
+    "agentNamePrefix": "[concat(variables('clusterName'), '-agentpool-')]",
 {{end}}
     "subscriptionId": "[subscription().subscriptionId]",
     "contributorRoleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -272,7 +272,7 @@
     "nsgName": "[concat(variables('agentNamePrefix'), 'nsg')]",
 {{end}}
     "nsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName'))]",
-    "primaryAvailabilitySetName": "[concat('{{ (index .AgentPoolProfiles 0).Name }}-availabilityset-',variables('nameSuffix'))]",
+    "primaryAvailabilitySetName": "[concat(variables('clusterName'), '-', '{{ (index .AgentPoolProfiles 0).Name }}-availabilityset)]",
 {{if not IsHostedMaster }}
     {{if IsPrivateCluster}}
         "kubeconfigServer": "[concat('https://', variables('kubernetesAPIServerIP'), ':443')]",

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -271,7 +271,7 @@
     "nsgName": "[concat(variables('agentNamePrefix'), 'nsg')]",
 {{end}}
     "nsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName'))]",
-    "primaryAvailabilitySetName": "[concat('{{ (index .AgentPoolProfiles 0).Name }}-availabilitySet-',variables('nameSuffix'))]",
+    "primaryAvailabilitySetName": "[concat('{{ (index .AgentPoolProfiles 0).Name }}-availabilityset-',variables('nameSuffix'))]",
 {{if not IsHostedMaster }}
     {{if IsPrivateCluster}}
         "kubeconfigServer": "[concat('https://', variables('kubernetesAPIServerIP'), ':443')]",

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -166,7 +166,7 @@
          "[parameters('location')]"
     ],
     "location": "[variables('locations')[mod(add(2,length(parameters('location'))),add(1,length(parameters('location'))))]]",
-    "masterAvailabilitySet": "[concat('master-availabilityset-', variables('nameSuffix'))]",
+    "masterAvailabilitySet": "[concat(parameters('clusterName'), '-master-availabilityset')]",
     "nameSuffix": "[parameters('nameSuffix')]",
     "orchestratorName": "[parameters('orchestratorName')]",
     "generatorCode": "[parameters('generatorCode')]",
@@ -236,19 +236,19 @@
     "virtualNetworkResourceGroupName": "[split(parameters('masterVnetSubnetID'), '/')[variables('vnetResourceGroupNameResourceSegmentIndex')]]",
   {{else}}
     "subnet": "[parameters('masterSubnet')]",
-    "subnetName": "[concat(variables('orchestratorName'), '-subnet')]",
+    "subnetName": "[concat(parameters('clusterName'), '-subnet')]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "vnetSubnetID": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "[concat(variables('orchestratorName'), '-vnet-', variables('nameSuffix'))]",
+    "virtualNetworkName": "[concat(parameters('clusterName'), '-vnet')]",
     "virtualNetworkResourceGroupName": "''",
   {{end}}
 {{else}}
     "subnet": "[parameters('masterSubnet')]",
-    "subnetName": "[concat(variables('orchestratorName'), '-subnet')]",
-    "virtualNetworkName": "[concat(variables('orchestratorName'), '-vnet-', variables('nameSuffix'))]",
+    "subnetName": "[concat(parameters('clusterName'), '-subnet')]",
+    "virtualNetworkName": "[concat(parameters('clusterName'), '-vnet')]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "vnetSubnetID": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "[concat(variables('orchestratorName'), '-vnet-', variables('nameSuffix'))]",
+    "virtualNetworkName": "[concat(parameters('clusterName'), '-vnet')]",
     "virtualNetworkResourceGroupName": "''",
 {{end}}
     "vnetCidr": "[parameters('vnetCidr')]",
@@ -295,29 +295,29 @@
             {{end}}
         {{end}}
     {{else}}
-        "masterPublicIPAddressName": "[concat(variables('orchestratorName'), '-master-ip-', variables('masterFqdnPrefix'), '-', variables('nameSuffix'))]",
+        "masterPublicIPAddressName": "[concat(parameters('clusterName'), '-master-ip-', variables('masterFqdnPrefix'))]",
         "masterLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('masterLbName'))]",
         "masterLbIPConfigID": "[concat(variables('masterLbID'),'/frontendIPConfigurations/', variables('masterLbIPConfigName'))]",
-        "masterLbIPConfigName": "[concat(variables('orchestratorName'), '-master-lbFrontEnd-', variables('nameSuffix'))]",
-        "masterLbName": "[concat(variables('orchestratorName'), '-master-lb-', variables('nameSuffix'))]",
+        "masterLbIPConfigName": "[concat(parameters('clusterName'), '-master-lbFrontEnd')]",
+        "masterLbName": "[concat(parameters('clusterName'), '-master-lb')]",
         "kubeconfigServer": "[concat('https://', variables('masterFqdnPrefix'), '.', variables('location'), '.', variables('fqdnEndpointSuffix'))]",
     {{end}}
 {{if gt .MasterProfile.Count 1}}
-    "masterInternalLbName": "[concat(variables('orchestratorName'), '-master-internal-lb-', variables('nameSuffix'))]",
+    "masterInternalLbName": "[concat(parameters('clusterName'), '-master-internal-lb')]",
     "masterInternalLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('masterInternalLbName'))]",
-    "masterInternalLbIPConfigName": "[concat(variables('orchestratorName'), '-master-internal-lbFrontEnd-', variables('nameSuffix'))]",
+    "masterInternalLbIPConfigName": "[concat(parameters('clusterName'), '-master-internal-lbFrontEnd')]",
     "masterInternalLbIPConfigID": "[concat(variables('masterInternalLbID'),'/frontendIPConfigurations/', variables('masterInternalLbIPConfigName'))]",
     "masterInternalLbIPOffset": {{GetDefaultInternalLbStaticIPOffset}},
     "kubernetesAPIServerIP": "[concat(variables('masterFirstAddrPrefix'), add(variables('masterInternalLbIPOffset'), int(variables('masterFirstAddrOctet4'))))]",
 {{else}}
     "kubernetesAPIServerIP": "[parameters('firstConsecutiveStaticIP')]",
 {{end}}
-    "masterLbBackendPoolName": "[concat(variables('orchestratorName'), '-master-pool-', variables('nameSuffix'))]",
+    "masterLbBackendPoolName": "[concat(parameters('clusterName'), '-master-pool')]",
     "masterFirstAddrComment": "these MasterFirstAddrComment are used to place multiple masters consecutively in the address space",
     "masterFirstAddrOctets": "[split(parameters('firstConsecutiveStaticIP'),'.')]",
     "masterFirstAddrOctet4": "[variables('masterFirstAddrOctets')[3]]",
     "masterFirstAddrPrefix": "[concat(variables('masterFirstAddrOctets')[0],'.',variables('masterFirstAddrOctets')[1],'.',variables('masterFirstAddrOctets')[2],'.')]",
-    "masterVMNamePrefix": "[concat(variables('orchestratorName'), '-master-', variables('nameSuffix'), '-')]",
+    "masterVMNamePrefix": "[concat(parameters('clusterName'), '-master-')]",
     "masterVMNames": [
       "[concat(variables('masterVMNamePrefix'), '0')]",
       "[concat(variables('masterVMNamePrefix'), '1')]",
@@ -355,7 +355,7 @@
     ],
 {{else}}
     "kubernetesAPIServerIP": "[parameters('kubernetesEndpoint')]",
-    "agentNamePrefix": "[concat(variables('orchestratorName'), '-agentpool-', variables('nameSuffix'), '-')]",
+    "agentNamePrefix": "[concat(parameters('clusterName'), '-agentpool-')]",
 {{end}}
     "subscriptionId": "[subscription().subscriptionId]",
     "contributorRoleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",

--- a/parts/masterparams.t
+++ b/parts/masterparams.t
@@ -1,3 +1,10 @@
+    "clusterName": {
+      "defaultValue": "",
+      "metadata": {
+        "description": "The name of the cluster which will prefix all resources name."
+      },
+      "type": "string"
+    },
     "linuxAdminUsername": {
       "metadata": {
         "description": "User name for the Linux Virtual Machines (SSH or Password)."

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -442,6 +442,7 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 	cloudSpecConfig := GetCloudSpecConfig(location)
 
 	// Master Parameters
+	addValue(parametersMap, "clusterName", cs.Properties.Name)
 	addValue(parametersMap, "location", location)
 
 	// Identify Master distro

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -431,6 +431,7 @@ func convertPropertiesToV20170701(api *Properties, p *v20170701.Properties) {
 }
 
 func convertPropertiesToVLabs(api *Properties, vlabsProps *vlabs.Properties) {
+	vlabsProps.Name = api.Name
 	vlabsProps.ProvisioningState = vlabs.ProvisioningState(api.ProvisioningState)
 	if api.OrchestratorProfile != nil {
 		vlabsProps.OrchestratorProfile = &vlabs.OrchestratorProfile{}

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -352,6 +352,7 @@ func convertV20170701Properties(v20170701 *v20170701.Properties, api *Properties
 }
 
 func convertVLabsProperties(vlabs *vlabs.Properties, api *Properties) {
+	api.Name = vlabs.Name
 	api.ProvisioningState = ProvisioningState(vlabs.ProvisioningState)
 	if vlabs.OrchestratorProfile != nil {
 		api.OrchestratorProfile = &OrchestratorProfile{}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -44,6 +44,7 @@ type ContainerService struct {
 
 // Properties represents the ACS cluster definition
 type Properties struct {
+	Name                    string                   `json:"clusterName,omitempty"`
 	ProvisioningState       ProvisioningState        `json:"provisioningState,omitempty"`
 	OrchestratorProfile     *OrchestratorProfile     `json:"orchestratorProfile,omitempty"`
 	MasterProfile           *MasterProfile           `json:"masterProfile,omitempty"`

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -30,6 +30,7 @@ type ContainerService struct {
 
 // Properties represents the ACS cluster definition
 type Properties struct {
+	Name                    string                   `json:"clusterName,omitempty"`
 	ProvisioningState       ProvisioningState        `json:"provisioningState,omitempty"`
 	OrchestratorProfile     *OrchestratorProfile     `json:"orchestratorProfile,omitempty" validate:"required"`
 	MasterProfile           *MasterProfile           `json:"masterProfile,omitempty" validate:"required"`


### PR DESCRIPTION
**What this PR does / why we need it**: 

Rename resources
from: `<orchestrator>-<resource_type>-<########>[-<index>]`
to: `<cluster_name>-<resource_type>[-<index>]`

Why? Because current naming convention makes managing **several** acs-engine generated clusters a nightmare due to the lack of hints in the resources name about which cluster the resource belong to.

**Which issue this PR fixes** : fixes #2367 
