### PR TITLE
Kubernetes v1.9.5 support

### DIFF
--- a/pkg/acsengine/k8s_versions.go
+++ b/pkg/acsengine/k8s_versions.go
@@ -144,6 +144,7 @@ var k8sComponentVersions = map[string]map[string]string{
 var KubeConfigs = map[string]map[string]string{
 	common.KubernetesVersion1Dot10Dot0Beta4: getK8sVersionComponents("1.10.0-beta.4", nil),
 	common.KubernetesVersion1Dot10Dot0Beta2: getK8sVersionComponents("1.10.0-beta.2", nil),
+	common.KubernetesVersion1Dot9Dot5:       getK8sVersionComponents("1.9.5", nil),
 	common.KubernetesVersion1Dot9Dot4:       getK8sVersionComponents("1.9.4", nil),
 	common.KubernetesVersion1Dot9Dot3:       getK8sVersionComponents("1.9.3", nil),
 	common.KubernetesVersion1Dot9Dot2:       getK8sVersionComponents("1.9.2", nil),

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -198,6 +198,7 @@ var AllKubernetesWindowsSupportedVersions = map[string]bool{
 	KubernetesVersion1Dot9Dot2:       true,
 	KubernetesVersion1Dot9Dot3:       true,
 	KubernetesVersion1Dot9Dot4:       true,
+	KubernetesVersion1Dot9Dot5:       true,
 	KubernetesVersion1Dot10Dot0Beta2: false,
 	KubernetesVersion1Dot10Dot0Beta4: false,
 }

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -67,6 +67,8 @@ const (
 	KubernetesVersion1Dot9Dot3 string = "1.9.3"
 	// KubernetesVersion1Dot9Dot4 is the major.minor.patch string for the 1.9.4 version of kubernetes
 	KubernetesVersion1Dot9Dot4 string = "1.9.4"
+	// KubernetesVersion1Dot9Dot5 is the major.minor.patch string for the 1.9.5 version of kubernetes
+	KubernetesVersion1Dot9Dot5 string = "1.9.5"
 	// KubernetesVersion1Dot8Dot0 is the major.minor.patch string for the 1.8.0 version of kubernetes
 	KubernetesVersion1Dot8Dot0 string = "1.8.0"
 	// KubernetesVersion1Dot8Dot1 is the major.minor.patch string for the 1.8.1 version of kubernetes
@@ -150,6 +152,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	KubernetesVersion1Dot9Dot2:       true,
 	KubernetesVersion1Dot9Dot3:       true,
 	KubernetesVersion1Dot9Dot4:       true,
+	KubernetesVersion1Dot9Dot5:       true,
 	KubernetesVersion1Dot10Dot0Beta2: true,
 	KubernetesVersion1Dot10Dot0Beta4: true,
 }

--- a/pkg/api/common/helper_test.go
+++ b/pkg/api/common/helper_test.go
@@ -56,8 +56,8 @@ func TestGetLatestPatchVersion(t *testing.T) {
 	}
 
 	version = GetLatestPatchVersion("1.9", GetAllSupportedKubernetesVersions())
-	if version != KubernetesVersion1Dot9Dot4 {
-		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot9Dot4)
+	if version != KubernetesVersion1Dot9Dot5 {
+		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot9Dot5)
 	}
 
 	version = GetLatestPatchVersion("1.10", GetAllSupportedKubernetesVersions())
@@ -129,8 +129,8 @@ func Test_RationalizeReleaseAndVersion(t *testing.T) {
 	}
 
 	version = RationalizeReleaseAndVersion(Kubernetes, "v1.9", "", false)
-	if version != KubernetesVersion1Dot9Dot4 {
-		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot9Dot4)
+	if version != KubernetesVersion1Dot9Dot5 {
+		t.Errorf("It is not Kubernetes version %s", KubernetesVersion1Dot9Dot5)
 	}
 
 	version = RationalizeReleaseAndVersion(Kubernetes, "1.10", "", false)

--- a/pkg/api/orchestrators_test.go
+++ b/pkg/api/orchestrators_test.go
@@ -87,13 +87,13 @@ func TestOrchestratorUpgradeInfo(t *testing.T) {
 	}
 	orch, e = GetOrchestratorVersionProfile(csOrch)
 	Expect(e).To(BeNil())
-	// 1.8.6, 1.8.7, 1.8.8, 1.8.9, 1.9.0, 1.9.1, 1.9.2, 1.9.3, 1.9.4
-	Expect(len(orch.Upgrades)).To(Equal(9))
+	// 1.8.6, 1.8.7, 1.8.8, 1.8.9, 1.9.0, 1.9.1, 1.9.2, 1.9.3, 1.9.4, 1.9.5
+	Expect(len(orch.Upgrades)).To(Equal(10))
 
-	// 1.9.4 is upgradable to 1.10.x
+	// 1.9.5 is upgradable to 1.10.x
 	csOrch = &OrchestratorProfile{
 		OrchestratorType:    Kubernetes,
-		OrchestratorVersion: "1.9.4",
+		OrchestratorVersion: "1.9.5",
 	}
 	orch, e = GetOrchestratorVersionProfile(csOrch)
 	Expect(e).To(BeNil())
@@ -121,12 +121,12 @@ func TestOrchestratorUpgradeInfo(t *testing.T) {
 	// v20170930 - all orchestrators
 	list, e := GetOrchestratorVersionProfileListV20170930("", "")
 	Expect(e).To(BeNil())
-	Expect(len(list.Properties.Orchestrators)).To(Equal(36))
+	Expect(len(list.Properties.Orchestrators)).To(Equal(37))
 
 	// v20170930 - kubernetes only
 	list, e = GetOrchestratorVersionProfileListV20170930(common.Kubernetes, "")
 	Expect(e).To(BeNil())
-	Expect(len(list.Properties.Orchestrators)).To(Equal(31))
+	Expect(len(list.Properties.Orchestrators)).To(Equal(32))
 }
 
 func TestKubernetesInfo(t *testing.T) {

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -514,6 +514,7 @@ func (a *KubernetesConfig) Validate(k8sVersion string) error {
 		common.KubernetesVersion1Dot9Dot2:       true,
 		common.KubernetesVersion1Dot9Dot3:       true,
 		common.KubernetesVersion1Dot9Dot4:       true,
+		common.KubernetesVersion1Dot9Dot5:       true,
 		common.KubernetesVersion1Dot8Dot0:       true,
 		common.KubernetesVersion1Dot8Dot1:       true,
 		common.KubernetesVersion1Dot8Dot2:       true,
@@ -685,6 +686,7 @@ func (a *KubernetesConfig) Validate(k8sVersion string) error {
 		common.KubernetesVersion1Dot9Dot2:       true,
 		common.KubernetesVersion1Dot9Dot3:       true,
 		common.KubernetesVersion1Dot9Dot4:       true,
+		common.KubernetesVersion1Dot9Dot5:       true,
 		common.KubernetesVersion1Dot10Dot0Beta2: true,
 		common.KubernetesVersion1Dot10Dot0Beta4: true,
 	}

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -628,7 +628,7 @@ func TestWindowsVersions(t *testing.T) {
 	}
 
 	p = getK8sDefaultProperties(true)
-	p.OrchestratorProfile.OrchestratorVersion = "1.9.4"
+	p.OrchestratorProfile.OrchestratorVersion = "1.9.5"
 	if err := p.Validate(false); err != nil {
 		t.Errorf(
 			"should not error on valid Windows version: %v", err,
@@ -636,7 +636,7 @@ func TestWindowsVersions(t *testing.T) {
 	}
 
 	p = getK8sDefaultProperties(true)
-	p.OrchestratorProfile.OrchestratorVersion = "1.9.5"
+	p.OrchestratorProfile.OrchestratorVersion = "1.9.6"
 	if err := p.Validate(false); err == nil {
 		t.Errorf(
 			"should error on invalid Windows version",

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -262,7 +262,7 @@ func Test_KubernetesConfig_Validate(t *testing.T) {
 	for _, k8sVersion := range []string{common.KubernetesVersion1Dot6Dot11, common.KubernetesVersion1Dot6Dot12, common.KubernetesVersion1Dot6Dot13,
 		common.KubernetesVersion1Dot7Dot7, common.KubernetesVersion1Dot7Dot9, common.KubernetesVersion1Dot7Dot10, common.KubernetesVersion1Dot7Dot12, common.KubernetesVersion1Dot7Dot13, common.KubernetesVersion1Dot7Dot14,
 		common.KubernetesVersion1Dot8Dot1, common.KubernetesVersion1Dot8Dot2, common.KubernetesVersion1Dot8Dot4, common.KubernetesVersion1Dot8Dot6, common.KubernetesVersion1Dot8Dot7, common.KubernetesVersion1Dot8Dot8, common.KubernetesVersion1Dot8Dot9,
-		common.KubernetesVersion1Dot9Dot0, common.KubernetesVersion1Dot9Dot1, common.KubernetesVersion1Dot9Dot2, common.KubernetesVersion1Dot9Dot3, common.KubernetesVersion1Dot9Dot4, common.KubernetesVersion1Dot10Dot0Beta2} {
+		common.KubernetesVersion1Dot9Dot0, common.KubernetesVersion1Dot9Dot1, common.KubernetesVersion1Dot9Dot2, common.KubernetesVersion1Dot9Dot3, common.KubernetesVersion1Dot9Dot4, common.KubernetesVersion1Dot9Dot5, common.KubernetesVersion1Dot10Dot0Beta2} {
 		c := KubernetesConfig{
 			CloudProviderBackoff:   true,
 			CloudProviderRateLimit: true,
@@ -750,7 +750,7 @@ func TestLinuxVersions(t *testing.T) {
 	}
 
 	p = getK8sDefaultProperties(false)
-	p.OrchestratorProfile.OrchestratorVersion = "1.9.5"
+	p.OrchestratorProfile.OrchestratorVersion = "1.9.6"
 	if err := p.Validate(false); err == nil {
 		t.Errorf(
 			"should error on invalid Linux version",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: adds Kubernetes v1.9.5 support:

https://github.com/kubernetes/kubernetes/releases/tag/v1.9.5

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
adds Kubernetes v1.9.5 support
```