### PR TITLE
totalNodes var and params are not IsHostedMaster

### DIFF
--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -3,8 +3,8 @@
     "etcdVersion": "[parameters('etcdVersion')]",
     "maxVMsPerPool": 100,
     "apiServerCertificate": "[parameters('apiServerCertificate')]",
-    "totalNodes": "[parameters('totalNodes')]",
 {{ if not IsHostedMaster }}
+    "totalNodes": "[parameters('totalNodes')]",
     "apiServerPrivateKey": "[parameters('apiServerPrivateKey')]",
     "etcdServerCertificate": "[parameters('etcdServerCertificate')]",
     "etcdServerPrivateKey": "[parameters('etcdServerPrivateKey')]",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: disassociation between template variable and parameter condition means IsHostedMaster flows got a totalNodes var with no param definition

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
totalNodes got a var but no params
```
