### PR TITLE
Generic kube-scheduler config interface

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -51,6 +51,7 @@ Here are the valid values for the orchestrator types:
 |controllerManagerConfig|no|Configure various runtime configuration for controller-manager. See `controllerManagerConfig` [below](#feat-controller-manager-config).|
 |cloudControllerManagerConfig|no|Configure various runtime configuration for cloud-controller-manager. See `cloudControllerManagerConfig` [below](#feat-cloud-controller-manager-config).|
 |apiServerConfig|no|Configure various runtime configuration for apiserver. See `apiServerConfig` [below](#feat-apiserver-config).|
+|schedulerConfig|no|Configure various runtime configuration for scheduler. See `schedulerConfig` [below](#feat-scheduler-config).|
 
 #### addons
 
@@ -312,7 +313,7 @@ Below is a list of apiserver options that acs-engine will configure by default:
 |"--feature-gates"|No default (can be a comma-separated list)|
 
 
-Below is a list of apiserver options that are *not* currently user-configurable, either because a higher order configuration vector is available that enforces kubelet configuration, or because a static configuration is required to build a functional cluster:
+Below is a list of apiserver options that are *not* currently user-configurable, either because a higher order configuration vector is available that enforces apiserver configuration, or because a static configuration is required to build a functional cluster:
 
 |apiserver option|default value|
 |---|---|
@@ -355,7 +356,38 @@ Below is a list of apiserver options that are *not* currently user-configurable,
 |"--oidc-client-id"|*calculated value that represents OID client ID* (*if has AADProfile*)|
 |"--oidc-issuer-url"|*calculated value that represents OID issuer URL* (*if has AADProfile*)|
 
-We consider `kubeletConfig`, `controllerManagerConfig`, and `apiServerConfig` to be generic conveniences that add power/flexibility to cluster deployments. Their usage comes with no operational guarantees! They are manual tuning features that enable low-level configuration of a kubernetes cluster.
+<a name="feat-scheduler-config"></a>
+#### schedulerConfig
+
+`schedulerConfig` declares runtime configuration for the kube-scheduler daemon running on all master nodes. Like `kubeletConfig`, `controllerManagerConfig`, and `apiServerConfig` it is a generic key/value object, and a child property of `kubernetesConfig`. An example custom apiserver config:
+
+```
+"kubernetesConfig": {
+    "schedulerConfig": {
+        "--v": "2"
+    }
+}
+```
+
+See [here](https://kubernetes.io/docs/reference/generated/kube-scheduler/) for a reference of supported kube-scheduler options.
+
+Below is a list of scheduler options that acs-engine will configure by default:
+
+|kube-scheduler option|default value|
+|---|---|
+|"--v"|"2"|
+|"--feature-gates"|No default (can be a comma-separated list)|
+
+
+Below is a list of kube-scheduler options that are *not* currently user-configurable, either because a higher order configuration vector is available that enforces kube-scheduler configuration, or because a static configuration is required to build a functional cluster:
+
+|kube-scheduler option|default value|
+|---|---|
+|"--kubeconfig"|"/var/lib/kubelet/kubeconfig"|
+|"--leader-elect"|"true"|
+|"--profiling"|"false"|
+
+We consider `kubeletConfig`, `controllerManagerConfig`, `apiServerConfig`, and `schedulerConfig` to be generic conveniences that add power/flexibility to cluster deployments. Their usage comes with no operational guarantees! They are manual tuning features that enable low-level configuration of a kubernetes cluster.
 
 <a name="feat-private-cluster"></a>
 #### privateCluster

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -267,6 +267,7 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
 {{end}}
     sed -i "s|<kubernetesControllerManagerConfig>|{{GetK8sRuntimeConfigKeyVals .OrchestratorProfile.KubernetesConfig.ControllerManagerConfig}}|g" "/etc/kubernetes/manifests/kube-controller-manager.yaml"
     sed -i "s|<kubernetesAPIServerConfig>|{{GetK8sRuntimeConfigKeyVals .OrchestratorProfile.KubernetesConfig.APIServerConfig}}|g" "/etc/kubernetes/manifests/kube-apiserver.yaml"
+    sed -i "s|<kubernetesSchedulerConfig>|{{GetK8sRuntimeConfigKeyVals .OrchestratorProfile.KubernetesConfig.SchedulerConfig}}|g" "/etc/kubernetes/manifests/kube-scheduler.yaml"
     sed -i "s|<kubernetesAPIServerIP>|{{WrapAsVariable "kubernetesAPIServerIP"}}|g" "/etc/kubernetes/manifests/kube-apiserver.yaml"
 {{if not EnablePodSecurityPolicy}}
     sed -i "s|apparmor_parser|d|g" "/etc/systemd/system/kubelet.service"

--- a/parts/k8s/manifests/kubernetesmaster-kube-scheduler.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-scheduler.yaml
@@ -11,13 +11,8 @@ spec:
   containers:
     - name: "kube-scheduler"
       image: "<kubernetesHyperkubeSpec>"
-      command:
-        - "/hyperkube"
-        - "scheduler"
-        - "--kubeconfig=/var/lib/kubelet/kubeconfig"
-        - "--leader-elect=true"
-        - "--profiling=false"
-        - "--v=2"
+      command: ["/hyperkube", "scheduler"]
+      args: [<kubernetesSchedulerConfig>]
       volumeMounts:
         - name: "etc-kubernetes"
           mountPath: "/etc/kubernetes"

--- a/pkg/acsengine/defaults-scheduler.go
+++ b/pkg/acsengine/defaults-scheduler.go
@@ -1,0 +1,51 @@
+package acsengine
+
+import (
+	"github.com/Azure/acs-engine/pkg/api"
+)
+
+func setSchedulerConfig(cs *api.ContainerService) {
+	o := cs.Properties.OrchestratorProfile
+	staticLinuxSchedulerConfig := map[string]string{
+		"--kubeconfig":   "/var/lib/kubelet/kubeconfig",
+		"--leader-elect": "true",
+		"--profiling":    "false",
+		"--v":            "2",
+	}
+
+	staticWindowsSchedulerConfig := make(map[string]string)
+	for key, val := range staticLinuxSchedulerConfig {
+		staticWindowsSchedulerConfig[key] = val
+	}
+	// Windows scheduler config overrides
+	// TODO placeholder for specific config overrides for Windows clusters
+
+	// Default scheduler config
+	// TODO move any user-overridable options from staticLinuxSchedulerConfig into here
+	defaultSchedulerConfig := map[string]string{}
+
+	// If no user-configurable scheduler config values exists, use the defaults
+	if o.KubernetesConfig.SchedulerConfig == nil {
+		o.KubernetesConfig.SchedulerConfig = defaultSchedulerConfig
+	} else {
+		for key, val := range defaultSchedulerConfig {
+			// If we don't have a user-configurable scheduler config for each option
+			if _, ok := o.KubernetesConfig.SchedulerConfig[key]; !ok {
+				// then assign the default value
+				o.KubernetesConfig.SchedulerConfig[key] = val
+			}
+		}
+	}
+
+	// We don't support user-configurable values for the following,
+	// so any of the value assignments below will override user-provided values
+	var overrideSchedulerConfig map[string]string
+	if cs.Properties.HasWindows() {
+		overrideSchedulerConfig = staticWindowsSchedulerConfig
+	} else {
+		overrideSchedulerConfig = staticLinuxSchedulerConfig
+	}
+	for key, val := range overrideSchedulerConfig {
+		o.KubernetesConfig.SchedulerConfig[key] = val
+	}
+}

--- a/pkg/acsengine/defaults-scheduler.go
+++ b/pkg/acsengine/defaults-scheduler.go
@@ -10,7 +10,6 @@ func setSchedulerConfig(cs *api.ContainerService) {
 		"--kubeconfig":   "/var/lib/kubelet/kubeconfig",
 		"--leader-elect": "true",
 		"--profiling":    "false",
-		"--v":            "2",
 	}
 
 	staticWindowsSchedulerConfig := make(map[string]string)
@@ -22,7 +21,9 @@ func setSchedulerConfig(cs *api.ContainerService) {
 
 	// Default scheduler config
 	// TODO move any user-overridable options from staticLinuxSchedulerConfig into here
-	defaultSchedulerConfig := map[string]string{}
+	defaultSchedulerConfig := map[string]string{
+		"--v": "2",
+	}
 
 	// If no user-configurable scheduler config values exists, use the defaults
 	if o.KubernetesConfig.SchedulerConfig == nil {

--- a/pkg/acsengine/defaults-scheduler.go
+++ b/pkg/acsengine/defaults-scheduler.go
@@ -4,26 +4,26 @@ import (
 	"github.com/Azure/acs-engine/pkg/api"
 )
 
+// staticLinuxSchedulerConfig is not user-overridable
+var staticLinuxSchedulerConfig = map[string]string{
+	"--kubeconfig":   "/var/lib/kubelet/kubeconfig",
+	"--leader-elect": "true",
+	"--profiling":    "false",
+}
+
+// defaultSchedulerConfig provides targeted defaults, but is user-overridable
+var defaultSchedulerConfig = map[string]string{
+	"--v": "2",
+}
+
 func setSchedulerConfig(cs *api.ContainerService) {
 	o := cs.Properties.OrchestratorProfile
-	staticLinuxSchedulerConfig := map[string]string{
-		"--kubeconfig":   "/var/lib/kubelet/kubeconfig",
-		"--leader-elect": "true",
-		"--profiling":    "false",
-	}
-
 	staticWindowsSchedulerConfig := make(map[string]string)
 	for key, val := range staticLinuxSchedulerConfig {
 		staticWindowsSchedulerConfig[key] = val
 	}
 	// Windows scheduler config overrides
 	// TODO placeholder for specific config overrides for Windows clusters
-
-	// Default scheduler config
-	// TODO move any user-overridable options from staticLinuxSchedulerConfig into here
-	defaultSchedulerConfig := map[string]string{
-		"--v": "2",
-	}
 
 	// If no user-configurable scheduler config values exists, use the defaults
 	if o.KubernetesConfig.SchedulerConfig == nil {

--- a/pkg/acsengine/defaults-scheduler_test.go
+++ b/pkg/acsengine/defaults-scheduler_test.go
@@ -1,0 +1,55 @@
+package acsengine
+
+import (
+	"testing"
+)
+
+func TestSchedulerDefaultConfig(t *testing.T) {
+	cs := createContainerService("testcluster", "1.9.6", 3, 2)
+	setSchedulerConfig(cs)
+	s := cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig
+	for key, val := range staticLinuxSchedulerConfig {
+		if val != s[key] {
+			t.Fatalf("got unexpected kube-scheduler static config value for %s. Expected %s, got %s",
+				key, val, s[key])
+		}
+	}
+	for key, val := range defaultSchedulerConfig {
+		if val != s[key] {
+			t.Fatalf("got unexpected kube-scheduler default config value for %s. Expected %s, got %s",
+				key, val, s[key])
+		}
+	}
+}
+
+func TestSchedulerUserConfig(t *testing.T) {
+	cs := createContainerService("testcluster", "1.9.6", 3, 2)
+	assignmentMap := map[string]string{
+		"--scheduler-name": "my-custom-name",
+		"--feature-gates":  "APIListChunking=true,APIResponseCompression=true,Accelerators=true,AdvancedAuditing=true",
+	}
+	cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig = assignmentMap
+	setSchedulerConfig(cs)
+	for key, val := range assignmentMap {
+		if val != cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig[key] {
+			t.Fatalf("got unexpected kube-scheduler config value for %s. Expected %s, got %s",
+				key, val, cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig[key])
+		}
+	}
+}
+
+func TestSchedulerStaticConfig(t *testing.T) {
+	cs := createContainerService("testcluster", "1.9.6", 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig = map[string]string{
+		"--kubeconfig":   "user-override",
+		"--leader-elect": "user-override",
+		"--profiling":    "user-override",
+	}
+	setSchedulerConfig(cs)
+	for key, val := range staticLinuxSchedulerConfig {
+		if val != cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig[key] {
+			t.Fatalf("kube-scheduler static config did not override user values for %s. Expected %s, got %s",
+				key, val, cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig)
+		}
+	}
+}

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -480,6 +480,8 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 		setCloudControllerManagerConfig(cs)
 		// Configure apiserver
 		setAPIServerConfig(cs)
+		// Configure scheduler
+		setSchedulerConfig(cs)
 
 	} else if o.OrchestratorType == api.DCOS {
 		if o.DcosConfig == nil {

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -691,6 +691,7 @@ func convertKubernetesConfigToVLabs(api *KubernetesConfig, vlabs *vlabs.Kubernet
 	convertControllerManagerConfigToVlabs(api, vlabs)
 	convertCloudControllerManagerConfigToVlabs(api, vlabs)
 	convertAPIServerConfigToVlabs(api, vlabs)
+	convertSchedulerConfigToVlabs(api, vlabs)
 	convertPrivateClusterToVlabs(api, vlabs)
 }
 
@@ -719,6 +720,13 @@ func convertAPIServerConfigToVlabs(a *KubernetesConfig, v *vlabs.KubernetesConfi
 	v.APIServerConfig = map[string]string{}
 	for key, val := range a.APIServerConfig {
 		v.APIServerConfig[key] = val
+	}
+}
+
+func convertSchedulerConfigToVlabs(a *KubernetesConfig, v *vlabs.KubernetesConfig) {
+	v.SchedulerConfig = map[string]string{}
+	for key, val := range a.SchedulerConfig {
+		v.SchedulerConfig[key] = val
 	}
 }
 

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -638,6 +638,7 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 	convertControllerManagerConfigToAPI(vlabs, api)
 	convertCloudControllerManagerConfigToAPI(vlabs, api)
 	convertAPIServerConfigToAPI(vlabs, api)
+	convertSchedulerConfigToAPI(vlabs, api)
 	convertPrivateClusterToAPI(vlabs, api)
 }
 
@@ -706,6 +707,13 @@ func convertAPIServerConfigToAPI(v *vlabs.KubernetesConfig, a *KubernetesConfig)
 	a.APIServerConfig = map[string]string{}
 	for key, val := range v.APIServerConfig {
 		a.APIServerConfig[key] = val
+	}
+}
+
+func convertSchedulerConfigToAPI(v *vlabs.KubernetesConfig, a *KubernetesConfig) {
+	a.SchedulerConfig = map[string]string{}
+	for key, val := range v.SchedulerConfig {
+		a.SchedulerConfig[key] = val
 	}
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -276,6 +276,7 @@ type KubernetesConfig struct {
 	ControllerManagerConfig          map[string]string `json:"controllerManagerConfig,omitempty"`
 	CloudControllerManagerConfig     map[string]string `json:"cloudControllerManagerConfig,omitempty"`
 	APIServerConfig                  map[string]string `json:"apiServerConfig,omitempty"`
+	SchedulerConfig                  map[string]string `json:"schedulerConfig,omitempty"`
 	CloudProviderBackoff             bool              `json:"cloudProviderBackoff,omitempty"`
 	CloudProviderBackoffRetries      int               `json:"cloudProviderBackoffRetries,omitempty"`
 	CloudProviderBackoffJitter       float64           `json:"cloudProviderBackoffJitter,omitempty"`

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -274,6 +274,7 @@ type KubernetesConfig struct {
 	ControllerManagerConfig      map[string]string `json:"controllerManagerConfig,omitempty"`
 	CloudControllerManagerConfig map[string]string `json:"cloudControllerManagerConfig,omitempty"`
 	APIServerConfig              map[string]string `json:"apiServerConfig,omitempty"`
+	SchedulerConfig              map[string]string `json:"schedulerConfig,omitempty"`
 	CloudProviderBackoff         bool              `json:"cloudProviderBackoff,omitempty"`
 	CloudProviderBackoffRetries  int               `json:"cloudProviderBackoffRetries,omitempty"`
 	CloudProviderBackoffJitter   float64           `json:"cloudProviderBackoffJitter,omitempty"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Enables configurable kube-scheduler runtime in api model

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2336

- [x] documentation
- [x] validate which existing values should be user-configurable
- [x] unit tests

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Adds generic kube-scheduler config interface
```