### PR TITLE
Add Ability to Add Custom Labels for Master Nodes

### DIFF
--- a/parts/dcos/dcosmasterresources.t
+++ b/parts/dcos/dcosmasterresources.t
@@ -362,7 +362,7 @@
         "osProfile": {
           "adminUsername": "[variables('adminUsername')]",
           "computername": "[concat(variables('masterVMNamePrefix'), copyIndex())]",
-          {{GetDCOSMasterCustomData}}
+          {{GetDCOSMasterCustomData .}}
           "linuxConfiguration": {
             "disablePasswordAuthentication": "true",
             "ssh": {

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -159,7 +159,7 @@ MASTER_ADDONS_CONFIG_PLACEHOLDER
     KUBELET_CONFIG={{GetKubeletConfigKeyVals .MasterProfile.KubernetesConfig}}
     KUBELET_IMAGE={{WrapAsVariable "kubernetesHyperkubeSpec"}}
     DOCKER_OPTS=
-    KUBELET_NODE_LABELS={{GetMasterKubernetesLabels "',variables('labelResourceGroup'),'"}}
+    KUBELET_NODE_LABELS={{GetMasterKubernetesLabels . "',variables('labelResourceGroup'),'"}}
 {{if IsKubernetesVersionGe "1.6.0"}}
   {{if HasLinuxAgents}}
     KUBELET_NON_MASQUERADE_CIDR={{WrapAsVariable "kubernetesNonMasqueradeCidr"}}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -315,6 +315,7 @@ type MasterProfile struct {
 	StorageProfile           string            `json:"storageProfile,omitempty"`
 	HTTPSourceAddressPrefix  string            `json:"HTTPSourceAddressPrefix,omitempty"`
 	OAuthEnabled             bool              `json:"oauthEnabled"`
+	CustomNodeLabels         map[string]string `json:"customNodeLabels,omitempty"`
 	PreprovisionExtension    *Extension        `json:"preProvisionExtension"`
 	Extensions               []Extension       `json:"extensions"`
 	Distro                   Distro            `json:"distro,omitempty"`

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -306,6 +306,7 @@ type MasterProfile struct {
 	StorageProfile           string            `json:"storageProfile,omitempty" validate:"eq=StorageAccount|eq=ManagedDisks|len=0"`
 	HTTPSourceAddressPrefix  string            `json:"HTTPSourceAddressPrefix,omitempty"`
 	OAuthEnabled             bool              `json:"oauthEnabled"`
+	CustomNodeLabels         map[string]string `json:"customNodeLabels,omitempty"`
 	PreProvisionExtension    *Extension        `json:"preProvisionExtension"`
 	Extensions               []Extension       `json:"extensions"`
 	Distro                   Distro            `json:"distro,omitempty"`

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -406,7 +406,7 @@ func (a *Properties) Validate(isUpdate bool) error {
 			}
 		}
 
-		if len(agentPoolProfile.CustomNodeLabels) > 0 {
+		if len(agentPoolProfile.CustomNodeLabels) > 0 || len(masterProfile.CustomNodeLabels) > 0 {
 			switch a.OrchestratorProfile.OrchestratorType {
 			case DCOS:
 			case Kubernetes:


### PR DESCRIPTION
This enables the usecase for Kubernetes where a user may want to place a
custom label on a master node for some reason.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
