### PR TITLE
change default windows node network policy to Azure CNI

### DIFF
--- a/pkg/api/vlabs/const.go
+++ b/pkg/api/vlabs/const.go
@@ -87,5 +87,5 @@ const (
 	// DefaultNetworkPolicy defines the network policy to use by default
 	DefaultNetworkPolicy = "azure"
 	// DefaultNetworkPolicyWindows defines the network policy to use by default for clusters with Windows agent pools
-	DefaultNetworkPolicyWindows = "none"
+	DefaultNetworkPolicyWindows = "azure"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR makes Azure CNI as default network policy for clusters with Windows nodes.

**Special notes for your reviewer**:
