### PR TITLE
Update Calico to 3.1

### DIFF
--- a/examples/networkpolicy/README.md
+++ b/examples/networkpolicy/README.md
@@ -57,9 +57,15 @@ The kubernetes-calico deployment template enables Calico networking and policies
       }
 ```
 
+<<<<<<< cca21c1a50cedc2631c9e73e9401be9fae0216f6
 If `"orchestratorRelease": "1.8",` is set a K8s 1.8.x cluster will be provisioned.  If `orchestratorRelease` is not specified a K8s 1.7.x cluster will be deployed.  In either of these cases, this template will deploy the [v2.6 release](https://docs.projectcalico.org/v2.6/releases/) of [Kubernetes Datastore Install](https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/) version of calico with the "Calico policy-only with user-supplied networking" which supports kubernetes ingress policies and has some limitations as denoted on the referenced page.
+=======
+This template will deploy the [v3.0 release](https://docs.projectcalico.org/v3.0/releases/) of [Kubernetes Datastore Install](https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/) version of calico with the "Calico policy-only with user-supplied networking" which supports kubernetes ingress policies and has some limitations as denoted on the referenced page.
+>>>>>>> Updates for 3.0 Calico
 
-> Note: If deploying on a K8s 1.8 cluster, then egress policies are also supported!
+> Note: The Typha service and deployment is installed on the cluster, but effectively disabled using the default settings of deployment replicas set to 0 and Typha service name not configured.  Typha is recommended to be enabled when scaling to 50+ nodes on the cluster to reduce the load on the Kubernetes API server.  If this functionality is desired to be configurable via the API model, please file an issue on Github requesting this feature be added.  Otherwise, this can be manually changed via modifying and applying changes with the `/etc/kubernetes/addons/calico-daemonset.yaml` file on every master node in the cluster.
+
+If deploying on a K8s 1.8 cluster, then egress policies are also supported!
 
 If `orchestratorRelease` is set to 1.5 or 1.6, then this template will deploy the [v2.4.1 release](https://github.com/projectcalico/calico/releases/tag/v2.4.1) of [Kubernetes Datastore Install](https://docs.projectcalico.org/v2.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/) version of calico with the "Calico policy-only with user-supplied networking" which supports kubernetes ingress policies and has some limitations as denoted on the referenced page.
 
@@ -67,7 +73,7 @@ To understand how to deploy this template, please read the baseline  [Kubernetes
 
 ### Post installation
 
-Once the template has been successfully deployed, following the [simple policy tutorial](https://docs.projectcalico.org/v2.6/getting-started/kubernetes/tutorials/simple-policy) or the [advanced policy tutorial](https://docs.projectcalico.org/v2.6/getting-started/kubernetes/tutorials/advanced-policy) will help to understand calico networking.
+Once the template has been successfully deployed, following the [simple policy tutorial](https://docs.projectcalico.org/v3.0/getting-started/kubernetes/tutorials/simple-policy) or the [advanced policy tutorial](https://docs.projectcalico.org/v3.0/getting-started/kubernetes/tutorials/advanced-policy) will help to understand calico networking.
 
 > Note: `ping` (ICMP) traffic is blocked on the cluster by default.  Wherever `ping` is used in any tutorial substitute testing access with something like `wget -q --timeout=5 google.com -O -` instead.
 

--- a/examples/networkpolicy/kubernetes-calico.json
+++ b/examples/networkpolicy/kubernetes-calico.json
@@ -10,19 +10,13 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_D2_v2"
+      "vmSize": "Standard_DS2_v2"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "AvailabilitySet"
-      },
-      {
-        "name": "agentpool2",
-        "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_DS2_v2",
         "availabilityProfile": "AvailabilitySet"
       }
     ],

--- a/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
@@ -9,13 +9,16 @@ kind: ServiceAccount
 metadata:
   name: calico-node
   namespace: kube-system
-
+  labels:
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 ---
 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: calico-node
+  labels:
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 rules:
   - apiGroups: [""]
     resources:
@@ -84,6 +87,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: calico-node
+  labels:
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -100,6 +105,8 @@ apiVersion: v1
 metadata:
   name: calico-config
   namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 data:
   # To enable Typha, set this to "calico-typha" *and* set a non-zero value for Typha replicas
   # below.  We recommend using Typha if you have more than 50 nodes. Above 100 nodes it is
@@ -150,6 +157,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   ports:
     - port: 5473
@@ -170,6 +178,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   # Number of Typha replicas.  To enable Typha, set this to a non-zero value *and* set the
   # typha_service_name variable in the calico-config ConfigMap above.
@@ -265,14 +274,14 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
-      annotations:
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted. 
-        # Deprecated in 1.10, Removed in 1.11. kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods 
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-    spec:
+        annotations:
+          # This, along with the CriticalAddonsOnly toleration below,
+          # marks the pod as a critical add-on, ensuring it gets
+          # priority scheduling and that its resources are reserved
+          # if it ever gets evicted. 
+          # Deprecated in 1.10, Removed in 1.11. kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods 
+          scheduler.alpha.kubernetes.io/critical-pod: ''  
+        spec:
       hostNetwork: true
       serviceAccountName: calico-node
       tolerations:
@@ -416,6 +425,8 @@ description: Calico Felix Configuration
 kind: CustomResourceDefinition
 metadata:
    name: felixconfigurations.crd.projectcalico.org
+   labels:
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -432,6 +443,8 @@ description: Calico BGP Configuration
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
+  labels:
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -448,6 +461,8 @@ description: Calico IP Pools
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
+  labels:
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -464,6 +479,8 @@ description: Calico Cluster Information
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
+  labels:
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -480,6 +497,8 @@ description: Calico Global Network Policies
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
+  labels:
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -496,6 +515,8 @@ description: Calico Network Policies
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
+  labels:
+    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Namespaced
   group: crd.projectcalico.org

--- a/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
@@ -1,8 +1,8 @@
-# Calico Version v3.0.4
-# https://docs.projectcalico.org/v3.0/releases#v3.0.4
+# Calico Version v3.1.1
+# https://docs.projectcalico.org/v3.1/releases#v3.1.1
 # This manifest includes the following component versions:
-#   calico/node:v3.0.4
-#   calico/cni:v2.0.3
+#   calico/node:v3.1.1
+#   calico/cni:v3.1.1
 
 apiVersion: v1
 kind: ServiceAccount
@@ -65,6 +65,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - globalfelixconfigs
@@ -74,15 +80,19 @@ rules:
       - bgpconfigurations
       - ippools
       - globalnetworkpolicies
+      - globalnetworksets
       - networkpolicies
       - clusterinformations
+      - hostendpoints
     verbs:
       - create
       - get
       - list
       - update
       - watch
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -97,6 +107,7 @@ subjects:
 - kind: ServiceAccount
   name: calico-node
   namespace: kube-system
+
 ---
 
 # This ConfigMap is used to configure a self-hosted Calico installation.
@@ -112,6 +123,7 @@ data:
   # below.  We recommend using Typha if you have more than 50 nodes. Above 100 nodes it is
   # essential.
   typha_service_name: "none"
+
   # The CNI network configuration to install on each node.
   cni_network_config: |-
     {
@@ -129,11 +141,9 @@ data:
               "subnet": "usePodCidr"
           },
           "policy": {
-              "type": "k8s",
-              "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+              "type": "k8s"
           },
           "kubernetes": {
-              "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
               "kubeconfig": "__KUBECONFIG_FILEPATH__"
           }
         },
@@ -199,15 +209,15 @@ spec:
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      hostNetwork: true
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
-      hostNetwork: true
       serviceAccountName: calico-node
       containers:
-      - image: quay.io/calico/typha:v0.6.2
+      - image: quay.io/calico/typha:v0.7.2
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -283,7 +293,6 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''  
     spec:
       hostNetwork: true
-      serviceAccountName: calico-node
       tolerations:
         # Allow the pod to run on the master.  This is required for
         # the master to communicate with pods.
@@ -294,6 +303,9 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      serviceAccountName: calico-node
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
@@ -302,7 +314,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.0.4
+          image: quay.io/calico/node:v3.1.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -315,7 +327,7 @@ spec:
               value: "none"
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
-              value: "k8s,acse"
+              value: "k8s"
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
@@ -375,10 +387,13 @@ spec:
             - mountPath: /var/run/calico
               name: var-run-calico
               readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v2.0.3
+          image: quay.io/calico/cni:v3.1.1
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -408,6 +423,9 @@ spec:
         - name: var-run-calico
           hostPath:
             path: /var/run/calico
+        - name: var-lib-calico
+          hostPath:
+            path: /var/lib/calico
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
@@ -424,8 +442,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 description: Calico Felix Configuration
 kind: CustomResourceDefinition
 metadata:
-   name: felixconfigurations.crd.projectcalico.org
-   labels:
+  name: felixconfigurations.crd.projectcalico.org
+  labels:
     addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
@@ -475,6 +493,24 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Host Endpoints
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+  labels:
+    addonmanager.kubernetes.io/mode: "EnsureExists"
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: HostEndpoint
+    plural: hostendpoints
+    singular: hostendpoint
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
 description: Calico Cluster Information
 kind: CustomResourceDefinition
 metadata:
@@ -507,6 +543,24 @@ spec:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Global Network Sets
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+  labels:
+    addonmanager.kubernetes.io/mode: "EnsureExists"
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkSet
+    plural: globalnetworksets
+    singular: globalnetworkset
 
 ---
 

--- a/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
@@ -1,8 +1,16 @@
-# Calico Version v3.0.3
-# https://docs.projectcalico.org/v3.0/releases#v3.0.3
+# Calico Version v3.0.4
+# https://docs.projectcalico.org/v3.0/releases#v3.0.4
 # This manifest includes the following component versions:
-#   calico/node:v3.0.3
-#   calico/cni:v2.0.1
+#   calico/node:v3.0.4
+#   calico/cni:v2.0.3
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system
+
+---
 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -285,7 +293,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.0.3
+          image: quay.io/calico/node:v3.0.4
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -361,7 +369,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v2.0.1
+          image: quay.io/calico/cni:v2.0.3
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -496,11 +504,3 @@ spec:
     kind: NetworkPolicy
     plural: networkpolicies
     singular: networkpolicy
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: calico-node
-  namespace: kube-system

--- a/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
@@ -274,14 +274,14 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
-        annotations:
-          # This, along with the CriticalAddonsOnly toleration below,
-          # marks the pod as a critical add-on, ensuring it gets
-          # priority scheduling and that its resources are reserved
-          # if it ever gets evicted. 
-          # Deprecated in 1.10, Removed in 1.11. kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods 
-          scheduler.alpha.kubernetes.io/critical-pod: ''  
-        spec:
+      annotations:
+        # This, along with the CriticalAddonsOnly toleration below,
+        # marks the pod as a critical add-on, ensuring it gets
+        # priority scheduling and that its resources are reserved
+        # if it ever gets evicted. 
+        # Deprecated in 1.10, Removed in 1.11. kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods 
+        scheduler.alpha.kubernetes.io/critical-pod: ''  
+    spec:
       hostNetwork: true
       serviceAccountName: calico-node
       tolerations:

--- a/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
@@ -1,15 +1,13 @@
-# Calico Version v2.6.3
-# https://docs.projectcalico.org/v2.6/releases#v2.6.3
+# Calico Version v3.0.3
+# https://docs.projectcalico.org/v3.0/releases#v3.0.3
 # This manifest includes the following component versions:
-#   calico/node:v2.6.3
-#   calico/cni:v1.11.1
+#   calico/node:v3.0.3
+#   calico/cni:v2.0.1
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: calico-node
-  namespace: kube-system
-  labels:
-    addonmanager.kubernetes.io/mode: "EnsureExists"
 rules:
   - apiGroups: [""]
     resources:
@@ -30,6 +28,17 @@ rules:
       - get
       - list
       - watch
+      - patch
+  - apiGroups: [""]
+    resources:
+      - services
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - endpoints
+    verbs:
+      - get
   - apiGroups: [""]
     resources:
       - nodes
@@ -48,10 +57,14 @@ rules:
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - globalfelixconfigs
+      - felixconfigurations
       - bgppeers
       - globalbgpconfigs
+      - bgpconfigurations
       - ippools
       - globalnetworkpolicies
+      - networkpolicies
+      - clusterinformations
     verbs:
       - create
       - get
@@ -63,8 +76,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: calico-node
-  labels:
-    addonmanager.kubernetes.io/mode: "EnsureExists"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -74,37 +85,157 @@ subjects:
   name: calico-node
   namespace: kube-system
 ---
+
+# This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: calico-config
   namespace: kube-system
-  labels:
-    addonmanager.kubernetes.io/mode: "EnsureExists"
 data:
+  # To enable Typha, set this to "calico-typha" *and* set a non-zero value for Typha replicas
+  # below.  We recommend using Typha if you have more than 50 nodes. Above 100 nodes it is
+  # essential.
+  typha_service_name: "none"
+  # The CNI network configuration to install on each node.
   cni_network_config: |-
     {
-        "name": "k8s-pod-network",
-        "cniVersion": "0.1.0",
-        "type": "calico",
-        "log_level": "info",
-        "datastore_type": "kubernetes",
-        "nodename": "__KUBERNETES_NODE_NAME__",
-        "mtu": 1500,
-        "ipam": {
-            "type": "host-local",
-            "subnet": "usePodCidr"
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.0",
+      "plugins": [
+        {
+          "type": "calico",
+          "log_level": "info",
+          "datastore_type": "kubernetes",
+          "nodename": "__KUBERNETES_NODE_NAME__",
+          "mtu": 1500,
+          "ipam": {
+              "type": "host-local",
+              "subnet": "usePodCidr"
+          },
+          "policy": {
+              "type": "k8s",
+              "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+          },
+          "kubernetes": {
+              "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+              "kubeconfig": "__KUBECONFIG_FILEPATH__"
+          }
         },
-        "policy": {
-            "type": "k8s",
-            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-        },
-        "kubernetes": {
-            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+        {
+          "type": "portmap",
+          "snat": true,
+          "capabilities": {"portMappings": true}
         }
+      ]
     }
+
 ---
+
+# This manifest creates a Service, which will be backed by Calico's Typha daemon.
+# Typha sits in between Felix and the API server, reducing Calico's load on the API server.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: calico-typha
+  namespace: kube-system
+  labels:
+    k8s-app: calico-typha
+spec:
+  ports:
+    - port: 5473
+      protocol: TCP
+      targetPort: calico-typha
+      name: calico-typha
+  selector:
+    k8s-app: calico-typha
+
+---
+
+# This manifest creates a Deployment of Typha to back the above service.
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: calico-typha
+  namespace: kube-system
+  labels:
+    k8s-app: calico-typha
+spec:
+  # Number of Typha replicas.  To enable Typha, set this to a non-zero value *and* set the
+  # typha_service_name variable in the calico-config ConfigMap above.
+  #
+  # We recommend using Typha if you have more than 50 nodes.  Above 100 nodes it is essential
+  # (when using the Kubernetes datastore).  Use one replica for every 100-200 nodes.  In
+  # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
+  replicas: 0
+  revisionHistoryLimit: 2
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-typha
+        addonmanager.kubernetes.io/mode: "EnsureExists"
+      annotations:
+        # This, along with the CriticalAddonsOnly toleration below, marks the pod as a critical
+        # add-on, ensuring it gets priority scheduling and that its resources are reserved
+        # if it ever gets evicted.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      # Since Calico can't network a pod until Typha is up, we need to run Typha itself
+      # as a host-networked pod.
+      hostNetwork: true
+      serviceAccountName: calico-node
+      containers:
+      - image: quay.io/calico/typha:v0.6.2
+        name: calico-typha
+        ports:
+        - containerPort: 5473
+          name: calico-typha
+          protocol: TCP
+        env:
+          # Enable "info" logging by default.  Can be set to "debug" to increase verbosity.
+          - name: TYPHA_LOGSEVERITYSCREEN
+            value: "info"
+          # Disable logging to file and syslog since those don't make sense in Kubernetes.
+          - name: TYPHA_LOGFILEPATH
+            value: "none"
+          - name: TYPHA_LOGSEVERITYSYS
+            value: "none"
+          # Monitor the Kubernetes API to find the number of running instances and rebalance
+          # connections.
+          - name: TYPHA_CONNECTIONREBALANCINGMODE
+            value: "kubernetes"
+          - name: TYPHA_DATASTORETYPE
+            value: "kubernetes"
+          - name: TYPHA_HEALTHENABLED
+            value: "true"
+          # Uncomment these lines to enable prometheus metrics.  Since Typha is host-networked,
+          # this opens a port on the host, which may need to be secured.
+          #- name: TYPHA_PROMETHEUSMETRICSENABLED
+          #  value: "true"
+          #- name: TYPHA_PROMETHEUSMETRICSPORT
+          #  value: "9093"
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 9098
+          periodSeconds: 30
+          initialDelaySeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 9098
+          periodSeconds: 10
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
 apiVersion: extensions/v1beta1
 metadata:
@@ -112,59 +243,93 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-node
+    # github.com/kubernetes/kubernetes/tree/master/cluster/addons/addon-manager
     addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   selector:
     matchLabels:
       k8s-app: calico-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:
         k8s-app: calico-node
       annotations:
+        # This, along with the CriticalAddonsOnly toleration below,
+        # marks the pod as a critical add-on, ensuring it gets
+        # priority scheduling and that its resources are reserved
+        # if it ever gets evicted. 
+        # Deprecated in 1.10, Removed in 1.11. kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods 
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: true
       serviceAccountName: calico-node
       tolerations:
+        # Allow the pod to run on the master.  This is required for
+        # the master to communicate with pods.
         - key: node-role.kubernetes.io/master
           operator: Equal
           value: "true"
           effect: NoSchedule
+        # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 0
       containers:
+        # Runs calico/node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
         - name: calico-node
-          image: quay.io/calico/node:v2.6.3
+          image: quay.io/calico/node:v3.0.3
           env:
+            # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
               value: "kubernetes"
+            # Enable felix info logging.
             - name: FELIX_LOGSEVERITYSCREEN
               value: "info"
+            # Don't enable BGP.
             - name: CALICO_NETWORKING_BACKEND
               value: "none"
+            # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "k8s,acse"
+            # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
+            # Disable IPV6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"
+            # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"
+            # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
             - name: CALICO_IPV4POOL_CIDR
               value: "<kubeClusterCidr>"
+            # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "off"
             - name: FELIX_IPTABLESREFRESHINTERVAL
               value: "60"
+            # Typha support: controlled by the ConfigMap.
+            - name: FELIX_TYPHAK8SSERVICENAME
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: typha_service_name
+            # Set based on the k8s node name.
             - name: NODENAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: IP
-              value: ""
             - name: FELIX_HEALTHENABLED
               value: "true"
             - name: FELIX_IPINIPENABLED
@@ -193,15 +358,22 @@ spec:
             - mountPath: /var/run/calico
               name: var-run-calico
               readOnly: false
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v1.11.1
+          image: quay.io/calico/cni:v2.0.1
           command: ["/install-cni.sh"]
           env:
+            # Name of the CNI config file to create.
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
+            # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: cni_network_config
+            # Set the hostname based on the k8s node name.
             - name: KUBERNETES_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -212,58 +384,62 @@ spec:
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
       volumes:
+        # Used by calico/node.
         - name: lib-modules
           hostPath:
             path: /lib/modules
         - name: var-run-calico
           hostPath:
             path: /var/run/calico
+        # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
             path: /opt/cni/bin
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
+
+# Create all the CustomResourceDefinitions needed for
+# Calico policy-only mode.
 ---
+
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global Felix Configuration
+description: Calico Felix Configuration
 kind: CustomResourceDefinition
 metadata:
-  name: globalfelixconfigs.crd.projectcalico.org
-  labels:
-    addonmanager.kubernetes.io/mode: "EnsureExists"
+   name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
   version: v1
   names:
-    kind: GlobalFelixConfig
-    plural: globalfelixconfigs
-    singular: globalfelixconfig
+    kind: FelixConfiguration
+    plural: felixconfigurations
+    singular: felixconfiguration
+
 ---
+
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global BGP Configuration
+description: Calico BGP Configuration
 kind: CustomResourceDefinition
 metadata:
-  name: globalbgpconfigs.crd.projectcalico.org
-  labels:
-    addonmanager.kubernetes.io/mode: "EnsureExists"
+  name: bgpconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
   version: v1
   names:
-    kind: GlobalBGPConfig
-    plural: globalbgpconfigs
-    singular: globalbgpconfig
+    kind: BGPConfiguration
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+
 ---
+
 apiVersion: apiextensions.k8s.io/v1beta1
 description: Calico IP Pools
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
-  labels:
-    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -272,14 +448,30 @@ spec:
     kind: IPPool
     plural: ippools
     singular: ippool
+
 ---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Cluster Information
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: ClusterInformation
+    plural: clusterinformations
+    singular: clusterinformation
+
+---
+
 apiVersion: apiextensions.k8s.io/v1beta1
 description: Calico Global Network Policies
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
-  labels:
-    addonmanager.kubernetes.io/mode: "EnsureExists"
 spec:
   scope: Cluster
   group: crd.projectcalico.org
@@ -288,11 +480,27 @@ spec:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
+
 ---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Network Policies
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    singular: networkpolicy
+
+---
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: calico-node
   namespace: kube-system
-  labels:
-    addonmanager.kubernetes.io/mode: "EnsureExists"


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates Calico from 2.6 to the latest 3.0 which enables [additional functionality](https://www.projectcalico.org/releasethecalico/). 

**Which issue this PR fixes** 
This lays the foundation for the requested IPAM support via these issues 
https://github.com/Azure/acs-engine/issues/2227
https://github.com/Azure/acs-engine/issues/1930

Potentially fixes #1621
fixes #2202

**If applicable**:
- [x] documentation
- [ ] network policy e2e test(s)
- [x] tested backward compatibility (ie. deploy with the previous version, upgrade with this branch)

```release-note
Updates Calico from 2.6 to the latest 3.0
```
