### PR TITLE
Fix the issue that azure file volume could not be dynamically created in v1.7

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-azure-cloud-provider-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-azure-cloud-provider-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: system:azure-cloud-provider


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
current `kubernetesmasteraddons-azure-cloud-provider-deployment.yaml` does not work for k8s 1.7, which means azure file volume could not be dynamically created in v1.7 now, this PR fix this issue. use v1beta1 for ClusterRole to support k8s 1.7

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:


**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Fix the issue that azure file volume could not be dynamically created in v1.7
```

@jackfrancis 