### PR TITLE
use cri-containerd not cri-o

### DIFF
--- a/examples/e2e-tests/kubernetes/kubernetes-config/clear-containers.json
+++ b/examples/e2e-tests/kubernetes/kubernetes-config/clear-containers.json
@@ -3,7 +3,9 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "1.10",
       "kubernetesConfig": {
+        "networkPolicy": "azure",
         "containerRuntime": "clear-containers"
       }
     },
@@ -14,9 +16,9 @@
     },
     "agentPoolProfiles": [
       {
-        "name": "linuxpool1",
+        "name": "agentpool1",
         "count": 3,
-        "vmSize": "Standard_D2_v2",
+        "vmSize": "Standard_D4s_v3",
         "availabilityProfile": "AvailabilitySet"
       }
     ],
@@ -33,7 +35,6 @@
     "servicePrincipalProfile": {
       "clientId": "",
       "secret": ""
-    },
-    "certificateProfile": {}
+    }
   }
 }

--- a/examples/kubernetes-clear-containers.json
+++ b/examples/kubernetes-clear-containers.json
@@ -3,11 +3,10 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.8",
+      "orchestratorRelease": "1.10",
       "kubernetesConfig": {
         "networkPolicy": "azure",
         "containerRuntime": "clear-containers",
-        "etcdVersion": "3.1.10",
         "addons": [
           {
             "name": "tiller",
@@ -30,9 +29,7 @@
         "name": "agentpool1",
         "count": 3,
         "vmSize": "Standard_D4s_v3",
-        "availabilityProfile": "AvailabilitySet",
-        "storageProfile": "ManagedDisks",
-        "diskSizesGB": [1023]
+        "availabilityProfile": "AvailabilitySet"
       }
     ],
     "linuxProfile": {

--- a/parts/k8s/kubernetesmastercustomscript.sh
+++ b/parts/k8s/kubernetesmastercustomscript.sh
@@ -288,11 +288,13 @@ function installGo() {
 		rm -rf "$GOPATH"
 	fi
 
-	GO_VERSION=$(curl --retry 5 --retry-delay 10 --retry-max-time 30 -sSL "https://golang.org/VERSION?m=text")
+	retrycmd_if_failure_no_stats 180 1 5 curl -fsSL https://golang.org/VERSION?m=text > /tmp/gover.txt
+	GO_VERSION=$(cat /tmp/gover.txt)
 	echo "Installing Go version $GO_VERSION..."
-	(
-	curl --retry 5 --retry-delay 10 --retry-max-time 30 -sSL "https://storage.googleapis.com/golang/${GO_VERSION}.linux-amd64.tar.gz" | sudo tar -v -C /usr/local -xz
-	)
+
+	retrycmd_get_tarball 60 1 /tmp/golang.tgz https://storage.googleapis.com/golang/${GO_VERSION}.linux-amd64.tar.gz
+	tar -v -C /usr/local -xzf /tmp/golang.tgz
+	rm -rf "/tmp/golang.tgz" "/tmp/gover.txt"
 
 	export PATH="${GO_SRC}/bin:${PATH}:${GOPATH}/bin"
 }


### PR DESCRIPTION
Switched the cri runtime for clear containers from cri-o to cri-containerd.
This is because I am more familiar with containerd and can debug it more easily
and it now has support for clear containers runtime, otherwise I would have
done this initially as well.

