### PR TITLE
Improve non-masquerade-cidr

### DIFF
--- a/parts/k8s/artifacts/kuberneteskubelet.service
+++ b/parts/k8s/artifacts/kuberneteskubelet.service
@@ -40,7 +40,6 @@ ExecStart=/usr/bin/docker run \
         --enable-server \
         --node-labels="${KUBELET_NODE_LABELS}" \
         --v=2 \
-        --non-masquerade-cidr=${KUBELET_NON_MASQUERADE_CIDR} \
         --volume-plugin-dir=/etc/kubernetes/volumeplugins \
         $KUBELET_CONFIG $KUBELET_OPTS \
         ${KUBELET_REGISTER_NODE} ${KUBELET_REGISTER_WITH_TAINTS}

--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -120,9 +120,6 @@ write_files:
     DOCKER_OPTS=
     KUBELET_REGISTER_SCHEDULABLE=true
     KUBELET_NODE_LABELS={{GetAgentKubernetesLabels . "',variables('labelResourceGroup'),'"}}
-{{if IsKubernetesVersionGe "1.6.0"}}
-    KUBELET_NON_MASQUERADE_CIDR={{WrapAsVariable "kubernetesNonMasqueradeCidr"}}
-{{end}}
 
 AGENT_ARTIFACTS_CONFIG_PLACEHOLDER
 

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -162,7 +162,6 @@ MASTER_ADDONS_CONFIG_PLACEHOLDER
     KUBELET_NODE_LABELS={{GetMasterKubernetesLabels "',variables('labelResourceGroup'),'"}}
 {{if IsKubernetesVersionGe "1.6.0"}}
   {{if HasLinuxAgents}}
-    KUBELET_NON_MASQUERADE_CIDR={{WrapAsVariable "kubernetesNonMasqueradeCidr"}}
     KUBELET_REGISTER_NODE=--register-node=true
     KUBELET_REGISTER_WITH_TAINTS=--register-with-taints={{WrapAsVariable "registerWithTaints"}}
   {{end}}

--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -15,8 +15,6 @@ const (
 	DefaultKubernetesClusterSubnet = "10.244.0.0/16"
 	// DefaultDockerBridgeSubnet specifies the default subnet for the docker bridge network for masters and agents.
 	DefaultDockerBridgeSubnet = "172.17.0.1/16"
-	// DefaultNonMasqueradeCidr specifies the subnet that should not be masqueraded on host
-	DefaultNonMasqueradeCidr = "10.0.0.0/8"
 	// DefaultFirstConsecutiveKubernetesStaticIP specifies the static IP address on Kubernetes master 0
 	DefaultFirstConsecutiveKubernetesStaticIP = "10.240.255.5"
 	// DefaultAgentSubnetTemplate specifies a default agent subnet

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -41,7 +41,7 @@ func setKubeletConfig(cs *api.ContainerService) {
 		"--node-status-update-frequency": KubeConfigs[o.OrchestratorVersion]["nodestatusfreq"],
 		"--image-gc-high-threshold":      strconv.Itoa(DefaultKubernetesGCHighThreshold),
 		"--image-gc-low-threshold":       strconv.Itoa(DefaultKubernetesGCLowThreshold),
-		"--non-masquerade-cidr":          DefaultNonMasqueradeCidr,
+		"--non-masquerade-cidr":          o.KubernetesConfig.ClusterSubnet,
 		"--cloud-provider":               "azure",
 		"--cloud-config":                 "/etc/kubernetes/azure.json",
 		"--event-qps":                    DefaultKubeletEventQPS,


### PR DESCRIPTION
--non-masquerade-cidr defaults to 10.0.0.0/8 if you don't define it.

That's way too large. If you are in a VNet within 10.0.0.0/8 setting this will prevent pods to contact resources in the VNet because everything in 10.0.0.0/8 will be considered to be within the kubernetes cluster.

Instead let us define it to the value of cluster subnet.