### PR TITLE
Trimmed down permission for dashboard service account

### DIFF
--- a/parts/k8s/addons/1.9/kubernetesmasteraddons-kubernetes-dashboard-deployment.yaml
+++ b/parts/k8s/addons/1.9/kubernetesmasteraddons-kubernetes-dashboard-deployment.yaml
@@ -8,18 +8,52 @@ metadata:
   name: kubernetes-dashboard
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: kubernetes-dashboard
+  name: kubernetes-dashboard-minimal
+  namespace: kube-system
+  labels:
+    k8s-app: kubernetes-dashboard
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["kubernetes-dashboard-key-holder"]
+  verbs: ["get", "update", "delete"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["kubernetes-dashboard-settings"]
+  verbs: ["get", "update"]
+- apiGroups: [""]
+  resources: ["services"]
+  resourceNames: ["heapster"]
+  verbs: ["proxy"]
+- apiGroups: [""]
+  resources: ["services/proxy"]
+  resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubernetes-dashboard-minimal
+  namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
+  kind: Role
+  name: kubernetes-dashboard-minimal
 subjects:
 - kind: ServiceAccount
   name: kubernetes-dashboard


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR trims down the dashboard service account to the minimum possible per https://github.com/kubernetes/dashboard/wiki/Access-control#default-dashboard-privileges .
Current permission allow users to skip dashboard authentication and inherit cluster-admin priviledges nullifying the login process and RBAC resulting in an unsecure cluster.
With the proposed configuration, skipping login results in no permissions.
For development clusters, users can still reinstate previous permission manually granting cluster-admin permission to the dashboard service account.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2425

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:

```release-note
Security: skipping kubernetes dashboard's login now effectively results in no permissions.
Logged in user will receive permission per RBAC profile.
```
