### PR TITLE
make e2e compatible with jumpbox for private clusters

### DIFF
--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -485,6 +485,9 @@
       "apiVersion": "[variables('apiVersionDefault')]",
       "location": "[variables('location')]",
       "properties": {
+          "dnsSettings": {
+            "domainNameLabel": "[variables('masterFqdnPrefix')]"
+          },
           "publicIpAllocationMethod": "Dynamic"
       }
     },

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -96,6 +96,9 @@ func Build(cfg *config.Config, subnetID string) (*Engine, error) {
 
 	if config.PublicSSHKey != "" {
 		cs.ContainerService.Properties.LinuxProfile.SSH.PublicKeys[0].KeyData = config.PublicSSHKey
+		if cs.ContainerService.Properties.OrchestratorProfile.KubernetesConfig != nil && cs.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster != nil && cs.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile != nil {
+			cs.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.PublicKey = config.PublicSSHKey
+		}
 	}
 
 	if config.WindowsAdminPasssword != "" {
@@ -177,6 +180,15 @@ func (e *Engine) HasAddon(name string) (bool, api.KubernetesAddon) {
 		}
 	}
 	return false, api.KubernetesAddon{}
+}
+
+// IsPrivate will return true if private cluster mode is enabled
+func (e *Engine) IsPrivate() bool {
+	kc := e.ClusterDefinition.Properties.OrchestratorProfile.KubernetesConfig
+	if kc != nil && kc.PrivateCluster != nil && *kc.PrivateCluster.Enabled {
+		return true
+	}
+	return false
 }
 
 // OrchestratorVersion1Dot8AndUp will return true if the orchestrator version is 1.8 and up

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -182,15 +182,6 @@ func (e *Engine) HasAddon(name string) (bool, api.KubernetesAddon) {
 	return false, api.KubernetesAddon{}
 }
 
-// IsPrivate will return true if private cluster mode is enabled
-func (e *Engine) IsPrivate() bool {
-	kc := e.ClusterDefinition.Properties.OrchestratorProfile.KubernetesConfig
-	if kc != nil && kc.PrivateCluster != nil && *kc.PrivateCluster.Enabled {
-		return true
-	}
-	return false
-}
-
 // OrchestratorVersion1Dot8AndUp will return true if the orchestrator version is 1.8 and up
 func (e *Engine) OrchestratorVersion1Dot8AndUp() bool {
 	return e.ClusterDefinition.ContainerService.Properties.OrchestratorProfile.OrchestratorVersion >= "1.8"

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -273,7 +273,7 @@ func (cli *CLIProvisioner) FetchProvisioningMetrics(path string, cfg *config.Con
 
 // IsPrivate will return true if the cluster has no public IPs
 func (cli *CLIProvisioner) IsPrivate() bool {
-	if cli.Config.IsKubernetes() && cli.Engine != nil && cli.Engine.ClusterDefinition != nil && cli.Engine.ClusterDefinition.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster != nil && helpers.IsTrueBoolPointer(cli.Engine.ClusterDefinition.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled) {
+	if cli.Config.IsKubernetes() && cli.Engine.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster != nil && helpers.IsTrueBoolPointer(cli.Engine.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled) {
 		return true
 	}
 	return false

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -201,16 +201,7 @@ func (cli *CLIProvisioner) waitForNodes() error {
 				return errors.New("Error: cannot test a private cluster without provisioning a jumpbox")
 			}
 			log.Printf("Testing a Kubernetes private cluster...")
-			// hostname := fmt.Sprintf("%s.%s.cloudapp.azure.com", cli.Config.Name, cli.Config.Location)
-			// conn, err := remote.NewConnection(hostname, "22", cli.Engine.ClusterDefinition.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Username, cli.Config.GetSSHKeyPath())
-			// if err != nil {
-			// 	return err
-			// }
-			// str, err := conn.Execute("kubectl get nodes -o json")
-			// if err != nil {
-			// 	return err
-			// }
-			// log.Printf("kubectl get nodes -o json\n %s", str)
+			// TODO: create SSH connection and get nodes and k8s version
 		}
 	}
 

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Azure/acs-engine/test/e2e/kubernetes/util"
 	"github.com/Azure/acs-engine/test/e2e/metrics"
 	"github.com/Azure/acs-engine/test/e2e/remote"
+	"github.com/Azure/fork/acs-engine/pkg/helpers"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -272,7 +273,7 @@ func (cli *CLIProvisioner) FetchProvisioningMetrics(path string, cfg *config.Con
 
 // IsPrivate will return true if the cluster has no public IPs
 func (cli *CLIProvisioner) IsPrivate() bool {
-	if cli.Config.IsKubernetes() && cli.Engine.ClusterDefinition.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster != nil && *cli.Engine.ClusterDefinition.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled {
+	if cli.Config.IsKubernetes() && cli.Engine != nil && cli.Engine.ClusterDefinition != nil && cli.Engine.ClusterDefinition.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster != nil && helpers.IsTrueBoolPointer(cli.Engine.ClusterDefinition.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.Enabled) {
 		return true
 	}
 	return false

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/acs-engine/pkg/helpers"
 	"github.com/Azure/acs-engine/test/e2e/azure"
 	"github.com/Azure/acs-engine/test/e2e/config"
 	"github.com/Azure/acs-engine/test/e2e/dcos"
@@ -19,7 +20,6 @@ import (
 	"github.com/Azure/acs-engine/test/e2e/kubernetes/util"
 	"github.com/Azure/acs-engine/test/e2e/metrics"
 	"github.com/Azure/acs-engine/test/e2e/remote"
-	"github.com/Azure/fork/acs-engine/pkg/helpers"
 	"github.com/kelseyhightower/envconfig"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Make e2e compatible with private cluster deployments (skips tests for now. TODO: add ssh connection to run tests from jumpbox)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
