### PR TITLE
timeout docker info command

### DIFF
--- a/parts/k8s/kubernetesmastercustomscript.sh
+++ b/parts/k8s/kubernetesmastercustomscript.sh
@@ -337,7 +337,7 @@ function ensureDocker() {
     if ! $REBOOTREQUIRED; then
         dockerStarted=1
         for i in {1..900}; do
-            if ! /usr/bin/docker info; then
+            if ! timeout 10s $DOCKER info; then
                 echo "status $?"
                 timeout 60s /bin/systemctl restart docker
             else


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: docker info can get stuck, so I enforce timeout upon thee

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
