### PR TITLE
[PoC] Add 'dump agent raw data' option for 'generate' command

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -173,7 +173,7 @@ func (gc *generateCmd) run() error {
 
 	if gc.dumpAgentRawData != "" {
 		if gc.containerService.Properties.OrchestratorProfile.OrchestratorType != api.Kubernetes {
-			return fmt.Errorf("Dumpping agent node raw data is not supported for orchestrator '%v'", gc.containerService.Properties.OrchestratorProfile)
+			return fmt.Errorf("Dumping agent node raw data is not supported for orchestrator '%v'", gc.containerService.Properties.OrchestratorProfile)
 		}
 
 		customDataDump, provisionScriptDump, err := templateGenerator.GenerateKubernetesAgentRawData(gc.containerService, gc.dumpAgentRawData)

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -363,7 +363,7 @@ func (t *TemplateGenerator) generateKubernetesAgentCustomData(cs *api.ContainerS
 	}
 
 	customDataTemplate := kubernetesAgentCustomDataYaml
-	if profile.OSType == "Windows" {
+	if profile.OSType == api.Windows {
 		customDataTemplate = kubernetesWindowsAgentCustomDataPS1
 	}
 


### PR DESCRIPTION
After a cluster is provisioned, sometimes a user might want to add extra agent nodes by themselves. All they need is the custom data and the provision script. Today the user will have to dig into the ARM template generated to find those, which is kind of hard. The user needs to know which custom data to look at and the provision script is even base64 encoded.

This change can optionally dump the raw data (aka. custom data and provision script) when generating the ARM template. Later, the user can leverage the dumped files to add new agent nodes.

**How is this different from scale command?**
1. No dependency on acs-engine. Users can directly use the dumped files to provision new agent nodes
2. No limited to existing agent pools. Scale command only supports scale an existing agent pool. With dumped files, users can freely add agent nodes in existing or new agent pools.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
