### PR TITLE
fixed nil o.OrchestratorVersion panic

### DIFF
--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -89,11 +89,18 @@ func (o *OrchestratorProfile) Validate(isUpdate bool) error {
 					return err
 				}
 				if o.KubernetesConfig.EnableAggregatedAPIs {
-					sv, _ := semver.NewVersion(o.OrchestratorVersion)
-					cons, _ := semver.NewConstraint("<" + "1.7.0")
+					sv, err := semver.NewVersion(version)
+					if err != nil {
+						return fmt.Errorf("could not validate version %s", version)
+					}
+					minVersion := "1.7.0"
+					cons, err := semver.NewConstraint("<" + minVersion)
+					if err != nil {
+						return fmt.Errorf("could not apply semver constraint < %s against version %s", minVersion, version)
+					}
 					if cons.Check(sv) {
 						return fmt.Errorf("enableAggregatedAPIs is only available in Kubernetes version %s or greater; unable to validate for Kubernetes version %s",
-							"1.7.0", o.OrchestratorVersion)
+							minVersion, version)
 					}
 
 					if o.KubernetesConfig.EnableRbac != nil {
@@ -103,11 +110,17 @@ func (o *OrchestratorProfile) Validate(isUpdate bool) error {
 					}
 
 					if helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableDataEncryptionAtRest) {
-						sv, _ := semver.NewVersion(o.OrchestratorVersion)
-						cons, _ := semver.NewConstraint("<" + "1.7.0")
+						sv, err := semver.NewVersion(version)
+						if err != nil {
+							return fmt.Errorf("could not validate version %s", version)
+						}
+						cons, err := semver.NewConstraint("<" + minVersion)
+						if err != nil {
+							return fmt.Errorf("could not apply semver constraint < %s against version %s", minVersion, version)
+						}
 						if cons.Check(sv) {
 							return fmt.Errorf("enableDataEncryptionAtRest is only available in Kubernetes version %s or greater; unable to validate for Kubernetes version %s",
-								"1.7.0", o.OrchestratorVersion)
+								minVersion, o.OrchestratorVersion)
 						}
 					}
 				}
@@ -115,11 +128,18 @@ func (o *OrchestratorProfile) Validate(isUpdate bool) error {
 					if !helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableRbac) {
 						return fmt.Errorf("enablePodSecurityPolicy requires the enableRbac feature as a prerequisite")
 					}
-					sv, _ := semver.NewVersion(o.OrchestratorVersion)
-					cons, _ := semver.NewConstraint("<" + "1.8.0")
+					sv, err := semver.NewVersion(version)
+					if err != nil {
+						return fmt.Errorf("could not validate version %s", version)
+					}
+					minVersion := "1.8.0"
+					cons, err := semver.NewConstraint("<" + minVersion)
+					if err != nil {
+						return fmt.Errorf("could not apply semver constraint < %s against version %s", minVersion, version)
+					}
 					if cons.Check(sv) {
 						return fmt.Errorf("enablePodSecurityPolicy is only supported in acs-engine for Kubernetes version %s or greater; unable to validate for Kubernetes version %s",
-							"1.8.0", o.OrchestratorVersion)
+							minVersion, version)
 					}
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Aggregated API validation is broken. Using rationalized verision to apply semver constraints against, and catching all semver errors.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2586

**Special notes for your reviewer**:

**If applicable**:
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
fix aggregated api bug when using orchestratorRelease
```