### PR TITLE
k8s 1.5 is deprecated, guarding against 1.6 incompatible kubelet features

### DIFF
--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -74,9 +74,9 @@ func setKubeletConfig(cs *api.ContainerService) {
 		o.KubernetesConfig.KubeletConfig[key] = val
 	}
 
-	// Get rid of values not supported in v1.5 clusters
-	if !common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.6.0") {
-		for _, key := range []string{"--non-masquerade-cidr", "--cgroups-per-qos", "--enforce-node-allocatable"} {
+	// Get rid of values not supported in v1.6 clusters
+	if !common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.7.0") {
+		for _, key := range []string{"--cgroups-per-qos", "--enforce-node-allocatable"} {
 			delete(o.KubernetesConfig.KubeletConfig, key)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: // TODO

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
restore k8s 1.6 cluster deployments
```
