### PR TITLE
k8s apiserver --oidc properties are user-overridable

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -312,6 +312,10 @@ Below is a list of apiserver options that acs-engine will configure by default:
 |"--audit-log-maxbackup"|"10"|
 |"--audit-log-maxsize"|"100"|
 |"--feature-gates"|No default (can be a comma-separated list)|
+|"--oidc-username-claim"|"oid" (*if has AADProfile*)|
+|"--oidc-groups-claim"|"groups" (*if has AADProfile*)|
+|"--oidc-client-id"|*calculated value that represents OID client ID* (*if has AADProfile*)|
+|"--oidc-issuer-url"|*calculated value that represents OID issuer URL* (*if has AADProfile*)|
 
 
 Below is a list of apiserver options that are *not* currently user-configurable, either because a higher order configuration vector is available that enforces apiserver configuration, or because a static configuration is required to build a functional cluster:
@@ -352,10 +356,6 @@ Below is a list of apiserver options that are *not* currently user-configurable,
 |"--requestheader-username-headers"|"X-Remote-User" (*if enableAggregatedAPIs is true*)|
 |"--cloud-provider"|"azure" (*unless useCloudControllerManager is true*)|
 |"--cloud-config"|"/etc/kubernetes/azure.json" (*unless useCloudControllerManager is true*)|
-|"--oidc-username-claim"|"oid" (*if has AADProfile*)|
-|"--oidc-groups-claim"|"groups" (*if has AADProfile*)|
-|"--oidc-client-id"|*calculated value that represents OID client ID* (*if has AADProfile*)|
-|"--oidc-issuer-url"|*calculated value that represents OID issuer URL* (*if has AADProfile*)|
 
 <a name="feat-scheduler-config"></a>
 #### schedulerConfig

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -78,12 +78,12 @@ func setAPIServerConfig(cs *api.ContainerService) {
 	if cs.Properties.HasAadProfile() {
 		defaultAPIServerConfig["--oidc-username-claim"] = "oid"
 		defaultAPIServerConfig["--oidc-groups-claim"] = "groups"
-		staticLinuxAPIServerConfig["--oidc-client-id"] = "spn:" + cs.Properties.AADProfile.ServerAppID
+		defaultAPIServerConfig["--oidc-client-id"] = "spn:" + cs.Properties.AADProfile.ServerAppID
 		issuerHost := "sts.windows.net"
 		if GetCloudTargetEnv(cs.Location) == "AzureChinaCloud" {
 			issuerHost = "sts.chinacloudapi.cn"
 		}
-		staticLinuxAPIServerConfig["--oidc-issuer-url"] = "https://" + issuerHost + "/" + cs.Properties.AADProfile.TenantID + "/"
+		defaultAPIServerConfig["--oidc-issuer-url"] = "https://" + issuerHost + "/" + cs.Properties.AADProfile.TenantID + "/"
 	}
 
 	// Audit Policy configuration

--- a/pkg/acsengine/defaults-apiserver_test.go
+++ b/pkg/acsengine/defaults-apiserver_test.go
@@ -146,19 +146,31 @@ func TestAPIServerConfigHasAadProfile(t *testing.T) {
 	}
 	usernameClaimOverride := "custom-username-claim"
 	groupsClaimOverride := "custom-groups-claim"
+	clientIDOverride := "custom-client-id"
+	issuerURLOverride := "custom-issuer-url"
 	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = map[string]string{
 		"--oidc-username-claim": usernameClaimOverride,
 		"--oidc-groups-claim":   groupsClaimOverride,
+		"--oidc-client-id":      clientIDOverride,
+		"--oidc-issuer-url":     issuerURLOverride,
 	}
 	setAPIServerConfig(cs)
 	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
 	if a["--oidc-username-claim"] != usernameClaimOverride {
-		t.Fatalf("got unexpected '--oidc-username-claim' API server config value for HasAadProfile=true: %s",
-			a["--oidc-username-claim"])
+		t.Fatalf("got unexpected '--oidc-username-claim' API server config value when user override provided: %s, expected: %s",
+			a["--oidc-username-claim"], usernameClaimOverride)
 	}
 	if a["--oidc-groups-claim"] != groupsClaimOverride {
-		t.Fatalf("got unexpected '--oidc-groups-claim' API server config value for HasAadProfile=true: %s",
-			a["--oidc-groups-claim"])
+		t.Fatalf("got unexpected '--oidc-groups-claim' API server config value when user override provided: %s, expected: %s",
+			a["--oidc-groups-claim"], groupsClaimOverride)
+	}
+	if a["--oidc-client-id"] != clientIDOverride {
+		t.Fatalf("got unexpected '--oidc-client-id' API server config value when user override provided: %s, expected: %s",
+			a["--oidc-client-id"], clientIDOverride)
+	}
+	if a["--oidc-issuer-url"] != issuerURLOverride {
+		t.Fatalf("got unexpected '--oidc-issuer-url' API server config value when user override provided: %s, expected: %s",
+			a["--oidc-issuer-url"], issuerURLOverride)
 	}
 
 	// Test China Cloud settings


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Enables the remaining --oidc options to be user-overridable.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2112

**Special notes for your reviewer**:

**If applicable**:
- [x] documentation
- [x] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
k8s apiserver --oidc properties are user-overridable
```