### PR TITLE
attach NSGs to nics, not to the subnet

### DIFF
--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -5,20 +5,17 @@
         "name": "loop"
       },
       "dependsOn": [
-{{if .IsCustomVNET}}
-      "[variables('nsgID')]"
-{{else}}
-      "[variables('vnetID')]"
+{{if not .IsCustomVNET}}
+      "[variables('vnetID')]",
 {{end}}
+      "[variables('nsgID')]"
       ],
       "location": "[variables('location')]",
       "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
       "properties": {
-{{if .IsCustomVNET}}
         "networkSecurityGroup": {
           "id": "[variables('nsgID')]"
         },
-{{end}}
         "ipConfigurations": [
           {{range $seq := loop 1 .IPAddressCount}}
           {

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -38,9 +38,7 @@
     {
       "apiVersion": "[variables('apiVersionDefault')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgName'))]"
 {{if not IsAzureCNI}}
-        ,
         "[concat('Microsoft.Network/routeTables/', variables('routeTableName'))]"
 {{end}}
       ],
@@ -56,10 +54,7 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnet')]",
-              "networkSecurityGroup": {
-                "id": "[variables('nsgID')]"
-              }
+              "addressPrefix": "[variables('subnet')]"
 {{if not IsAzureCNI}}
               ,
               "routeTable": {
@@ -236,9 +231,8 @@
         "name": "nicLoopNode"
       },
       "dependsOn": [
-{{if .MasterProfile.IsCustomVNET}}
         "[variables('nsgID')]",
-{{else}}
+{{if not .MasterProfile.IsCustomVNET}}
         "[variables('vnetID')]",
 {{end}}
         "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')))]"
@@ -297,11 +291,9 @@
         ,
         "enableIPForwarding": true
 {{end}}
-{{if .MasterProfile.IsCustomVNET}}
         ,"networkSecurityGroup": {
           "id": "[variables('nsgID')]"
         }
-{{end}}
       },
       "type": "Microsoft.Network/networkInterfaces"
     },
@@ -313,11 +305,10 @@
           "name": "nicLoopNode"
         },
         "dependsOn": [
-  {{if .MasterProfile.IsCustomVNET}}
           "[variables('nsgID')]"
-  {{else}}
-          "[variables('vnetID')]"
-  {{end}}
+{{if not .MasterProfile.IsCustomVNET}}
+          ,"[variables('vnetID')]"
+{{end}}
   {{if gt .MasterProfile.Count 1}}
           ,"[variables('masterInternalLbName')]"
   {{end}}
@@ -366,11 +357,9 @@
           ,
           "enableIPForwarding": true
   {{end}}
-  {{if .MasterProfile.IsCustomVNET}}
           ,"networkSecurityGroup": {
             "id": "[variables('nsgID')]"
           }
-  {{end}}
         },
         "type": "Microsoft.Network/networkInterfaces"
       },


### PR DESCRIPTION
This PR attaches the NSG to the nics, not to the subnet, in k8s deployments.  This is a precursor to being able to attach different NSGs to different VMs where required.