### PR TITLE
remove deprecated etcd-quorum-read flag from apiserver

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -297,7 +297,7 @@ Or perhaps you want to customize/override the set of admission-control flags pas
           "--admission-control":  "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"
         }
       }
-    } 
+    }
 ```
 
 See [here](https://kubernetes.io/docs/reference/generated/kube-apiserver/) for a reference of supported apiserver options.
@@ -334,7 +334,6 @@ Below is a list of apiserver options that are *not* currently user-configurable,
 |"--etcd-certfile"|"/etc/kubernetes/certs/etcdclient.crt"|
 |"--etcd-keyfile"|"/etc/kubernetes/certs/etcdclient.key"|
 |"--etcd-servers"|*calculated value that represents etcd servers*|
-|"--etcd-quorum-read"|"true"|
 |"--profiling"|"false"|
 |"--repair-malformed-updates"|"false"|
 |"--tls-cert-file"|"/etc/kubernetes/certs/apiserver.crt"|

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -23,7 +23,6 @@ func setAPIServerConfig(cs *api.ContainerService) {
 		"--etcd-certfile":              "/etc/kubernetes/certs/etcdclient.crt",
 		"--etcd-keyfile":               "/etc/kubernetes/certs/etcdclient.key",
 		"--etcd-servers":               "https://127.0.0.1:" + strconv.Itoa(DefaultMasterEtcdClientPort),
-		"--etcd-quorum-read":           "true",
 		"--tls-cert-file":              "/etc/kubernetes/certs/apiserver.crt",
 		"--tls-private-key-file":       "/etc/kubernetes/certs/apiserver.key",
 		"--client-ca-file":             "/etc/kubernetes/certs/ca.crt",


### PR DESCRIPTION
**What this PR does / why we need it**:
The apiserver flag `--etcd-quorum-read was deprecated in Kubernetes v1.9 and removed in v1.10 because setting it to false causes bugs in controllers because of stale reads. It is true by default in from >= v1.8 upward until v1.10, where it was removed entirely.

Note: starting in v1.7 users had this option, and had to explicitly disable etcd quorum reads if desired, so this shouldn't affect older acs-engine clusters nor should it affect upgrades. This is effectively a non-issue since we use etcd3 by default which is much more performant with reads.

More info:
- https://github.com/kubernetes/kubernetes/pull/53795


**If applicable**:
- [x] documentation
- [x] unit tests
- [x] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)
