### PR TITLE
Use latest patch of DefaultKubernetesRelease as default k8s version

### DIFF
--- a/pkg/api/apiloader_test.go
+++ b/pkg/api/apiloader_test.go
@@ -57,7 +57,7 @@ func TestLoadContainerServiceFromFile(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesDefaultVersion {
+	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.GetDefaultKubernetesVersion() {
 		t.Errorf("Failed  set orcherstator version when it is not set in the json, got %s", containerService.Properties.OrchestratorProfile.OrchestratorVersion)
 	}
 
@@ -65,7 +65,7 @@ func TestLoadContainerServiceFromFile(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesDefaultVersion {
+	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != common.GetDefaultKubernetesVersion() {
 		t.Errorf("Failed  set orcherstator version when it is not set in the json, got %s", containerService.Properties.OrchestratorProfile.OrchestratorVersion)
 	}
 }

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -53,8 +53,8 @@ const (
 )
 
 const (
-	// KubernetesDefaultVersion is the default Kubernetes version
-	KubernetesDefaultVersion string = "1.8.11"
+	// KubernetesDefaultRelease is the default Kubernetes release
+	KubernetesDefaultRelease string = "1.8"
 )
 
 const (

--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -54,7 +54,7 @@ const (
 
 const (
 	// KubernetesDefaultVersion is the default Kubernetes version
-	KubernetesDefaultVersion string = "1.8.9"
+	KubernetesDefaultVersion string = "1.8.11"
 )
 
 const (

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -50,12 +50,17 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.10.0":        true,
 }
 
+// GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release
+func GetDefaultKubernetesVersion() string {
+	return GetLatestPatchVersion(KubernetesDefaultRelease, GetAllSupportedKubernetesVersions())
+}
+
 // GetSupportedKubernetesVersion verifies that a passed-in version string is supported, or returns a default version string if not
 func GetSupportedKubernetesVersion(version string) string {
 	if k8sVersion := version; AllKubernetesSupportedVersions[k8sVersion] {
 		return k8sVersion
 	}
-	return KubernetesDefaultVersion
+	return GetDefaultKubernetesVersion()
 }
 
 // GetAllSupportedKubernetesVersions returns a slice of all supported Kubernetes versions
@@ -214,9 +219,9 @@ func GetSupportedVersions(orchType string, hasWindows bool) (versions []string, 
 	switch orchType {
 	case Kubernetes:
 		if hasWindows {
-			return GetAllSupportedKubernetesVersionsWindows(), string(KubernetesDefaultVersion)
+			return GetAllSupportedKubernetesVersionsWindows(), GetDefaultKubernetesVersion()
 		}
-		return GetAllSupportedKubernetesVersions(), string(KubernetesDefaultVersion)
+		return GetAllSupportedKubernetesVersions(), GetDefaultKubernetesVersion()
 
 	case DCOS:
 		return AllDCOSSupportedVersions, DCOSDefaultVersion

--- a/pkg/api/common/versions_test.go
+++ b/pkg/api/common/versions_test.go
@@ -28,8 +28,8 @@ func Test_GetSupportedKubernetesVersion(t *testing.T) {
 	}
 
 	defaultVersion := GetSupportedKubernetesVersion("")
-	if defaultVersion != KubernetesDefaultVersion {
-		t.Errorf("GetSupportedKubernetesVersion(\"\") should return the default version %s, instead returned %s", KubernetesDefaultVersion, defaultVersion)
+	if defaultVersion != GetDefaultKubernetesVersion() {
+		t.Errorf("GetSupportedKubernetesVersion(\"\") should return the default version %s, instead returned %s", GetDefaultKubernetesVersion(), defaultVersion)
 	}
 }
 
@@ -222,7 +222,7 @@ func TestGetVersionsBetween(t *testing.T) {
 
 func Test_GetValidPatchVersion(t *testing.T) {
 	v := GetValidPatchVersion(Kubernetes, "")
-	if v != KubernetesDefaultVersion {
+	if v != GetDefaultKubernetesVersion() {
 		t.Errorf("It is not the default Kubernetes version")
 	}
 
@@ -314,7 +314,7 @@ func TestGetMaxVersion(t *testing.T) {
 
 func Test_RationalizeReleaseAndVersion(t *testing.T) {
 	version := RationalizeReleaseAndVersion(Kubernetes, "", "", false)
-	if version != KubernetesDefaultVersion {
+	if version != GetDefaultKubernetesVersion() {
 		t.Errorf("It is not the default Kubernetes version")
 	}
 

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -528,7 +528,7 @@ func convertV20160330OrchestratorProfile(v20160330 *v20160330.OrchestratorProfil
 func convertV20170131OrchestratorProfile(v20170131 *v20170131.OrchestratorProfile, api *OrchestratorProfile) {
 	api.OrchestratorType = v20170131.OrchestratorType
 	if api.OrchestratorType == Kubernetes {
-		api.OrchestratorVersion = common.KubernetesDefaultVersion
+		api.OrchestratorVersion = common.GetDefaultKubernetesVersion()
 	} else if api.OrchestratorType == DCOS {
 		api.OrchestratorVersion = DCOSVersion1Dot9Dot8
 	}

--- a/pkg/api/convertertoapi_test.go
+++ b/pkg/api/convertertoapi_test.go
@@ -86,7 +86,7 @@ func TestOrchestratorVersion(t *testing.T) {
 		},
 	}
 	cs := ConvertV20170701ContainerService(v20170701cs)
-	if cs.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesDefaultVersion {
+	if cs.Properties.OrchestratorProfile.OrchestratorVersion != common.GetDefaultKubernetesVersion() {
 		t.Fatalf("incorrect OrchestratorVersion '%s'", cs.Properties.OrchestratorProfile.OrchestratorVersion)
 	}
 
@@ -111,7 +111,7 @@ func TestOrchestratorVersion(t *testing.T) {
 		},
 	}
 	cs = ConvertVLabsContainerService(vlabscs)
-	if cs.Properties.OrchestratorProfile.OrchestratorVersion != common.KubernetesDefaultVersion {
+	if cs.Properties.OrchestratorProfile.OrchestratorVersion != common.GetDefaultKubernetesVersion() {
 		t.Fatalf("incorrect OrchestratorVersion '%s'", cs.Properties.OrchestratorProfile.OrchestratorVersion)
 	}
 

--- a/pkg/api/orchestrators.go
+++ b/pkg/api/orchestrators.go
@@ -127,7 +127,7 @@ func kubernetesInfo(csOrch *OrchestratorProfile) ([]*OrchestratorVersionProfile,
 						OrchestratorType:    Kubernetes,
 						OrchestratorVersion: ver,
 					},
-					Default:  ver == common.KubernetesDefaultVersion,
+					Default:  ver == common.GetDefaultKubernetesVersion(),
 					Upgrades: upgrades,
 				})
 		}
@@ -154,7 +154,7 @@ func kubernetesInfo(csOrch *OrchestratorProfile) ([]*OrchestratorVersionProfile,
 					OrchestratorType:    Kubernetes,
 					OrchestratorVersion: csOrch.OrchestratorVersion,
 				},
-				Default:  csOrch.OrchestratorVersion == common.KubernetesDefaultVersion,
+				Default:  csOrch.OrchestratorVersion == common.GetDefaultKubernetesVersion(),
 				Upgrades: upgrades,
 			})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Update k8s default version from 1.8.9 to 1.8.11

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
