### PR TITLE
Adding parameter to specify more master SANs

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -421,6 +421,7 @@ We consider `kubeletConfig`, `controllerManagerConfig`, `apiServerConfig`, and `
 |---|---|---|
 |count|yes|Masters have count value of 1, 3, or 5 masters|
 |dnsPrefix|yes|The dns prefix for the master FQDN.  The master FQDN is used for SSH or commandline access. This must be a unique name. ([bring your own VNET examples](../examples/vnet))|
+|subjectAltNames|no|An array of fully qualified domain names using which a user can reach API server. These domains are added as Subject Alternative Names to the generated API server certificate. **NOTE**: These domains **will not** be automatically provisioned.|
 |firstConsecutiveStaticIP|only required when vnetSubnetId specified|The IP address of the first master.  IP Addresses will be assigned consecutively to additional master nodes|
 |vmsize|yes|Describes a valid [Azure VM Sizes](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-windows-sizes/). These are restricted to machines with at least 2 cores and 100GB of ephemeral disk space|
 |osDiskSizeGB|no|Describes the OS Disk Size in GB|

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -761,7 +761,7 @@ func setDefaultCerts(a *api.Properties) (bool, error) {
 		return false, nil
 	}
 
-	masterExtraFQDNs := FormatAzureProdFQDNs(a.MasterProfile.DNSPrefix)
+	masterExtraFQDNs := append(FormatAzureProdFQDNs(a.MasterProfile.DNSPrefix), a.MasterProfile.SubjectAltNames...)
 	firstMasterIP := net.ParseIP(a.MasterProfile.FirstConsecutiveStaticIP).To4()
 
 	if firstMasterIP == nil {

--- a/pkg/acsengine/pki_test.go
+++ b/pkg/acsengine/pki_test.go
@@ -3,6 +3,8 @@ package acsengine
 import (
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/pem"
+	"net"
 	"testing"
 )
 
@@ -79,5 +81,95 @@ func TestCreateCertificateWithoutOrganisation(t *testing.T) {
 
 	if len(certificationOrganization) != 0 {
 		t.Fatalf("certificate organisation should be empty but has length %d", len(certificationOrganization))
+	}
+}
+
+func TestSubjectAltNameInCert(t *testing.T) {
+	dnsPrefix := "santest"
+	extraIPs := []net.IP{net.ParseIP("10.255.255.5"), net.ParseIP("10.255.255.15")}
+	roots := x509.NewCertPool()
+
+	// Prepare CA and add it to certificate store.
+	caCertificate, caPrivateKey, err := createCertificate("ca", nil, nil, false, false, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to generate CA certificates: %s.", err)
+	}
+	caPair := &PkiKeyCertPair{CertificatePem: string(certificateToPem(caCertificate.Raw)), PrivateKeyPem: string(privateKeyToPem(caPrivateKey))}
+
+	ok := roots.AppendCertsFromPEM([]byte(caPair.CertificatePem))
+	if !ok {
+		t.Fatalf("failed to parse generated CA certificate.")
+	}
+
+	// Test SAN is not empty
+	SubjectAltNames := []string{"santest.mydomain.com", "santest2.testdomain.net"}
+	masterExtraFQDNs := append(FormatAzureProdFQDNs(dnsPrefix), SubjectAltNames...)
+	expectedDNSNames := []string{"santest.australiaeast.cloudapp.azure.com", "santest.australiasoutheast.cloudapp.azure.com", "santest.brazilsouth.cloudapp.azure.com", "santest.canadacentral.cloudapp.azure.com", "santest.canadaeast.cloudapp.azure.com", "santest.centralindia.cloudapp.azure.com", "santest.centralus.cloudapp.azure.com", "santest.centraluseuap.cloudapp.azure.com", "santest.chinaeast.cloudapp.chinacloudapi.cn", "santest.chinanorth.cloudapp.chinacloudapi.cn", "santest.eastasia.cloudapp.azure.com", "santest.eastus.cloudapp.azure.com", "santest.eastus2.cloudapp.azure.com", "santest.eastus2euap.cloudapp.azure.com", "santest.japaneast.cloudapp.azure.com", "santest.japanwest.cloudapp.azure.com", "santest.koreacentral.cloudapp.azure.com", "santest.koreasouth.cloudapp.azure.com", "santest.northcentralus.cloudapp.azure.com", "santest.northeurope.cloudapp.azure.com", "santest.southcentralus.cloudapp.azure.com", "santest.southeastasia.cloudapp.azure.com", "santest.southindia.cloudapp.azure.com", "santest.uksouth.cloudapp.azure.com", "santest.ukwest.cloudapp.azure.com", "santest.westcentralus.cloudapp.azure.com", "santest.westeurope.cloudapp.azure.com", "santest.westindia.cloudapp.azure.com", "santest.westus.cloudapp.azure.com", "santest.westus2.cloudapp.azure.com", "santest.chinaeast.cloudapp.chinacloudapi.cn", "santest.chinanorth.cloudapp.chinacloudapi.cn", "santest.germanycentral.cloudapp.microsoftazure.de", "santest.germanynortheast.cloudapp.microsoftazure.de", "santest.usgovvirginia.cloudapp.usgovcloudapi.net", "santest.usgoviowa.cloudapp.usgovcloudapi.net", "santest.usgovarizona.cloudapp.usgovcloudapi.net", "santest.usgovtexas.cloudapp.usgovcloudapi.net", "santest.francecentral.cloudapp.azure.com", "santest.mydomain.com", "santest2.testdomain.net", "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc.cluster.local", "kubernetes.kube-system", "kubernetes.kube-system.svc", "kubernetes.kube-system.svc.cluster.local"}
+
+	apiServerPair, _, _, _, _, _, err := CreatePki(masterExtraFQDNs, extraIPs, DefaultKubernetesClusterDomain, caPair, 1)
+
+	if err != nil {
+		t.Fatalf("failed to generate certificates: %s.", err)
+	}
+
+	if apiServerPair != nil {
+		block, _ := pem.Decode([]byte(apiServerPair.CertificatePem))
+		if block == nil {
+			panic("failed to parse certificate PEM")
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+
+		if err != nil {
+			t.Fatalf("Can not parse generated certificate %s", err)
+		}
+
+		for _, domain := range expectedDNSNames {
+			opts := x509.VerifyOptions{
+				DNSName: domain,
+				Roots:   roots,
+			}
+
+			if _, err := cert.Verify(opts); err != nil {
+				t.Fatalf("failed to verify certificate: %s", err)
+			}
+		}
+	} else {
+		t.Fatalf("API server pair not generated.")
+	}
+
+	// Test SAN is empty
+	SubjectAltNames = []string{}
+	masterExtraFQDNs = append(FormatAzureProdFQDNs(dnsPrefix), SubjectAltNames...)
+	expectedDNSNames = []string{"santest.australiaeast.cloudapp.azure.com", "santest.australiasoutheast.cloudapp.azure.com", "santest.brazilsouth.cloudapp.azure.com", "santest.canadacentral.cloudapp.azure.com", "santest.canadaeast.cloudapp.azure.com", "santest.centralindia.cloudapp.azure.com", "santest.centralus.cloudapp.azure.com", "santest.centraluseuap.cloudapp.azure.com", "santest.chinaeast.cloudapp.chinacloudapi.cn", "santest.chinanorth.cloudapp.chinacloudapi.cn", "santest.eastasia.cloudapp.azure.com", "santest.eastus.cloudapp.azure.com", "santest.eastus2.cloudapp.azure.com", "santest.eastus2euap.cloudapp.azure.com", "santest.japaneast.cloudapp.azure.com", "santest.japanwest.cloudapp.azure.com", "santest.koreacentral.cloudapp.azure.com", "santest.koreasouth.cloudapp.azure.com", "santest.northcentralus.cloudapp.azure.com", "santest.northeurope.cloudapp.azure.com", "santest.southcentralus.cloudapp.azure.com", "santest.southeastasia.cloudapp.azure.com", "santest.southindia.cloudapp.azure.com", "santest.uksouth.cloudapp.azure.com", "santest.ukwest.cloudapp.azure.com", "santest.westcentralus.cloudapp.azure.com", "santest.westeurope.cloudapp.azure.com", "santest.westindia.cloudapp.azure.com", "santest.westus.cloudapp.azure.com", "santest.westus2.cloudapp.azure.com", "santest.chinaeast.cloudapp.chinacloudapi.cn", "santest.chinanorth.cloudapp.chinacloudapi.cn", "santest.germanycentral.cloudapp.microsoftazure.de", "santest.germanynortheast.cloudapp.microsoftazure.de", "santest.usgovvirginia.cloudapp.usgovcloudapi.net", "santest.usgoviowa.cloudapp.usgovcloudapi.net", "santest.usgovarizona.cloudapp.usgovcloudapi.net", "santest.usgovtexas.cloudapp.usgovcloudapi.net", "santest.francecentral.cloudapp.azure.com", "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc.cluster.local", "kubernetes.kube-system", "kubernetes.kube-system.svc", "kubernetes.kube-system.svc.cluster.local"}
+
+	apiServerPair, _, _, _, _, _, err = CreatePki(masterExtraFQDNs, extraIPs, DefaultKubernetesClusterDomain, caPair, 1)
+
+	if err != nil {
+		t.Fatalf("failed to generate certificates: %s.", err)
+	}
+
+	if apiServerPair != nil {
+		block, _ := pem.Decode([]byte(apiServerPair.CertificatePem))
+		if block == nil {
+			panic("failed to parse certificate PEM")
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+
+		if err != nil {
+			t.Fatalf("Can not parse generated certificate %s", err)
+		}
+
+		for _, domain := range expectedDNSNames {
+			opts := x509.VerifyOptions{
+				DNSName: domain,
+				Roots:   roots,
+			}
+
+			if _, err := cert.Verify(opts); err != nil {
+				t.Fatalf("failed to verify certificate: %s", err)
+			}
+		}
+	} else {
+		t.Fatalf("API server pair not generated.")
 	}
 }

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -841,6 +841,7 @@ func convertMasterProfileToV20170701(api *MasterProfile, v20170701Profile *v2017
 func convertMasterProfileToVLabs(api *MasterProfile, vlabsProfile *vlabs.MasterProfile) {
 	vlabsProfile.Count = api.Count
 	vlabsProfile.DNSPrefix = api.DNSPrefix
+	vlabsProfile.SubjectAltNames = api.SubjectAltNames
 	vlabsProfile.VMSize = api.VMSize
 	vlabsProfile.OSDiskSizeGB = api.OSDiskSizeGB
 	vlabsProfile.VnetSubnetID = api.VnetSubnetID

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -829,6 +829,7 @@ func convertV20170701MasterProfile(v20170701 *v20170701.MasterProfile, api *Mast
 func convertVLabsMasterProfile(vlabs *vlabs.MasterProfile, api *MasterProfile) {
 	api.Count = vlabs.Count
 	api.DNSPrefix = vlabs.DNSPrefix
+	api.SubjectAltNames = vlabs.SubjectAltNames
 	api.VMSize = vlabs.VMSize
 	api.OSDiskSizeGB = vlabs.OSDiskSizeGB
 	api.VnetSubnetID = vlabs.VnetSubnetID

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -338,6 +338,7 @@ type OpenShiftConfig struct {
 type MasterProfile struct {
 	Count                    int               `json:"count"`
 	DNSPrefix                string            `json:"dnsPrefix"`
+	SubjectAltNames          []string          `json:"subjectAltNames"`
 	VMSize                   string            `json:"vmSize"`
 	OSDiskSizeGB             int               `json:"osDiskSizeGB,omitempty"`
 	VnetSubnetID             string            `json:"vnetSubnetID,omitempty"`

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -328,6 +328,7 @@ type OpenShiftConfig struct {
 type MasterProfile struct {
 	Count                    int               `json:"count" validate:"required,eq=1|eq=3|eq=5"`
 	DNSPrefix                string            `json:"dnsPrefix" validate:"required"`
+	SubjectAltNames          []string          `json:"subjectAltNames"`
 	VMSize                   string            `json:"vmSize" validate:"required"`
 	OSDiskSizeGB             int               `json:"osDiskSizeGB,omitempty" validate:"min=0,max=1023"`
 	VnetSubnetID             string            `json:"vnetSubnetID,omitempty"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Adding a new parameter to define more SAN's using which API servers can be reached using kubectl.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2614

**Special notes for your reviewer**:

**If applicable**:
- [x] documentation
- [x] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
