### PR TITLE
Update prometheus-grafana-k8s example and documentation

### DIFF
--- a/examples/extensions/prometheus-grafana-k8s.json
+++ b/examples/extensions/prometheus-grafana-k8s.json
@@ -7,19 +7,19 @@
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_DS2_v2"
+      "vmSize": "Standard_DS2_v2",
+      "extensions": [
+        {
+          "name": "prometheus-grafana-k8s"
+        }
+      ]
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
         "vmSize": "Standard_DS2_v2",
-        "availabilityProfile": "AvailabilitySet",
-        "extensions": [
-          {
-            "name": "prometheus-grafana-k8s"
-          }
-        ]
+        "availabilityProfile": "AvailabilitySet"
       }
     ],
     "linuxProfile": {

--- a/extensions/prometheus-grafana-k8s/README.md
+++ b/extensions/prometheus-grafana-k8s/README.md
@@ -13,19 +13,19 @@ This is the prometheus-grafana extension.  Add this extension to the api model y
     "masterProfile": {
       "count": 1,
       "dnsPrefix": "",
-      "vmSize": "Standard_DS2_v2"
+      "vmSize": "Standard_DS2_v2",
+      "extensions": [
+          {
+              "name": "prometheus-grafana-k8s"
+          }
+      ]
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 3,
         "vmSize": "Standard_DS2_v2",
-        "availabilityProfile": "AvailabilitySet",
-        "extensions": [
-          { 
-            "name": "prometheus-grafana-k8s"
-          }
-        ]
+        "availabilityProfile": "AvailabilitySet"
       }
     ],
     "linuxProfile": {
@@ -39,8 +39,8 @@ This is the prometheus-grafana extension.  Add this extension to the api model y
       }
     },
     "extensionProfiles": [
-      { 
-        "name": "prometheus-grafana-k8s", 
+      {
+        "name": "prometheus-grafana-k8s",
         "version": "v1",
         "rootURL": "https://raw.githubusercontent.com/Azure/acs-engine/master/"
       }
@@ -63,7 +63,33 @@ $ prometheus-grafana-k8s.sh
 You can validate that the extension is running as expected with the following commands:
 
 ```
-$ kubectl get pods --show-all
+$ kubectl get pods --all-namespaces
+
+NAMESPACE     NAME                                                        READY     STATUS    RESTARTS   AGE
+default       cadvisor-pshlh                                              1/1       Running   0          32m
+default       cadvisor-z84d6                                              1/1       Running   0          32m
+default       dashboard-grafana-5d864656b8-m47q4                          1/1       Running   0          31m
+default       monitoring-prometheus-kube-state-metrics-6bc48cd465-mfrzm   1/1       Running   0          32m
+default       monitoring-prometheus-node-exporter-74s6d                   1/1       Running   0          32m
+default       monitoring-prometheus-node-exporter-c44ff                   1/1       Running   0          32m
+default       monitoring-prometheus-pushgateway-d4f679b7-zstwf            1/1       Running   0          32m
+default       monitoring-prometheus-server-75bb797794-rmjft               2/2       Running   0          32m
+kube-system   calico-node-2b6tz                                           2/2       Running   0          34m
+kube-system   calico-node-cf29f                                           2/2       Running   0          34m
+kube-system   calico-node-x86bl                                           2/2       Running   0          34m
+kube-system   heapster-568476f785-hp8c6                                   2/2       Running   0          32m
+kube-system   kube-addon-manager-k8s-master-35213955-0                    1/1       Running   0          33m
+kube-system   kube-apiserver-k8s-master-35213955-0                        1/1       Running   2          33m
+kube-system   kube-controller-manager-k8s-master-35213955-0               1/1       Running   0          33m
+kube-system   kube-dns-v20-59b4f7dc55-hjc7q                               3/3       Running   0          34m
+kube-system   kube-dns-v20-59b4f7dc55-mqs7d                               3/3       Running   0          34m
+kube-system   kube-proxy-l8crw                                            1/1       Running   0          34m
+kube-system   kube-proxy-p966n                                            1/1       Running   0          34m
+kube-system   kube-proxy-zvjgk                                            1/1       Running   0          34m
+kube-system   kube-scheduler-k8s-master-35213955-0                        1/1       Running   0          33m
+kube-system   kubernetes-dashboard-64dcf5784f-sr464                       1/1       Running   0          34m
+kube-system   metrics-server-7fcdc5dbb9-6scj6                             1/1       Running   1          34m
+kube-system   tiller-deploy-d85ccb55c-rz897                               1/1       Running   0          34m
 
 $ NAMESPACE=default
 $ K8S_SECRET_NAME=dashboard-grafana


### PR DESCRIPTION
**What this PR does / why we need it**:
The current example of how to install the prometheus-grafana-k8s extension used the agentPoolProfile for it (I tried several times to deploy it this way and it didn't work), but the prometheus-grafana-k8s.sh executes some commands that only will work on the master so the installation of the extension must be done in the masterProfile instead.

- [x] documentation
- [x] tested deploying k8s cluster in Azure
