### PR TITLE
E2E ILB test only create service once

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -263,7 +263,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if eng.HasLinuxAgents() {
 				By("Creating a nginx deployment")
 				r := rand.New(rand.NewSource(time.Now().UnixNano()))
-				serviceName := "ingress-nginx"
+				serviceName := fmt.Sprintf("ingress-nginx-%v", r.Intn(99999))
 				deploymentName := fmt.Sprintf("ingress-nginx-%s-%v", cfg.Name, r.Intn(99999))
 				deploy, err := deployment.CreateLinuxDeploy("library/nginx:latest", deploymentName, "default", "--labels=app="+serviceName)
 				Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -263,7 +263,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if eng.HasLinuxAgents() {
 				By("Creating a nginx deployment")
 				r := rand.New(rand.NewSource(time.Now().UnixNano()))
-				serviceName := fmt.Sprintf("ingress-nginx-%v", r.Intn(99999))
+				serviceName := fmt.Sprintf("ingress-nginx")
 				deploymentName := fmt.Sprintf("ingress-nginx-%s-%v", cfg.Name, r.Intn(99999))
 				deploy, err := deployment.CreateLinuxDeploy("library/nginx:latest", deploymentName, "default", "--labels=app="+serviceName)
 				Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -263,7 +263,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			if eng.HasLinuxAgents() {
 				By("Creating a nginx deployment")
 				r := rand.New(rand.NewSource(time.Now().UnixNano()))
-				serviceName := fmt.Sprintf("ingress-nginx")
+				serviceName := "ingress-nginx"
 				deploymentName := fmt.Sprintf("ingress-nginx-%s-%v", cfg.Name, r.Intn(99999))
 				deploy, err := deployment.CreateLinuxDeploy("library/nginx:latest", deploymentName, "default", "--labels=app="+serviceName)
 				Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/kubernetes/service/service.go
+++ b/test/e2e/kubernetes/service/service.go
@@ -162,6 +162,11 @@ func (s *Service) Validate(check string, attempts int, sleep, wait time.Duration
 
 // CreateServiceFromFile will create a Service from file with a name
 func CreateServiceFromFile(filename, name, namespace string) (*Service, error) {
+	svc, err := Get(name, namespace)
+	if err == nil {
+		log.Printf("Service %s already exists\n", name)
+		return svc, nil
+	}
 	cmd := exec.Command("kubectl", "create", "-f", filename)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
@@ -169,7 +174,7 @@ func CreateServiceFromFile(filename, name, namespace string) (*Service, error) {
 		log.Printf("Error trying to create Service %s:%s\n", name, string(out))
 		return nil, err
 	}
-	svc, err := Get(name, namespace)
+	svc, err = Get(name, namespace)
 	if err != nil {
 		log.Printf("Error while trying to fetch Service %s:%s\n", name, err)
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Currently the ILB test will fail if the cluster already has an ingress-nginx service with error "AlreadyExists". Check if the service exists and only create one if it doesn't.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
