### PR TITLE
open prometheus metrics port of kube-dns

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-kube-dns-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-kube-dns-deployment.yaml
@@ -79,6 +79,9 @@ spec:
         - "--v=2"
         - "--config-dir=/kube-dns-config"
         image: <kubernetesKubeDNSSpec>
+        env:
+        - name: PROMETHEUS_PORT
+          value: "10055"
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -95,6 +98,9 @@ spec:
           protocol: UDP
         - containerPort: 10053
           name: dns-tcp-local
+          protocol: TCP
+        - containerPort: 10055
+          name: metrics
           protocol: TCP
         readinessProbe:
           httpGet:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR opens the prometheus metrics collection port for kube-dns.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Recently in our cluster, due to some unknown issue, the kube-dns was crashing continuously. We already had prometheus-alertmanager-grafana in place, but because of closed metrics port for kube-dns we could not monitor and set alerts on it. It took a while for us to figure out that kube-dns was crashing. This PR enables monitoring of kube-dns using prometheus.

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
