### PR TITLE
Validation logic backward compatibility support for custom VNET

### DIFF
--- a/pkg/acsengine/testdata/agentPoolOnly/v20180331/agentsWithFullNetworkProfile.json
+++ b/pkg/acsengine/testdata/agentPoolOnly/v20180331/agentsWithFullNetworkProfile.json
@@ -8,12 +8,19 @@
       {
         "name": "agentpool1",
         "count": 1,
-        "vmSize": "Standard_D2_v2"
+        "vmSize": "Standard_D2_v2",
+        "vnetSubnetID": "/subscriptions/mySubscription/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet"
       }
     ],
     "servicePrincipalProfile": {
       "clientID": "ServicePrincipalClientID",
       "secret": "myServicePrincipalClientSecret"
+    },
+    "networkProfile": {
+      "networkPlugin": "azure",
+      "serviceCidr": "10.0.0.0/8",
+      "dnsServiceIP": "10.0.0.10",
+      "dockerBridgeCidr": "172.17.0.1/32"
     }
   }
 }

--- a/pkg/acsengine/testdata/agentPoolOnly/v20180331/agentsWithOnlyNetworkPlugin.json
+++ b/pkg/acsengine/testdata/agentPoolOnly/v20180331/agentsWithOnlyNetworkPlugin.json
@@ -8,12 +8,16 @@
       {
         "name": "agentpool1",
         "count": 1,
-        "vmSize": "Standard_D2_v2"
+        "vmSize": "Standard_D2_v2",
+        "vnetSubnetID": "/subscriptions/mySubscription/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet"
       }
     ],
     "servicePrincipalProfile": {
       "clientID": "ServicePrincipalClientID",
       "secret": "myServicePrincipalClientSecret"
+    },
+    "networkProfile": {
+      "networkPlugin": "none"
     }
   }
 }

--- a/pkg/acsengine/testdata/agentPoolOnly/v20180331/agentsWithOnlyNetworkPlugin.json
+++ b/pkg/acsengine/testdata/agentPoolOnly/v20180331/agentsWithOnlyNetworkPlugin.json
@@ -17,7 +17,7 @@
       "secret": "myServicePrincipalClientSecret"
     },
     "networkProfile": {
-      "networkPlugin": "none"
+      "networkPlugin": "kubenet"
     }
   }
 }

--- a/pkg/api/agentPoolOnlyApi/v20180331/errors.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/errors.go
@@ -2,9 +2,6 @@ package v20180331
 
 import "fmt"
 
-// ErrorNilAgentPoolProfile error
-var ErrorNilAgentPoolProfile = fmt.Errorf("Agent pool profile can not be nil")
-
 // ErrorInvalidNetworkProfile error
 var ErrorInvalidNetworkProfile = fmt.Errorf("ServiceCidr, DNSServiceIP, DockerBridgeCidr should all be empty or neither should be empty")
 

--- a/pkg/api/agentPoolOnlyApi/v20180331/errors.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/errors.go
@@ -2,14 +2,14 @@ package v20180331
 
 import "fmt"
 
-// ErrorNilNetworkProfile error
-var ErrorNilNetworkProfile = fmt.Errorf("Network profile can not be nil")
-
 // ErrorNilAgentPoolProfile error
 var ErrorNilAgentPoolProfile = fmt.Errorf("Agent pool profile can not be nil")
 
+// ErrorInvalidNetworkProfile error
+var ErrorInvalidNetworkProfile = fmt.Errorf("ServiceCidr, DNSServiceIP, DockerBridgeCidr should all be empty or neither should be empty")
+
 // ErrorInvalidNetworkPlugin error
-var ErrorInvalidNetworkPlugin = fmt.Errorf("Network plugin should be either \"azure\" or \"kubenet\"")
+var ErrorInvalidNetworkPlugin = fmt.Errorf("Network plugin should be either Azure or Kubenet")
 
 // ErrorInvalidServiceCidr error
 var ErrorInvalidServiceCidr = fmt.Errorf("ServiceCidr is not a valid CIDR")
@@ -26,11 +26,8 @@ var ErrorDNSServiceIPNotInServiceCidr = fmt.Errorf("DNSServiceIP is not within S
 // ErrorDNSServiceIPAlreadyUsed error
 var ErrorDNSServiceIPAlreadyUsed = fmt.Errorf("DNSServiceIP can not be the first IP address in ServiceCidr")
 
-// ErrorAgentPoolNoSubnet error
-var ErrorAgentPoolNoSubnet = fmt.Errorf("Agent pool does not have subnet defined")
-
-// ErrorKubenetNoCustomization error
-var ErrorKubenetNoCustomization = fmt.Errorf("Kubenet does not support ServiceCidr or DNSServiceIP or DockerBridgeCidr customization")
+// ErrorAtLeastAgentPoolNoSubnet error
+var ErrorAtLeastAgentPoolNoSubnet = fmt.Errorf("At least one agent pool does not have subnet defined")
 
 // ErrorParsingSubnetID error
 var ErrorParsingSubnetID = fmt.Errorf("Failed to parse VnetSubnetID")

--- a/pkg/api/agentPoolOnlyApi/v20180331/types.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/types.go
@@ -59,7 +59,7 @@ const (
 	// Azure represents Azure CNI network plugin
 	Azure NetworkPlugin = "azure"
 	// Kubenet represents Kubenet network plugin
-	Kubenet NetworkPlugin = "none"
+	Kubenet NetworkPlugin = "kubenet"
 )
 
 // AddonProfile represents an addon for managed cluster

--- a/pkg/api/agentPoolOnlyApi/v20180331/types.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/types.go
@@ -59,7 +59,7 @@ const (
 	// Azure represents Azure CNI network plugin
 	Azure NetworkPlugin = "azure"
 	// Kubenet represents Kubenet network plugin
-	Kubenet NetworkPlugin = "kubenet"
+	Kubenet NetworkPlugin = "none"
 )
 
 // AddonProfile represents an addon for managed cluster

--- a/pkg/api/agentPoolOnlyApi/v20180331/validate.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/validate.go
@@ -192,8 +192,6 @@ func validateVNET(a *Properties) error {
 		if e := validateAgentPoolVNET(a.AgentPoolProfiles); e != nil {
 			return e
 		}
-	} else {
-		return ErrorNilAgentPoolProfile
 	}
 
 	return nil

--- a/pkg/api/agentPoolOnlyApi/v20180331/validate.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/validate.go
@@ -143,7 +143,8 @@ func validateVNET(a *Properties) error {
 
 	// validate network profile settings
 	if n != nil {
-		if string(n.NetworkPlugin) == string(Azure) || string(n.NetworkPlugin) == string(Kubenet) {
+		switch n.NetworkPlugin {
+		case Azure, Kubenet:
 			if n.ServiceCidr != "" && n.DNSServiceIP != "" && n.DockerBridgeCidr != "" {
 				// validate ServiceCidr
 				_, serviceCidr, err := net.ParseCIDR(n.ServiceCidr)
@@ -181,7 +182,7 @@ func validateVNET(a *Properties) error {
 			} else {
 				return ErrorInvalidNetworkProfile
 			}
-		} else {
+		default:
 			return ErrorInvalidNetworkPlugin
 		}
 	}

--- a/pkg/api/agentPoolOnlyApi/v20180331/validate.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/validate.go
@@ -141,108 +141,121 @@ func validateVNET(a *Properties) error {
 
 	n := a.NetworkProfile
 
-	if n == nil {
-		return ErrorNilNetworkProfile
-	}
-
-	if string(n.NetworkPlugin) == string(Azure) {
-		// validate ServiceCidr
-		_, serviceCidr, err := net.ParseCIDR(n.ServiceCidr)
-		if err != nil {
-			return ErrorInvalidServiceCidr
-		}
-
-		// validate DNSServiceIP
-		dnsServiceIP := net.ParseIP(n.DNSServiceIP)
-		if dnsServiceIP == nil {
-			return ErrorInvalidDNSServiceIP
-		}
-
-		// validate DockerBridgeCidr
-		_, _, err = net.ParseCIDR(n.DockerBridgeCidr)
-		if err != nil {
-			return ErrorInvalidDockerBridgeCidr
-		}
-
-		// validate DNSServiceIP is within ServiceCidr
-		if !serviceCidr.Contains(dnsServiceIP) {
-			return ErrorDNSServiceIPNotInServiceCidr
-		}
-
-		// validate DNSServiceIP is not the first IP in ServiceCidr. The first IP is reserved for redirect svc.
-		kubernetesServiceIP, err := common.CidrStringFirstIP(n.ServiceCidr)
-		if err != nil {
-			return ErrorInvalidServiceCidr
-		}
-		if dnsServiceIP.String() == kubernetesServiceIP.String() {
-			return ErrorDNSServiceIPAlreadyUsed
-		}
-
-		if a.AgentPoolProfiles == nil {
-			return ErrorNilAgentPoolProfile
-		}
-
-		// validate custom VNET logic
-		if isCustomVNET(a.AgentPoolProfiles) {
-			var subscription string
-			var resourceGroup string
-			var vnet string
-
-			for _, agentPool := range a.AgentPoolProfiles {
-				// validate subscription, resource group and vnet are the same among subnets
-				subnetSubscription, subnetResourceGroup, subnetVnet, _, err := GetVNETSubnetIDComponents(agentPool.VnetSubnetID)
+	// validate network profile settings
+	if n != nil {
+		if string(n.NetworkPlugin) == string(Azure) || string(n.NetworkPlugin) == string(Kubenet) {
+			if n.ServiceCidr != "" && n.DNSServiceIP != "" && n.DockerBridgeCidr != "" {
+				// validate ServiceCidr
+				_, serviceCidr, err := net.ParseCIDR(n.ServiceCidr)
 				if err != nil {
-					return ErrorParsingSubnetID
+					return ErrorInvalidServiceCidr
 				}
 
-				if subscription == "" {
-					subscription = subnetSubscription
-				} else {
-					if subscription != subnetSubscription {
-						return ErrorSubscriptionNotMatch
-					}
+				// validate DNSServiceIP
+				dnsServiceIP := net.ParseIP(n.DNSServiceIP)
+				if dnsServiceIP == nil {
+					return ErrorInvalidDNSServiceIP
 				}
 
-				if resourceGroup == "" {
-					resourceGroup = subnetResourceGroup
-				} else {
-					if resourceGroup != subnetResourceGroup {
-						return ErrorResourceGroupNotMatch
-					}
+				// validate DockerBridgeCidr
+				_, _, err = net.ParseCIDR(n.DockerBridgeCidr)
+				if err != nil {
+					return ErrorInvalidDockerBridgeCidr
 				}
 
-				if vnet == "" {
-					vnet = subnetVnet
-				} else {
-					if vnet != subnetVnet {
-						return ErrorVnetNotMatch
-					}
+				// validate DNSServiceIP is within ServiceCidr
+				if !serviceCidr.Contains(dnsServiceIP) {
+					return ErrorDNSServiceIPNotInServiceCidr
 				}
+
+				// validate DNSServiceIP is not the first IP in ServiceCidr. The first IP is reserved for redirect svc.
+				kubernetesServiceIP, err := common.CidrStringFirstIP(n.ServiceCidr)
+				if err != nil {
+					return ErrorInvalidServiceCidr
+				}
+				if dnsServiceIP.String() == kubernetesServiceIP.String() {
+					return ErrorDNSServiceIPAlreadyUsed
+				}
+			} else if n.ServiceCidr == "" && n.DNSServiceIP == "" && n.DockerBridgeCidr == "" {
+				// this is a valid case, and no validation needed.
+			} else {
+				return ErrorInvalidNetworkProfile
 			}
 		} else {
-			return ErrorAgentPoolNoSubnet
+			return ErrorInvalidNetworkPlugin
 		}
+	}
 
-	} else if string(n.NetworkPlugin) == string(Kubenet) {
-		if n.ServiceCidr != "" || n.DNSServiceIP != "" || n.DockerBridgeCidr != "" {
-			return ErrorKubenetNoCustomization
+	// validate agent pool custom VNET settings
+	if a.AgentPoolProfiles != nil {
+		if e := validateAgentPoolVNET(a.AgentPoolProfiles); e != nil {
+			return e
 		}
 	} else {
-		return ErrorInvalidNetworkPlugin
+		return ErrorNilAgentPoolProfile
 	}
 
 	return nil
 }
 
-func isCustomVNET(a []*AgentPoolProfile) bool {
+func validateAgentPoolVNET(a []*AgentPoolProfile) error {
 
-	for _, agentPool := range a {
-		if !agentPool.IsCustomVNET() {
-			return false
+	// validate custom VNET logic at agent pool level
+	if isCustomVNET(a) {
+		var subscription string
+		var resourceGroup string
+		var vnet string
+
+		for _, agentPool := range a {
+			// validate each agent pool has a subnet
+			if !agentPool.IsCustomVNET() {
+				return ErrorAtLeastAgentPoolNoSubnet
+			}
+
+			// validate subscription, resource group and vnet are the same among subnets
+			subnetSubscription, subnetResourceGroup, subnetVnet, _, err := GetVNETSubnetIDComponents(agentPool.VnetSubnetID)
+			if err != nil {
+				return ErrorParsingSubnetID
+			}
+
+			if subscription == "" {
+				subscription = subnetSubscription
+			} else {
+				if subscription != subnetSubscription {
+					return ErrorSubscriptionNotMatch
+				}
+			}
+
+			if resourceGroup == "" {
+				resourceGroup = subnetResourceGroup
+			} else {
+				if resourceGroup != subnetResourceGroup {
+					return ErrorResourceGroupNotMatch
+				}
+			}
+
+			if vnet == "" {
+				vnet = subnetVnet
+			} else {
+				if vnet != subnetVnet {
+					return ErrorVnetNotMatch
+				}
+			}
 		}
 	}
 
-	return true
+	return nil
+}
+
+// check agent pool subnet, return true as long as one agent pool has a subnet defined.
+func isCustomVNET(a []*AgentPoolProfile) bool {
+	for _, agentPool := range a {
+		if agentPool.IsCustomVNET() {
+			return true
+		}
+	}
+
+	return false
 }
 
 // GetVNETSubnetIDComponents extract subscription, resourcegroup, vnetname, subnetname from the vnetSubnetID

--- a/pkg/api/agentPoolOnlyApi/v20180331/validate_test.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/validate_test.go
@@ -124,25 +124,9 @@ func TestValidateVNET(t *testing.T) {
 		t.Errorf("Failed to validate VNET: %s", ErrorInvalidNetworkProfile)
 	}
 
-	// AgentPoolProfiles is nil
+	// NetworkPlugin is not azure or kubenet
 	n = &NetworkProfile{
-		NetworkPlugin:    NetworkPlugin("azure"),
-		ServiceCidr:      serviceCidr,
-		DNSServiceIP:     dNSServiceIP,
-		DockerBridgeCidr: dockerBridgeCidr,
-	}
-
-	a = &Properties{
-		NetworkProfile: n,
-	}
-
-	if err := validateVNET(a); err != ErrorNilAgentPoolProfile {
-		t.Errorf("Failed to throw error, %s", ErrorNilAgentPoolProfile)
-	}
-
-	// NetworkPlugin is not azure or kubenet or none
-	n = &NetworkProfile{
-		NetworkPlugin:    NetworkPlugin("notsupport"),
+		NetworkPlugin:    NetworkPlugin("none"),
 		ServiceCidr:      serviceCidr,
 		DNSServiceIP:     dNSServiceIP,
 		DockerBridgeCidr: dockerBridgeCidr,

--- a/pkg/api/agentPoolOnlyApi/v20180331/validate_test.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/validate_test.go
@@ -25,7 +25,7 @@ func TestValidateVNET(t *testing.T) {
 	maxPods1 := 20
 	maxPods2 := 50
 
-	// happy case
+	// all network profile fields have values, should pass
 	n := &NetworkProfile{
 		NetworkPlugin:    NetworkPlugin("azure"),
 		ServiceCidr:      serviceCidr,
@@ -53,7 +53,7 @@ func TestValidateVNET(t *testing.T) {
 		t.Errorf("Failed to validate VNET: %s", err)
 	}
 
-	// NetworkProfile is nil
+	// no network profile, this is prior v20180331 case, should pass
 	p = []*AgentPoolProfile{
 		{
 			VnetSubnetID: vnetSubnetID1,
@@ -69,8 +69,59 @@ func TestValidateVNET(t *testing.T) {
 		AgentPoolProfiles: p,
 	}
 
-	if err := validateVNET(a); err != ErrorNilNetworkProfile {
-		t.Errorf("Failed to throw error, %s", ErrorNilNetworkProfile)
+	if err := validateVNET(a); err != nil {
+		t.Errorf("Failed to validate VNET: %s", err)
+	}
+
+	// network profile has only NetworkPlugin field, should pass
+	n = &NetworkProfile{
+		NetworkPlugin: NetworkPlugin("azure"),
+	}
+
+	p = []*AgentPoolProfile{
+		{
+			VnetSubnetID: vnetSubnetID1,
+			MaxPods:      maxPods1,
+		},
+		{
+			VnetSubnetID: vnetSubnetID2,
+			MaxPods:      maxPods2,
+		},
+	}
+
+	a = &Properties{
+		NetworkProfile:    n,
+		AgentPoolProfiles: p,
+	}
+
+	if err := validateVNET(a); err != nil {
+		t.Errorf("Failed to validate VNET: %s", err)
+	}
+
+	// network profile has NetworkPlugin and ServiceCidr field, should fail
+	n = &NetworkProfile{
+		NetworkPlugin: NetworkPlugin("azure"),
+		ServiceCidr:   serviceCidr,
+	}
+
+	p = []*AgentPoolProfile{
+		{
+			VnetSubnetID: vnetSubnetID1,
+			MaxPods:      maxPods1,
+		},
+		{
+			VnetSubnetID: vnetSubnetID2,
+			MaxPods:      maxPods2,
+		},
+	}
+
+	a = &Properties{
+		NetworkProfile:    n,
+		AgentPoolProfiles: p,
+	}
+
+	if err := validateVNET(a); err != ErrorInvalidNetworkProfile {
+		t.Errorf("Failed to validate VNET: %s", ErrorInvalidNetworkProfile)
 	}
 
 	// AgentPoolProfiles is nil
@@ -89,7 +140,7 @@ func TestValidateVNET(t *testing.T) {
 		t.Errorf("Failed to throw error, %s", ErrorNilAgentPoolProfile)
 	}
 
-	// NetworkPlugin is not azure or kubenet
+	// NetworkPlugin is not azure or kubenet or none
 	n = &NetworkProfile{
 		NetworkPlugin:    NetworkPlugin("notsupport"),
 		ServiceCidr:      serviceCidr,
@@ -257,7 +308,7 @@ func TestValidateVNET(t *testing.T) {
 		t.Errorf("Failed to throw error, %s", ErrorDNSServiceIPAlreadyUsed)
 	}
 
-	// NetworkPlugin = Azure, Agent pool does not have subnet defined
+	// NetworkPlugin = Azure, at least one agent pool does not have subnet defined
 	n = &NetworkProfile{
 		NetworkPlugin:    NetworkPlugin("azure"),
 		ServiceCidr:      serviceCidr,
@@ -280,36 +331,8 @@ func TestValidateVNET(t *testing.T) {
 		AgentPoolProfiles: p,
 	}
 
-	if err := validateVNET(a); err != ErrorAgentPoolNoSubnet {
-		t.Errorf("Failed to throw error, %s", ErrorAgentPoolNoSubnet)
-	}
-
-	// NetworkPlugin = Kubenet, with customization
-	n = &NetworkProfile{
-		NetworkPlugin:    NetworkPlugin("kubenet"),
-		ServiceCidr:      serviceCidr,
-		DNSServiceIP:     dNSServiceIP,
-		DockerBridgeCidr: dockerBridgeCidr,
-	}
-
-	p = []*AgentPoolProfile{
-		{
-			VnetSubnetID: vnetSubnetID1,
-			MaxPods:      maxPods1,
-		},
-		{
-			VnetSubnetID: vnetSubnetID2,
-			MaxPods:      maxPods2,
-		},
-	}
-
-	a = &Properties{
-		NetworkProfile:    n,
-		AgentPoolProfiles: p,
-	}
-
-	if err := validateVNET(a); err != ErrorKubenetNoCustomization {
-		t.Errorf("Failed to throw error, %s", ErrorKubenetNoCustomization)
+	if err := validateVNET(a); err != ErrorAtLeastAgentPoolNoSubnet {
+		t.Errorf("Failed to throw error, %s", ErrorAtLeastAgentPoolNoSubnet)
 	}
 
 	// NetworkPlugin = Azure, Failed to parse VnetSubnetID

--- a/pkg/api/converterfromagentpoolonlyapi.go
+++ b/pkg/api/converterfromagentpoolonlyapi.go
@@ -191,7 +191,12 @@ func convertOrchestratorProfileToV20180331AgentPoolOnly(orchestratorProfile *Orc
 		k := orchestratorProfile.KubernetesConfig
 		if k.NetworkPolicy != "" || k.ServiceCIDR != "" || k.DNSServiceIP != "" || k.DockerBridgeSubnet != "" {
 			networkProfile = &v20180331.NetworkProfile{}
-			networkProfile.NetworkPlugin = v20180331.NetworkPlugin(k.NetworkPolicy)
+			// ACS-E uses "none" in the un-versioned model to represent kubenet.
+			if k.NetworkPolicy == "none" {
+				networkProfile.NetworkPlugin = v20180331.Kubenet
+			} else {
+				networkProfile.NetworkPlugin = v20180331.NetworkPlugin(k.NetworkPolicy)
+			}
 			networkProfile.ServiceCidr = k.ServiceCIDR
 			networkProfile.DNSServiceIP = k.DNSServiceIP
 			networkProfile.DockerBridgeCidr = k.DockerBridgeSubnet

--- a/pkg/api/converterfromagentpoolonlyapi.go
+++ b/pkg/api/converterfromagentpoolonlyapi.go
@@ -152,8 +152,7 @@ func convertPropertiesToV20180331AgentPoolOnly(api *Properties, p *v20180331.Pro
 
 	if api.OrchestratorProfile != nil {
 		p.EnableRBAC = convertKubernetesConfigToEnableRBACV20180331AgentPoolOnly(api.OrchestratorProfile.KubernetesConfig)
-		p.NetworkProfile = &v20180331.NetworkProfile{}
-		convertOrchestratorProfileToV20180331AgentPoolOnly(api.OrchestratorProfile, &p.KubernetesVersion, p.NetworkProfile)
+		p.KubernetesVersion, p.NetworkProfile = convertOrchestratorProfileToV20180331AgentPoolOnly(api.OrchestratorProfile)
 	}
 	if api.HostedMasterProfile != nil {
 		p.DNSPrefix = api.HostedMasterProfile.DNSPrefix
@@ -183,17 +182,23 @@ func convertPropertiesToV20180331AgentPoolOnly(api *Properties, p *v20180331.Pro
 	}
 }
 
-func convertOrchestratorProfileToV20180331AgentPoolOnly(orchestratorProfile *OrchestratorProfile, kubernetesVersion *string, networkProfile *v20180331.NetworkProfile) {
+func convertOrchestratorProfileToV20180331AgentPoolOnly(orchestratorProfile *OrchestratorProfile) (kubernetesVersion string, networkProfile *v20180331.NetworkProfile) {
 	if orchestratorProfile.OrchestratorVersion != "" {
-		*kubernetesVersion = orchestratorProfile.OrchestratorVersion
+		kubernetesVersion = orchestratorProfile.OrchestratorVersion
 	}
 
 	if orchestratorProfile.KubernetesConfig != nil {
-		networkProfile.NetworkPlugin = v20180331.NetworkPlugin(orchestratorProfile.KubernetesConfig.NetworkPolicy)
-		networkProfile.ServiceCidr = orchestratorProfile.KubernetesConfig.ServiceCIDR
-		networkProfile.DNSServiceIP = orchestratorProfile.KubernetesConfig.DNSServiceIP
-		networkProfile.DockerBridgeCidr = orchestratorProfile.KubernetesConfig.DockerBridgeSubnet
+		k := orchestratorProfile.KubernetesConfig
+		if k.NetworkPolicy != "" || k.ServiceCIDR != "" || k.DNSServiceIP != "" || k.DockerBridgeSubnet != "" {
+			networkProfile = &v20180331.NetworkProfile{}
+			networkProfile.NetworkPlugin = v20180331.NetworkPlugin(k.NetworkPolicy)
+			networkProfile.ServiceCidr = k.ServiceCIDR
+			networkProfile.DNSServiceIP = k.DNSServiceIP
+			networkProfile.DockerBridgeCidr = k.DockerBridgeSubnet
+		}
 	}
+
+	return kubernetesVersion, networkProfile
 }
 
 func convertLinuxProfileToV20180331AgentPoolOnly(api *LinuxProfile, obj *v20180331.LinuxProfile) {

--- a/pkg/api/converterfromagentpoolonlyapi_test.go
+++ b/pkg/api/converterfromagentpoolonlyapi_test.go
@@ -60,6 +60,10 @@ func TestConvertOrchestratorProfileToV20180331AgentPoolOnly(t *testing.T) {
 
 	version, p = convertOrchestratorProfileToV20180331AgentPoolOnly(api)
 
+	if version != orchestratorVersion {
+		t.Error("error in orchestrator profile orchestratorVersion conversion")
+	}
+
 	if p != nil {
 		t.Error("error in orchestrator profile networkProfile conversion")
 	}

--- a/pkg/api/converterfromagentpoolonlyapi_test.go
+++ b/pkg/api/converterfromagentpoolonlyapi_test.go
@@ -15,6 +15,7 @@ func TestConvertOrchestratorProfileToV20180331AgentPoolOnly(t *testing.T) {
 	dnsServiceIP := "10.0.0.10"
 	dockerBridgeSubnet := "172.17.0.1/16"
 
+	// all networkProfile related fields are defined in kubernetesConfig
 	kubernetesConfig := &KubernetesConfig{
 		NetworkPolicy:      networkPolicy,
 		ServiceCIDR:        serviceCIDR,
@@ -27,8 +28,8 @@ func TestConvertOrchestratorProfileToV20180331AgentPoolOnly(t *testing.T) {
 	}
 
 	var version string
-	p := &v20180331.NetworkProfile{}
-	convertOrchestratorProfileToV20180331AgentPoolOnly(api, &version, p)
+	var p *v20180331.NetworkProfile
+	version, p = convertOrchestratorProfileToV20180331AgentPoolOnly(api)
 
 	if version != orchestratorVersion {
 		t.Error("error in orchestrator profile orchestratorVersion conversion")
@@ -49,6 +50,51 @@ func TestConvertOrchestratorProfileToV20180331AgentPoolOnly(t *testing.T) {
 	if p.DockerBridgeCidr != dockerBridgeSubnet {
 		t.Error("error in orchestrator profile dockerBridgeCidr conversion")
 	}
+
+	// none networkProfile related fields are defined in kubernetesConfig
+	kubernetesConfig = &KubernetesConfig{}
+	api = &OrchestratorProfile{
+		OrchestratorVersion: orchestratorVersion,
+		KubernetesConfig:    kubernetesConfig,
+	}
+
+	version, p = convertOrchestratorProfileToV20180331AgentPoolOnly(api)
+
+	if p != nil {
+		t.Error("error in orchestrator profile networkProfile conversion")
+	}
+
+	// only networkProfile networkPolicy field is defined in kubernetesConfig
+	kubernetesConfig = &KubernetesConfig{
+		NetworkPolicy: networkPolicy,
+	}
+	api = &OrchestratorProfile{
+		OrchestratorVersion: orchestratorVersion,
+		KubernetesConfig:    kubernetesConfig,
+	}
+
+	version, p = convertOrchestratorProfileToV20180331AgentPoolOnly(api)
+
+	if version != orchestratorVersion {
+		t.Error("error in orchestrator profile orchestratorVersion conversion")
+	}
+
+	if string(p.NetworkPlugin) != networkPolicy {
+		t.Error("error in orchestrator profile networkPlugin conversion")
+	}
+
+	if p.ServiceCidr != "" {
+		t.Error("error in orchestrator profile serviceCidr conversion")
+	}
+
+	if p.DNSServiceIP != "" {
+		t.Error("error in orchestrator profile dnsServiceIP conversion")
+	}
+
+	if p.DockerBridgeCidr != "" {
+		t.Error("error in orchestrator profile dockerBridgeCidr conversion")
+	}
+
 }
 
 func TestConvertAgentPoolProfileToV20180331AgentPoolOnly(t *testing.T) {

--- a/pkg/api/convertertoagentpoolonlyapi.go
+++ b/pkg/api/convertertoagentpoolonlyapi.go
@@ -19,6 +19,15 @@ import (
 // for converting.
 ///////////////////////////////////////////////////////////
 
+const (
+	// DefaultKubernetesServiceCIDR specifies the IP subnet that kubernetes will create Service IPs within.
+	DefaultKubernetesServiceCIDR = "10.0.0.0/16"
+	// DefaultKubernetesDNSServiceIP specifies the IP address that kube-dns listens on by default. must by in the default Service CIDR range.
+	DefaultKubernetesDNSServiceIP = "10.0.0.10"
+	// DefaultDockerBridgeSubnet specifies the default subnet for the docker bridge network for masters and agents.
+	DefaultDockerBridgeSubnet = "172.17.0.1/16"
+)
+
 // ConvertV20170831AgentPoolOnly converts an AgentPoolOnly object into an in-memory container service
 func ConvertV20170831AgentPoolOnly(v20170831 *v20170831.ManagedCluster) *ContainerService {
 	c := &ContainerService{}
@@ -216,9 +225,9 @@ func convertV20170831AgentPoolOnlyOrchestratorProfile(kubernetesVersion string) 
 			EnableSecureKubelet: helpers.PointerToBool(false),
 			// set network default for un-versioned model
 			NetworkPolicy:      "none",
-			ServiceCIDR:        "10.0.0.0/16",
-			DNSServiceIP:       "10.0.0.10",
-			DockerBridgeSubnet: "172.17.0.1/16",
+			ServiceCIDR:        DefaultKubernetesServiceCIDR,
+			DNSServiceIP:       DefaultKubernetesDNSServiceIP,
+			DockerBridgeSubnet: DefaultDockerBridgeSubnet,
 		},
 	}
 }
@@ -389,19 +398,19 @@ func convertV20180331AgentPoolOnlyOrchestratorProfile(kubernetesVersion string, 
 			if networkProfile.ServiceCidr != "" {
 				kubernetesConfig.ServiceCIDR = networkProfile.ServiceCidr
 			} else {
-				kubernetesConfig.ServiceCIDR = "10.0.0.0/16"
+				kubernetesConfig.ServiceCIDR = DefaultKubernetesServiceCIDR
 			}
 
 			if networkProfile.DNSServiceIP != "" {
 				kubernetesConfig.DNSServiceIP = networkProfile.DNSServiceIP
 			} else {
-				kubernetesConfig.DNSServiceIP = "10.0.0.10"
+				kubernetesConfig.DNSServiceIP = DefaultKubernetesDNSServiceIP
 			}
 
 			if networkProfile.DockerBridgeCidr != "" {
 				kubernetesConfig.DockerBridgeSubnet = networkProfile.DockerBridgeCidr
 			} else {
-				kubernetesConfig.DockerBridgeSubnet = "172.17.0.1/16"
+				kubernetesConfig.DockerBridgeSubnet = DefaultDockerBridgeSubnet
 			}
 		case v20180331.Kubenet:
 			kubernetesConfig.NetworkPolicy = "none"
@@ -409,19 +418,19 @@ func convertV20180331AgentPoolOnlyOrchestratorProfile(kubernetesVersion string, 
 			if networkProfile.ServiceCidr != "" {
 				kubernetesConfig.ServiceCIDR = networkProfile.ServiceCidr
 			} else {
-				kubernetesConfig.ServiceCIDR = "10.0.0.0/16"
+				kubernetesConfig.ServiceCIDR = DefaultKubernetesServiceCIDR
 			}
 
 			if networkProfile.DNSServiceIP != "" {
 				kubernetesConfig.DNSServiceIP = networkProfile.DNSServiceIP
 			} else {
-				kubernetesConfig.DNSServiceIP = "10.0.0.10"
+				kubernetesConfig.DNSServiceIP = DefaultKubernetesDNSServiceIP
 			}
 
 			if networkProfile.DockerBridgeCidr != "" {
 				kubernetesConfig.DockerBridgeSubnet = networkProfile.DockerBridgeCidr
 			} else {
-				kubernetesConfig.DockerBridgeSubnet = "172.17.0.1/16"
+				kubernetesConfig.DockerBridgeSubnet = DefaultDockerBridgeSubnet
 			}
 		default:
 			kubernetesConfig.NetworkPolicy = string(networkProfile.NetworkPlugin)
@@ -432,9 +441,9 @@ func convertV20180331AgentPoolOnlyOrchestratorProfile(kubernetesVersion string, 
 	} else {
 		// set network default for un-versioned model
 		kubernetesConfig.NetworkPolicy = "none"
-		kubernetesConfig.ServiceCIDR = "10.0.0.0/16"
-		kubernetesConfig.DNSServiceIP = "10.0.0.10"
-		kubernetesConfig.DockerBridgeSubnet = "172.17.0.1/16"
+		kubernetesConfig.ServiceCIDR = DefaultKubernetesServiceCIDR
+		kubernetesConfig.DNSServiceIP = DefaultKubernetesDNSServiceIP
+		kubernetesConfig.DockerBridgeSubnet = DefaultDockerBridgeSubnet
 	}
 
 	return &OrchestratorProfile{

--- a/pkg/api/convertertoagentpoolonlyapi.go
+++ b/pkg/api/convertertoagentpoolonlyapi.go
@@ -377,7 +377,11 @@ func convertV20180331AgentPoolOnlyOrchestratorProfile(kubernetesVersion string, 
 	}
 
 	if networkProfile != nil {
-		kubernetesConfig.NetworkPolicy = string(networkProfile.NetworkPlugin)
+		if networkProfile.NetworkPlugin == v20180331.Kubenet {
+			kubernetesConfig.NetworkPolicy = "none"
+		} else {
+			kubernetesConfig.NetworkPolicy = string(networkProfile.NetworkPlugin)
+		}
 		kubernetesConfig.ServiceCIDR = networkProfile.ServiceCidr
 		kubernetesConfig.DNSServiceIP = networkProfile.DNSServiceIP
 		kubernetesConfig.DockerBridgeSubnet = networkProfile.DockerBridgeCidr

--- a/pkg/api/convertertoagentpoolonlyapi_test.go
+++ b/pkg/api/convertertoagentpoolonlyapi_test.go
@@ -54,19 +54,19 @@ func TestConvertV20180331AgentPoolOnlyOrchestratorProfile(t *testing.T) {
 		t.Error("error in orchestrator profile kubernetesVersion conversion")
 	}
 
-	if api.KubernetesConfig.NetworkPolicy != "" {
+	if api.KubernetesConfig.NetworkPolicy != "none" {
 		t.Error("error in orchestrator profile networkPlugin conversion")
 	}
 
-	if api.KubernetesConfig.ServiceCIDR != "" {
+	if api.KubernetesConfig.ServiceCIDR != "10.0.0.0/16" {
 		t.Error("error in orchestrator profile networkPlugin conversion")
 	}
 
-	if api.KubernetesConfig.DNSServiceIP != "" {
+	if api.KubernetesConfig.DNSServiceIP != "10.0.0.10" {
 		t.Error("error in orchestrator profile networkPlugin conversion")
 	}
 
-	if api.KubernetesConfig.DockerBridgeSubnet != "" {
+	if api.KubernetesConfig.DockerBridgeSubnet != "172.17.0.1/16" {
 		t.Error("error in orchestrator profile networkPlugin conversion")
 	}
 
@@ -85,15 +85,15 @@ func TestConvertV20180331AgentPoolOnlyOrchestratorProfile(t *testing.T) {
 		t.Error("error in orchestrator profile networkPlugin conversion")
 	}
 
-	if api.KubernetesConfig.ServiceCIDR != "" {
+	if api.KubernetesConfig.ServiceCIDR != "10.0.0.0/16" {
 		t.Error("error in orchestrator profile networkPlugin conversion")
 	}
 
-	if api.KubernetesConfig.DNSServiceIP != "" {
+	if api.KubernetesConfig.DNSServiceIP != "10.0.0.10" {
 		t.Error("error in orchestrator profile networkPlugin conversion")
 	}
 
-	if api.KubernetesConfig.DockerBridgeSubnet != "" {
+	if api.KubernetesConfig.DockerBridgeSubnet != "172.17.0.1/16" {
 		t.Error("error in orchestrator profile networkPlugin conversion")
 	}
 }

--- a/pkg/api/convertertoagentpoolonlyapi_test.go
+++ b/pkg/api/convertertoagentpoolonlyapi_test.go
@@ -15,6 +15,7 @@ func TestConvertV20180331AgentPoolOnlyOrchestratorProfile(t *testing.T) {
 	dnsServiceIP := "10.0.0.10"
 	dockerBridgeSubnet := "172.17.0.1/16"
 
+	// all networkProfile fields are defined
 	p := &v20180331.NetworkProfile{
 		NetworkPlugin:    networkPlugin,
 		ServiceCidr:      serviceCIDR,
@@ -41,6 +42,58 @@ func TestConvertV20180331AgentPoolOnlyOrchestratorProfile(t *testing.T) {
 	}
 
 	if api.KubernetesConfig.DockerBridgeSubnet != string(dockerBridgeSubnet) {
+		t.Error("error in orchestrator profile networkPlugin conversion")
+	}
+
+	// no networkProfile is defined
+	p = nil
+
+	api = convertV20180331AgentPoolOnlyOrchestratorProfile(kubernetesVersion, p, nil)
+
+	if api.OrchestratorVersion != kubernetesVersion {
+		t.Error("error in orchestrator profile kubernetesVersion conversion")
+	}
+
+	if api.KubernetesConfig.NetworkPolicy != "" {
+		t.Error("error in orchestrator profile networkPlugin conversion")
+	}
+
+	if api.KubernetesConfig.ServiceCIDR != "" {
+		t.Error("error in orchestrator profile networkPlugin conversion")
+	}
+
+	if api.KubernetesConfig.DNSServiceIP != "" {
+		t.Error("error in orchestrator profile networkPlugin conversion")
+	}
+
+	if api.KubernetesConfig.DockerBridgeSubnet != "" {
+		t.Error("error in orchestrator profile networkPlugin conversion")
+	}
+
+	// only networkProfile NetworkPlugin fields is defined
+	p = &v20180331.NetworkProfile{
+		NetworkPlugin: networkPlugin,
+	}
+
+	api = convertV20180331AgentPoolOnlyOrchestratorProfile(kubernetesVersion, p, nil)
+
+	if api.OrchestratorVersion != kubernetesVersion {
+		t.Error("error in orchestrator profile kubernetesVersion conversion")
+	}
+
+	if api.KubernetesConfig.NetworkPolicy != string(networkPlugin) {
+		t.Error("error in orchestrator profile networkPlugin conversion")
+	}
+
+	if api.KubernetesConfig.ServiceCIDR != "" {
+		t.Error("error in orchestrator profile networkPlugin conversion")
+	}
+
+	if api.KubernetesConfig.DNSServiceIP != "" {
+		t.Error("error in orchestrator profile networkPlugin conversion")
+	}
+
+	if api.KubernetesConfig.DockerBridgeSubnet != "" {
 		t.Error("error in orchestrator profile networkPlugin conversion")
 	}
 }


### PR DESCRIPTION
Validation logic backward compatibility support for API models converted from prior v20180331 models.

This PR adds validation support for API models generated by serialization of
1) un-versioned models created prior to v20180331.
2) use template generator generated model with default values set.

Also adds various testings.