### PR TITLE
Bugfix etcd encryption key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ debug
 _output/
 _input/
 .vscode
+.idea
 .DS_Store
 test/user.env
 user.env

--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -41,6 +41,7 @@ Here are the valid values for the orchestrator types:
 |enableRbac|no|Enable [Kubernetes RBAC](https://kubernetes.io/docs/admin/authorization/rbac/) (boolean - default == true) |
 |enableAggregatedAPIs|no|Enable [Kubernetes Aggregated APIs](https://kubernetes.io/docs/concepts/api-extension/apiserver-aggregation/).This is required by [Service Catalog](https://github.com/kubernetes-incubator/service-catalog/blob/master/README.md). (boolean - default == false) |
 |enableDataEncryptionAtRest|no|Enable [kuberetes data encryption at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).This is currently an alpha feature. (boolean - default == false) |
+|etcdEncryptionKey|no|Enryption key to be used if enableDataEncryptionAtRest is enabled. Defaults to a random, generated, key|
 |enablePodSecurityPolicy|no|Enable [kuberetes pod security policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/).This is currently a beta feature. (boolean - default == false)|
 |etcdDiskSizeGB|no|Size in GB to assign to etcd data volume. Defaults (if no user value provided) are: 256 GB for clusters up to 3 nodes; 512 GB for clusters with between 4 and 10 nodes; 1024 GB for clusters with between 11 and 20 nodes; and 2048 GB for clusters with more than 20 nodes|
 |privateCluster|no|Build a cluster without public addresses assigned. See `privateClusters` [below](#feat-private-cluster).|

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -246,8 +246,7 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
 {{end}}
 
 {{if EnableDataEncryptionAtRest }}
-    ETCD_ENCRYPTION_SECRET="$(head -c 32 /dev/urandom | base64)"
-    sed -i "s|<etcdEncryptionSecret>|$ETCD_ENCRYPTION_SECRET|g" "/etc/kubernetes/encryption-config.yaml"
+    sed -i "s|<etcdEncryptionSecret>|{{WrapAsVariable "etcdEncryptionKey"}}|g" "/etc/kubernetes/encryption-config.yaml"
 {{end}}
 
 {{if eq .OrchestratorProfile.KubernetesConfig.NetworkPolicy "calico"}}

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -411,3 +411,6 @@
     "agentWindowsVersion": "[parameters('agentWindowsVersion')]",
     "windowsCustomScriptSuffix": " $inputFile = '%SYSTEMDRIVE%\\AzureData\\CustomData.bin' ; $outputFile = '%SYSTEMDRIVE%\\AzureData\\CustomDataSetupScript.ps1' ; Copy-Item $inputFile $outputFile ; Invoke-Expression('{0} {1}' -f $outputFile, $arguments) ; "
 {{end}}
+{{if EnableDataEncryptionAtRest}}
+    ,"etcdEncryptionKey": "[parameters('etcdEncryptionKey')]"
+{{end}}

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -692,6 +692,12 @@
         "description": "etcd version"
       },
       "type": "string"
+    },
+    "etcdEncryptionKey": {
+      "metadata": {
+        "description": "Encryption at rest key for etcd"
+      },
+      "type": "string"
     }
 {{if ProvisionJumpbox}}
     ,"jumpboxVMName": {

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -2,13 +2,13 @@ package acsengine
 
 import (
 	"bytes"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"sort"
 	"strconv"
 	"strings"
-	"crypto/rand"
-	"encoding/base64"
 
 	"github.com/Azure/acs-engine/pkg/api"
 	"github.com/Azure/acs-engine/pkg/api/common"
@@ -463,9 +463,9 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 		}
 
 		if helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableDataEncryptionAtRest) {
-		  if "" == a.OrchestratorProfile.KubernetesConfig.EtcdEncryptionKey {
-		    a.OrchestratorProfile.KubernetesConfig.EtcdEncryptionKey = generateEtcdEncryptionKey()
-		  }
+			if "" == a.OrchestratorProfile.KubernetesConfig.EtcdEncryptionKey {
+				a.OrchestratorProfile.KubernetesConfig.EtcdEncryptionKey = generateEtcdEncryptionKey()
+			}
 		}
 
 		if a.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision() && a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB == 0 {
@@ -1022,7 +1022,7 @@ func k8sVersionMetricsServerAddonEnabled(o *api.OrchestratorProfile) *bool {
 }
 
 func generateEtcdEncryptionKey() string {
-  b := make([]byte, 32)
-  rand.Read(b)
-  return base64.URLEncoding.EncodeToString(b)
+	b := make([]byte, 32)
+	rand.Read(b)
+	return base64.URLEncoding.EncodeToString(b)
 }

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"crypto/rand"
+	"encoding/base64"
 
 	"github.com/Azure/acs-engine/pkg/api"
 	"github.com/Azure/acs-engine/pkg/api/common"
@@ -458,6 +460,12 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 			default:
 				a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB = DefaultEtcdDiskSize
 			}
+		}
+
+		if helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableDataEncryptionAtRest) {
+		  if "" == a.OrchestratorProfile.KubernetesConfig.EtcdEncryptionKey {
+		    a.OrchestratorProfile.KubernetesConfig.EtcdEncryptionKey = generateEtcdEncryptionKey()
+		  }
 		}
 
 		if a.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision() && a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB == 0 {
@@ -1011,4 +1019,10 @@ func enforceK8sVersionAddonOverrides(addons []api.KubernetesAddon, o *api.Orches
 
 func k8sVersionMetricsServerAddonEnabled(o *api.OrchestratorProfile) *bool {
 	return helpers.PointerToBool(common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.9.0"))
+}
+
+func generateEtcdEncryptionKey() string {
+  b := make([]byte, 32)
+  rand.Read(b)
+  return base64.URLEncoding.EncodeToString(b)
 }

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -688,6 +688,7 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 		addValue(parametersMap, "etcdDownloadURLBase", cloudSpecConfig.KubernetesSpecConfig.EtcdDownloadURLBase)
 		addValue(parametersMap, "etcdVersion", cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdVersion)
 		addValue(parametersMap, "etcdDiskSizeGB", cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB)
+		addValue(parametersMap, "etcdEncryptionKey", cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdEncryptionKey)
 		if cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision() {
 			addValue(parametersMap, "jumpboxVMName", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Name)
 			addValue(parametersMap, "jumpboxVMSize", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.VMSize)
@@ -1711,6 +1712,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 					val = cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdVersion
 				case "etcdDiskSizeGB":
 					val = cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB
+				case "etcdEncryptionKey":
+					val = cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdEncryptionKey
 				case "jumpboxOSDiskSizeGB":
 					val = strconv.Itoa(cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.OSDiskSizeGB)
 				default:

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -713,6 +713,7 @@ func convertKubernetesConfigToVLabs(api *KubernetesConfig, vlabs *vlabs.Kubernet
 	vlabs.GCLowThreshold = api.GCLowThreshold
 	vlabs.EtcdVersion = api.EtcdVersion
 	vlabs.EtcdDiskSizeGB = api.EtcdDiskSizeGB
+	vlabs.EtcdEncryptionKey = api.EtcdEncryptionKey
 	convertAddonsToVlabs(api, vlabs)
 	convertKubeletConfigToVlabs(api, vlabs)
 	convertControllerManagerConfigToVlabs(api, vlabs)

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -677,6 +677,7 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 	api.GCLowThreshold = vlabs.GCLowThreshold
 	api.EtcdVersion = vlabs.EtcdVersion
 	api.EtcdDiskSizeGB = vlabs.EtcdDiskSizeGB
+	api.EtcdEncryptionKey = vlabs.EtcdEncryptionKey
 	convertAddonsToAPI(vlabs, api)
 	convertKubeletConfigToAPI(vlabs, api)
 	convertControllerManagerConfigToAPI(vlabs, api)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -282,6 +282,7 @@ type KubernetesConfig struct {
 	GCLowThreshold                   int               `json:"gclowthreshold,omitempty"`
 	EtcdVersion                      string            `json:"etcdVersion,omitempty"`
 	EtcdDiskSizeGB                   string            `json:"etcdDiskSizeGB,omitempty"`
+	EtcdEncryptionKey                string            `json:"etcdEncryptionKey,omitempty"`
 	EnableDataEncryptionAtRest       *bool             `json:"enableDataEncryptionAtRest,omitempty"`
 	EnablePodSecurityPolicy          *bool             `json:"enablePodSecurityPolicy,omitempty"`
 	Addons                           []KubernetesAddon `json:"addons,omitempty"`

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -282,6 +282,7 @@ type KubernetesConfig struct {
 	GCLowThreshold               int               `json:"gclowthreshold,omitempty"`
 	EtcdVersion                  string            `json:"etcdVersion,omitempty"`
 	EtcdDiskSizeGB               string            `json:"etcdDiskSizeGB,omitempty"`
+	EtcdEncryptionKey            string            `json:"etcdEncryptionKey,omitempty"`
 	EnableDataEncryptionAtRest   *bool             `json:"enableDataEncryptionAtRest,omitempty"`
 	EnablePodSecurityPolicy      *bool             `json:"enablePodSecurityPolicy,omitempty"`
 	Addons                       []KubernetesAddon `json:"addons,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:

Bugfix to deploy a common etcd encryption key on all master nodes.

- Before this commit, all masters (if there should be more than one) would end up with different encryption keys, resulting in all but one masters to not be ready at all time.
  - calico did not start, complain about invalid padding in the secret
  - `/etc/cni/net.d` was not present on all but one master
- This key can either be specified as an option to `kubeConfig`, or will be generated before deployment.

**Test setup**

- Kubernetes 1.10.1
- custom acs-engine build (this fix on top of #2521, which was also rebased on the latest master)
  - Mac OS X 10.12.6
- 3 masters
- 2 agent nodes

```
{
  "apiVersion": "vlabs",
  "properties": {
    "orchestratorProfile": {
      "orchestratorType": "Kubernetes",
      "orchestratorVersion": "1.10.1",
      "kubernetesConfig": {
        "enableDataEncryptionAtRest": true,
        "useManagedIdentity": true,
        "enableRbac": true,
        "networkPolicy": "calico",
        "privateCluster": {
            "enabled": true
        },
        "dnsServiceIP": "10.11.96.96",
        "serviceCidr": "10.11.64.0/18",
        "clusterSubnet": "10.11.128.0/17",
        "etcdDiskSizeGB": "256"
      }
    },
    "aadProfile": {
      "serverAppID": "****",
      "clientAppID": "****",
      "tenantID": "****"
    },
    "masterProfile": {
      "count": 3,
      "dnsPrefix": "dev2",
      "vmSize": "Standard_A4_v2",
      "vnetSubnetId": "/subscriptions/****/resourceGroups/****/providers/Microsoft.Network/virtualNetworks/dev2-k8s-network/subnets/dev2-k8s-master-subnet",
      "firstConsecutiveStaticIP": "10.11.24.10",
      "vnetCidr": "10.11.0.0/16"
    },
    "agentPoolProfiles": [
      {
        "name": "agent",
        "count": 2,
        "vmSize": "Standard_A4_v2",
        "vnetSubnetId": "/subscriptions/****/resourceGroups/****/providers/Microsoft.Network/virtualNetworks/dev2-k8s-network/subnets/dev2-k8s-worker-subnet",
        "availabilityProfile": "AvailabilitySet"
      }
    ],
    "linuxProfile": {
      "adminUsername": "****",
      "ssh": {
        "publicKeys": [
          {
            "keyData": "ssh-rsa ****"
          }
        ]
      }
    },
    "servicePrincipalProfile": {
      "clientId": "****",
      "secret": "****"
    }
  }
}

```
**Which issue this PR fixes** 

relates to #2521 and #2587
*In this PR it is stated that Kubernetes 1.10 was not yet achieved with Calico 3. This was however possible for me.*

relates to #2202
*Most likely fixes this issue, but I did not test with 1.9 and calico 2.x*

**Special notes for your reviewer**:

Even though this fix worked on my installation, I am not quite familiar with the project so far. So please review the changes carefully and report back to me if I shall rollback some of changes.

Most importantly, I did not find a very accurate description of this flag for kubernetes. I assume this key should be equal on all machines and by doing so my issue was fixed, but I am not 100% sure about that.

I did not adapt or write tests so far. However, we should also note that none of the existing tests catched this issue!

- [x] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Mentions**:

@CecileRobertMichon @jackfrancis @khaldoune

I think this could be interesting for you. I followed some of your recent tickets and fixes until I finally ended up here. Thanks so far!