### PR TITLE
Update custom-image example to use managed disks

### DIFF
--- a/examples/custom-image.json
+++ b/examples/custom-image.json
@@ -11,6 +11,7 @@
       },
       "count": 1,
       "dnsPrefix": "",
+      "storageProfile": "ManagedDisks",
       "vmSize": "Standard_D2_v2"
     },
     "agentPoolProfiles": [
@@ -21,6 +22,7 @@
           "name": "stretch",
           "resourceGroup": "debian"
         },
+        "storageProfile": "ManagedDisks",
         "vmSize": "Standard_D2_v2",
         "availabilityProfile": "AvailabilitySet"
       }


### PR DESCRIPTION
If no managed disks are used by the k8s templates today, the VM api version is old enough to invalidate the use of custom images. I want to avoid adding extra validation in the code for this since it may be possible to run custom images with unmanaged disks (haven't tested).

Closes https://github.com/Azure/acs-engine/issues/2629