### PR TITLE
test encryption at rest w/ 1.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,35 +235,6 @@ jobs:
           echo 'export ORCHESTRATOR_RELEASE=1.10' >> $BASH_ENV
           echo 'export CLUSTER_DEFINITION=examples/e2e-tests/kubernetes/release/default/definition.json' >> $BASH_ENV
           echo 'export CREATE_VNET=true' >> $BASH_ENV
-          echo 'export CLEANUP_ON_EXIT=false' >> $BASH_ENV
-          echo 'export RETAIN_SSH=false' >> $BASH_ENV
-          echo 'export SUBSCRIPTION_ID=${SUBSCRIPTION_ID_E2E_KUBERNETES}' >> $BASH_ENV
-          echo 'export CLIENT_ID=${SERVICE_PRINCIPAL_CLIENT_ID_E2E_KUBERNETES}' >> $BASH_ENV
-          echo 'export CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET_E2E_KUBERNETES}' >> $BASH_ENV
-      - run:
-          name: compile
-          command: make build-binary
-      - run:
-          name: ginkgo k8s e2e tests
-          command: make test-kubernetes
-          no_output_timeout: "30m"
-      - store_artifacts:
-          path: /go/src/github.com/Azure/acs-engine/_logs
-      - store_artifacts:
-          path: /go/src/github.com/Azure/acs-engine/_output
-  k8s-1.10-release-kms-e2e:
-    working_directory: /go/src/github.com/Azure/acs-engine
-    docker:
-      - image: quay.io/deis/go-dev:v1.9.1
-        environment:
-          GOPATH: /go
-    steps:
-      - checkout
-      - run: |
-          echo 'export TIMEOUT=20m' >> $BASH_ENV
-          echo 'export ORCHESTRATOR_RELEASE=1.10' >> $BASH_ENV
-          echo 'export CLUSTER_DEFINITION=examples/e2e-tests/kubernetes/release/default/definition.json' >> $BASH_ENV
-          echo 'export CREATE_VNET=true' >> $BASH_ENV
           echo 'export ENABLE_KMS_ENCRYPTION=true' >> $BASH_ENV
           echo 'export CLEANUP_ON_EXIT=false' >> $BASH_ENV
           echo 'export RETAIN_SSH=false' >> $BASH_ENV
@@ -459,12 +430,6 @@ workflows:
             branches:
               ignore: master
       - k8s-1.10-release-e2e:
-          requires:
-            - pr-e2e-hold
-          filters:
-            branches:
-              ignore: master
-      - k8s-1.10-release-kms-e2e:
           requires:
             - pr-e2e-hold
           filters:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Test encryption at rest w/ 1.10 clusters. See:

https://github.com/Azure/acs-engine/pull/2544

We test vanilla k8s 1.10 out-of-band, so this adds add'l coverage to the PR 1.10 test

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```