### PR TITLE
Print age of soak cluster in test

### DIFF
--- a/test/e2e/azure/cli.go
+++ b/test/e2e/azure/cli.go
@@ -305,7 +305,9 @@ func (a *Account) IsClusterExpired(d time.Duration) bool {
 		return true
 	}
 	t := time.Unix(tag, 0)
-	return time.Since(t) > d
+	age := time.Since(t)
+	log.Printf("Cluster is %v hours old\n", int(age.Hours()))
+	return age > d
 }
 
 // CreateStorageAccount will create a new Azure Storage Account


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Adds log to print the age of the cluster being tested.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
