### PR TITLE
fix the older api version to make LinuxProfile not required

### DIFF
--- a/pkg/api/agentPoolOnlyApi/v20170831/types.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/types.go
@@ -34,7 +34,7 @@ type Properties struct {
 	DNSPrefix               string                   `json:"dnsPrefix" validate:"required"`
 	FQDN                    string                   `json:"fqdn,omitempty"`
 	AgentPoolProfiles       []*AgentPoolProfile      `json:"agentPoolProfiles,omitempty" validate:"dive,required"`
-	LinuxProfile            *LinuxProfile            `json:"linuxProfile,omitempty" validate:"required"`
+	LinuxProfile            *LinuxProfile            `json:"linuxProfile,omitempty"`
 	WindowsProfile          *WindowsProfile          `json:"windowsProfile,omitempty"`
 	ServicePrincipalProfile *ServicePrincipalProfile `json:"servicePrincipalProfile,omitempty"`
 	AccessProfiles          map[string]AccessProfile `json:"accessProfiles,omitempty"`

--- a/pkg/api/agentPoolOnlyApi/v20170831/validate.go
+++ b/pkg/api/agentPoolOnlyApi/v20170831/validate.go
@@ -36,7 +36,7 @@ func handleValidationErrors(e validator.ValidationErrors) error {
 	ns := err.Namespace()
 	switch ns {
 	// TODO: Add more validation here
-	case "Properties.LinuxProfile", "Properties.ServicePrincipalProfile.ClientID",
+	case "Properties.ServicePrincipalProfile.ClientID",
 		"Properties.ServicePrincipalProfile.Secret", "Properties.WindowsProfile.AdminUsername",
 		"Properties.WindowsProfile.AdminPassword":
 		return fmt.Errorf("missing %s", ns)


### PR DESCRIPTION
when AKS is created without ssh key using new api version,
the linux profile will not be returned in v20170831 api version.
The removal of required LinuxProfile will make the following update
(such as scaling) calls without LinuxProfile succeed

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
