### PR TITLE
Update references to gcr.io to point to Azure CDN endpoint

### DIFF
--- a/docs/kubernetes/k8s-developers.md
+++ b/docs/kubernetes/k8s-developers.md
@@ -23,7 +23,7 @@ cd ../../..
 * Push your Docker image to Docker Hub:
 
 ```
-docker tag gcr.io/google-containers/hyperkube-amd64:sometag dockerhubid/hyperkube-amd64:sometag
+docker tag k8s-gcrio.azureedge.net/hyperkube-amd64:sometag dockerhubid/hyperkube-amd64:sometag
 docker push dockerhubid/hyperkube-amd64:sometag
 ```
 

--- a/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml
+++ b/extensions/prometheus-grafana-k8s/v1/prometheus_values.yaml
@@ -194,7 +194,7 @@ kubeStateMetrics:
   ## kube-state-metrics container image
   ##
   image:
-    repository: k8s.gcr.io/kube-state-metrics
+    repository: k8s-gcrio.azureedge.net/kube-state-metrics
     tag: v1.2.0
     pullPolicy: IfNotPresent
 

--- a/jenkins/Jenkinsfile.azure.kubernetes
+++ b/jenkins/Jenkinsfile.azure.kubernetes
@@ -55,7 +55,7 @@ node(env.NODE? env.NODE : 'slave') {
             sh("docker login -u ${REGISTRY_USERNAME} -p ${REGISTRY_PASSWORD} ${REGISTRY_USERNAME}.azurecr.io")
 
             // We retag the gcr image from hyperkube-amd64 to just hyperkube since we can use image tags for separate architectures
-            sh("cd /go/src/github.com/kubernetes/kubernetes && docker tag gcr.io/google-containers/hyperkube-amd64:${tag} ${REGISTRY_USERNAME}.azurecr.io/hyperkube:${tag}")
+            sh("cd /go/src/github.com/kubernetes/kubernetes && docker tag k8s-gcrio.azureedge.net/hyperkube-amd64:${tag} ${REGISTRY_USERNAME}.azurecr.io/hyperkube:${tag}")
             sh("cd /go/src/github.com/kubernetes/kubernetes && docker push ${REGISTRY_USERNAME}.azurecr.io/hyperkube:${tag}")
           }
         }

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -307,7 +307,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				// Inspired by http://blog.kubernetes.io/2016/07/autoscaling-in-kubernetes.html
 				r := rand.New(rand.NewSource(time.Now().UnixNano()))
 				phpApacheName := fmt.Sprintf("php-apache-%s-%v", cfg.Name, r.Intn(99999))
-				phpApacheDeploy, err := deployment.CreateLinuxDeploy("gcr.io/google_containers/hpa-example", phpApacheName, "default", "--requests=cpu=50m,memory=50M")
+				phpApacheDeploy, err := deployment.CreateLinuxDeploy("k8s-gcrio.azureedge.net/hpa-example", phpApacheName, "default", "--requests=cpu=50m,memory=50M")
 				if err != nil {
 					fmt.Println(err)
 				}


### PR DESCRIPTION
This PR updates some URLs in documentation and in code to point to the k8s-gcrio.azureedge.net CDN endpoint. Most were already doing so after #2042 but a few outliers crept in.

I found these with `git grep gcr.io | grep -v vendor`.

Note the official [k8s.gcr.io change announcement](https://groups.google.com/forum/#!topic/kubernetes-dev/ytjk_rNrTa0).



```release-note
NONE
```
