### PR TITLE
Add etcd encryption key

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -41,6 +41,7 @@ Here are the valid values for the orchestrator types:
 |enableRbac|no|Enable [Kubernetes RBAC](https://kubernetes.io/docs/admin/authorization/rbac/) (boolean - default == true) |
 |enableAggregatedAPIs|no|Enable [Kubernetes Aggregated APIs](https://kubernetes.io/docs/concepts/api-extension/apiserver-aggregation/).This is required by [Service Catalog](https://github.com/kubernetes-incubator/service-catalog/blob/master/README.md). (boolean - default == false) |
 |enableDataEncryptionAtRest|no|Enable [kubernetes data encryption at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).This is currently an alpha feature. (boolean - default == false) |
+|etcdEncryptionKey|no|Enryption key to be used if enableDataEncryptionAtRest is enabled. Defaults to a random, generated, key|
 |enablePodSecurityPolicy|no|Enable [kubernetes pod security policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/).This is currently a beta feature. (boolean - default == false)|
 |enableEncryptionWithExternalKms|no|Enable [kubernetes data encryption at rest with external KMS](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).This is currently an alpha feature. (boolean - default == false) |
 |etcdDiskSizeGB|no|Size in GB to assign to etcd data volume. Defaults (if no user value provided) are: 256 GB for clusters up to 3 nodes; 512 GB for clusters with between 4 and 10 nodes; 1024 GB for clusters with between 11 and 20 nodes; and 2048 GB for clusters with more than 20 nodes|

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -264,8 +264,7 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
 {{end}}
 
 {{if EnableDataEncryptionAtRest }}
-    ETCD_ENCRYPTION_SECRET="$(head -c 32 /dev/urandom | base64)"
-    sed -i "s|<etcdEncryptionSecret>|$ETCD_ENCRYPTION_SECRET|g" "/etc/kubernetes/encryption-config.yaml"
+    sed -i "s|<etcdEncryptionSecret>|{{WrapAsVariable "etcdEncryptionKey"}}|g" "/etc/kubernetes/encryption-config.yaml" 
 {{end}}
 
 {{if eq .OrchestratorProfile.KubernetesConfig.NetworkPolicy "calico"}}

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -138,6 +138,9 @@
     "vnetCidr": "[parameters('vnetCidr')]",
     "gcHighThreshold":"[parameters('gcHighThreshold')]",
     "gcLowThreshold":"[parameters('gcLowThreshold')]",
+{{if EnableDataEncryptionAtRest}} 
+    "etcdEncryptionKey": "[parameters('etcdEncryptionKey')]",
+{{end}}
 {{ if UseManagedIdentity }}
     "servicePrincipalClientId": "msi",
     "servicePrincipalClientSecret": "msi",

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -692,6 +692,12 @@
         "description": "etcd version"
       },
       "type": "string"
+    },
+    "etcdEncryptionKey": { 
+      "metadata": {
+        "description": "Encryption at rest key for etcd" 
+      },
+      "type": "string"
     }
 {{if ProvisionJumpbox}}
     ,"jumpboxVMName": {

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -2,6 +2,8 @@ package acsengine
 
 import (
 	"bytes"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"sort"
@@ -476,6 +478,12 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 				a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB = DefaultEtcdDiskSizeGT3Nodes
 			default:
 				a.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB = DefaultEtcdDiskSize
+			}
+		}
+
+		if helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableDataEncryptionAtRest) {
+			if "" == a.OrchestratorProfile.KubernetesConfig.EtcdEncryptionKey {
+				a.OrchestratorProfile.KubernetesConfig.EtcdEncryptionKey = generateEtcdEncryptionKey()
 			}
 		}
 
@@ -1032,4 +1040,10 @@ func enforceK8sVersionAddonOverrides(addons []api.KubernetesAddon, o *api.Orches
 
 func k8sVersionMetricsServerAddonEnabled(o *api.OrchestratorProfile) *bool {
 	return helpers.PointerToBool(common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.9.0"))
+}
+
+func generateEtcdEncryptionKey() string {
+	b := make([]byte, 32)
+	rand.Read(b)
+	return base64.URLEncoding.EncodeToString(b)
 }

--- a/pkg/acsengine/defaults_test.go
+++ b/pkg/acsengine/defaults_test.go
@@ -1,6 +1,7 @@
 package acsengine
 
 import (
+	"encoding/base64"
 	"reflect"
 	"testing"
 
@@ -380,6 +381,20 @@ func TestEtcdDiskSize(t *testing.T) {
 	if properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB != customEtcdDiskSize {
 		t.Fatalf("EtcdDiskSizeGB did not have the expected size, got %s, expected %s",
 			properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB, customEtcdDiskSize)
+	}
+}
+
+func TestGenerateEtcdEncryptionKey(t *testing.T) {
+	key1 := generateEtcdEncryptionKey()
+	key2 := generateEtcdEncryptionKey()
+	if key1 == key2 {
+		t.Fatalf("generateEtcdEncryptionKey should return a unique key each time, instead returned identical %s and %s", key1, key2)
+	}
+	for _, val := range []string{key1, key2} {
+		_, err := base64.URLEncoding.DecodeString(val)
+		if err != nil {
+			t.Fatalf("generateEtcdEncryptionKey should return a base64 encoded key, instead returned %s", val)
+		}
 	}
 }
 

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -692,6 +692,7 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 		addValue(parametersMap, "etcdDownloadURLBase", cloudSpecConfig.KubernetesSpecConfig.EtcdDownloadURLBase)
 		addValue(parametersMap, "etcdVersion", cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdVersion)
 		addValue(parametersMap, "etcdDiskSizeGB", cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB)
+		addValue(parametersMap, "etcdEncryptionKey", cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdEncryptionKey)
 		if cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateJumpboxProvision() {
 			addValue(parametersMap, "jumpboxVMName", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.Name)
 			addValue(parametersMap, "jumpboxVMSize", cs.Properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.VMSize)
@@ -1725,6 +1726,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 					val = cloudSpecConfig.KubernetesSpecConfig.EtcdDownloadURLBase
 				case "etcdVersion":
 					val = cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdVersion
+				case "etcdEncryptionKey":
+					val = cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdEncryptionKey
 				case "etcdDiskSizeGB":
 					val = cs.Properties.OrchestratorProfile.KubernetesConfig.EtcdDiskSizeGB
 				case "jumpboxOSDiskSizeGB":

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -714,6 +714,7 @@ func convertKubernetesConfigToVLabs(api *KubernetesConfig, vlabs *vlabs.Kubernet
 	vlabs.GCLowThreshold = api.GCLowThreshold
 	vlabs.EtcdVersion = api.EtcdVersion
 	vlabs.EtcdDiskSizeGB = api.EtcdDiskSizeGB
+	vlabs.EtcdEncryptionKey = api.EtcdEncryptionKey
 	convertAddonsToVlabs(api, vlabs)
 	convertKubeletConfigToVlabs(api, vlabs)
 	convertControllerManagerConfigToVlabs(api, vlabs)

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -672,6 +672,7 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 	api.GCLowThreshold = vlabs.GCLowThreshold
 	api.EtcdVersion = vlabs.EtcdVersion
 	api.EtcdDiskSizeGB = vlabs.EtcdDiskSizeGB
+	api.EtcdEncryptionKey = vlabs.EtcdEncryptionKey
 	convertAddonsToAPI(vlabs, api)
 	convertKubeletConfigToAPI(vlabs, api)
 	convertControllerManagerConfigToAPI(vlabs, api)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -283,6 +283,7 @@ type KubernetesConfig struct {
 	GCLowThreshold                   int               `json:"gclowthreshold,omitempty"`
 	EtcdVersion                      string            `json:"etcdVersion,omitempty"`
 	EtcdDiskSizeGB                   string            `json:"etcdDiskSizeGB,omitempty"`
+	EtcdEncryptionKey                string            `json:"etcdEncryptionKey,omitempty"`
 	EnableDataEncryptionAtRest       *bool             `json:"enableDataEncryptionAtRest,omitempty"`
 	EnableEncryptionWithExternalKms  *bool             `json:"enableEncryptionWithExternalKms,omitempty"`
 	EnablePodSecurityPolicy          *bool             `json:"enablePodSecurityPolicy,omitempty"`

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -283,6 +283,7 @@ type KubernetesConfig struct {
 	GCLowThreshold                  int               `json:"gclowthreshold,omitempty"`
 	EtcdVersion                     string            `json:"etcdVersion,omitempty"`
 	EtcdDiskSizeGB                  string            `json:"etcdDiskSizeGB,omitempty"`
+	EtcdEncryptionKey               string            `json:"etcdEncryptionKey,omitempty"`
 	EnableDataEncryptionAtRest      *bool             `json:"enableDataEncryptionAtRest,omitempty"`
 	EnableEncryptionWithExternalKms *bool             `json:"enableEncryptionWithExternalKms,omitempty"`
 	EnablePodSecurityPolicy         *bool             `json:"enablePodSecurityPolicy,omitempty"`

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -1,6 +1,7 @@
 package vlabs
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net"
@@ -124,7 +125,12 @@ func (o *OrchestratorProfile) Validate(isUpdate bool) error {
 						return fmt.Errorf("enableDataEncryptionAtRest is only available in Kubernetes version %s or greater; unable to validate for Kubernetes version %s",
 							minVersion, o.OrchestratorVersion)
 					}
-
+					if o.KubernetesConfig.EtcdEncryptionKey != "" {
+						_, err = base64.StdEncoding.DecodeString(o.KubernetesConfig.EtcdEncryptionKey)
+						if err != nil {
+							return fmt.Errorf("etcdEncryptionKey must be base64 encoded. Please provide a valid base64 encoded value or leave the etcdEncryptionKey empty to auto-generate the value")
+						}
+					}
 				}
 
 				if helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableEncryptionWithExternalKms) {

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -126,7 +126,7 @@ func (o *OrchestratorProfile) Validate(isUpdate bool) error {
 							minVersion, o.OrchestratorVersion)
 					}
 					if o.KubernetesConfig.EtcdEncryptionKey != "" {
-						_, err = base64.StdEncoding.DecodeString(o.KubernetesConfig.EtcdEncryptionKey)
+						_, err = base64.URLEncoding.DecodeString(o.KubernetesConfig.EtcdEncryptionKey)
 						if err != nil {
 							return fmt.Errorf("etcdEncryptionKey must be base64 encoded. Please provide a valid base64 encoded value or leave the etcdEncryptionKey empty to auto-generate the value")
 						}


### PR DESCRIPTION
**What this PR does / why we need it**:

Re-implement #2694 because CLA was not signed.

In @croeck 's words:

Bugfix to deploy a common etcd encryption key on all master nodes.

- Before this commit, all masters (if there should be more than one) would end up with different encryption keys, resulting in all but one masters to not be ready at all time.
  - calico did not start, complain about invalid padding in the secret
  - `/etc/cni/net.d` was not present on all but one master
- This key can either be specified as an option to `kubeConfig`, or will be generated before deployment.

**Test setup**

- Kubernetes 1.10.1
- custom acs-engine build (this fix on top of #2521, which was also rebased on the latest master)
  - Mac OS X 10.12.6
- 3 masters
- 2 agent nodes

```
{
  "apiVersion": "vlabs",
  "properties": {
    "orchestratorProfile": {
      "orchestratorType": "Kubernetes",
      "orchestratorVersion": "1.10.1",
      "kubernetesConfig": {
        "enableDataEncryptionAtRest": true,
        "useManagedIdentity": true,
        "enableRbac": true,
        "networkPolicy": "calico",
        "privateCluster": {
            "enabled": true
        },
        "dnsServiceIP": "10.11.96.96",
        "serviceCidr": "10.11.64.0/18",
        "clusterSubnet": "10.11.128.0/17",
        "etcdDiskSizeGB": "256"
      }
    },
    "aadProfile": {
      "serverAppID": "****",
      "clientAppID": "****",
      "tenantID": "****"
    },
    "masterProfile": {
      "count": 3,
      "dnsPrefix": "dev2",
      "vmSize": "Standard_A4_v2",
      "vnetSubnetId": "/subscriptions/****/resourceGroups/****/providers/Microsoft.Network/virtualNetworks/dev2-k8s-network/subnets/dev2-k8s-master-subnet",
      "firstConsecutiveStaticIP": "10.11.24.10",
      "vnetCidr": "10.11.0.0/16"
    },
    "agentPoolProfiles": [
      {
        "name": "agent",
        "count": 2,
        "vmSize": "Standard_A4_v2",
        "vnetSubnetId": "/subscriptions/****/resourceGroups/****/providers/Microsoft.Network/virtualNetworks/dev2-k8s-network/subnets/dev2-k8s-worker-subnet",
        "availabilityProfile": "AvailabilitySet"
      }
    ],
    "linuxProfile": {
      "adminUsername": "****",
      "ssh": {
        "publicKeys": [
          {
            "keyData": "ssh-rsa ****"
          }
        ]
      }
    },
    "servicePrincipalProfile": {
      "clientId": "****",
      "secret": "****"
    }
  }
}

```
**Which issue this PR fixes** 

relates to #2521 and #2587
*In this PR it is stated that Kubernetes 1.10 was not yet achieved with Calico 3. This was however possible for me.*

relates to #2202
*Most likely fixes this issue, but I did not test with 1.9 and calico 2.x*

- [x] documentation
- [x] unit tests
- [x] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)
