### PR TITLE
Provisioning of custom files when deploying k8s cluster

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -440,7 +440,7 @@ We consider `kubeletConfig`, `controllerManagerConfig`, `apiServerConfig`, and `
 |imageReference.name|no|The name of the Linux OS image. Needs to be used in conjunction with resourceGroup, below|
 |imageReference.resourceGroup|no|Resource group that contains the Linux OS image. Needs to be used in conjunction with name, above|
 |distro|no|Select Master(s) Operating System (Linux only). Currently supported values are: `ubuntu` and `coreos` (CoreOS support is currently experimental). Defaults to `ubuntu` if undefined. Currently supported OS and orchestrator configurations -- `ubuntu`: DCOS, Docker Swarm, Kubernetes; `RHEL`: OpenShift; `coreos`: Kubernetes. [Example of CoreOS Master with CoreOS Agents](../examples/coreos/kubernetes-coreos.json)|
-|customFiles|no|The custom files to be provisioned to the master nodes. Defined as an array of json objects with each defined as `"Source":"absolute-local-path", "dest":"absolute-path-on-masternodes"`.[See examples](../examples/customfiles) |
+|customFiles|no|The custom files to be provisioned to the master nodes. Defined as an array of json objects with each defined as `"source":"absolute-local-path", "dest":"absolute-path-on-masternodes"`.[See examples](../examples/customfiles) |
 
 ### agentPoolProfiles
 A cluster can have 0 to 12 agent pool profiles. Agent Pool Profiles are used for creating agents with different capabilities such as VMSizes, VMSS or Availability Set, Public/Private access, user-defined OS Images, [attached storage disks](../examples/disks-storageaccount), [attached managed disks](../examples/disks-managed), or [Windows](../examples/windows).

--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -440,6 +440,7 @@ We consider `kubeletConfig`, `controllerManagerConfig`, `apiServerConfig`, and `
 |imageReference.name|no|The name of the Linux OS image. Needs to be used in conjunction with resourceGroup, below|
 |imageReference.resourceGroup|no|Resource group that contains the Linux OS image. Needs to be used in conjunction with name, above|
 |distro|no|Select Master(s) Operating System (Linux only). Currently supported values are: `ubuntu` and `coreos` (CoreOS support is currently experimental). Defaults to `ubuntu` if undefined. Currently supported OS and orchestrator configurations -- `ubuntu`: DCOS, Docker Swarm, Kubernetes; `RHEL`: OpenShift; `coreos`: Kubernetes. [Example of CoreOS Master with CoreOS Agents](../examples/coreos/kubernetes-coreos.json)|
+|customFiles|no|The custom files to be provisioned to the master nodes. Defined as an array of json objects with each defined as `"Source":"absolute-local-path", "dest":"absolute-path-on-masternodes"`.[See examples](../examples/customfiles) |
 
 ### agentPoolProfiles
 A cluster can have 0 to 12 agent pool profiles. Agent Pool Profiles are used for creating agents with different capabilities such as VMSizes, VMSS or Availability Set, Public/Private access, user-defined OS Images, [attached storage disks](../examples/disks-storageaccount), [attached managed disks](../examples/disks-managed), or [Windows](../examples/windows).

--- a/examples/customfiles/README.md
+++ b/examples/customfiles/README.md
@@ -23,7 +23,7 @@ podNodeSelectorPluginConfig:
  clusterDefaultNodeSelector: "agentpool=defaultpool"
 ```
 
-These two need to be provisioned to your master nodes in order for the api server to be able to use them. As seen in the example, the `apiServerConfig` inside the `kubernetsConfig` has been defined as:
+These two need to be provisioned to your master nodes in order for the api server to be able to use them. As seen in the example, the `apiServerConfig` inside the `kubernetesConfig` has been defined as:
 
 ```
 "apiServerConfig": {

--- a/examples/customfiles/README.md
+++ b/examples/customfiles/README.md
@@ -1,0 +1,34 @@
+# Microsoft Azure Container Service Engine - Provisioning of master node custom files
+
+## Overview
+
+ACS-Engine enables you to provision custom files to your master nodes. This can be used to put whichever files you want on your master nodes to whichever path you want (and have permission to). For example, the use case is when you want additional configurations to native kubernetes features, such as in
+the [given example](../examples/customfiles/kubernetes-customfiles-podnodeselector.yaml)
+
+## Examples
+[Admission control with pod node selector](../examples/customfiles/kubernetes-customfiles-podnodeselector.yaml) provisions two local files to defined paths on our master nodes. These files define admission control for the apiserver. They could look like:
+
+`admission-control.yaml`
+```
+kind: AdmissionConfiguration
+apiVersion: apiserver.k8s.io/v1alpha1
+plugins:
+- name: PodNodeSelector
+  path: /etc/kubernetes/podnodeselector.yaml
+```
+
+`podnodeselector.yaml`
+```
+podNodeSelectorPluginConfig:
+ clusterDefaultNodeSelector: "agentpool=defaultpool"
+```
+
+These two need to be provisioned to your master nodes in order for the api server to be able to use them. As seen in the example, the `apiServerConfig` inside the `kubernetsConfig` has been defined as:
+
+```
+"apiServerConfig": {
+    "--admission-control-config-file":  "/etc/kubernetes/admissioncontrol.yaml"
+}
+```
+
+This way, the files are provisioned to `/etc/kubernetes` on our master nodes and the apiserver boots up with those provisioned files defining the admission control.

--- a/examples/customfiles/kubernetes-customfiles-podnodeselector.json
+++ b/examples/customfiles/kubernetes-customfiles-podnodeselector.json
@@ -1,0 +1,59 @@
+{
+    "apiVersion": "vlabs",
+    "properties": {
+      "orchestratorProfile": {
+        "orchestratorType": "Kubernetes",
+        "orchestratorVersion": "1.10.2",
+        "kubernetesConfig": {
+          "enableRbac" : true,
+          "enableAggregatedAPIs": true,
+          "apiServerConfig": {
+            "--admission-control-config-file":  "/etc/kubernetes/admissioncontrol.yaml"
+          }
+        }
+      },
+      "aadProfile": {
+        "serverAppID": "",
+        "clientAppID": "",
+        "tenantID":    ""
+      },
+      "masterProfile": {
+        "count": 3,
+        "dnsPrefix": "",
+        "vmSize": "Standard_D4s_v3",
+        "customFiles": [
+            { 
+                "source":"/Users/user/files/admissioncontrol.yaml",
+                "dest":"/etc/kubernetes/admissioncontrol.yaml"
+            },
+            { 
+                "source":"/Users/user/files/podnodeselector.yaml",
+                "dest":"/etc/kubernetes/podnodeselector..yaml"
+            }
+        ]
+      },
+      "agentPoolProfiles": [
+        {
+          "name": "agentpool1",
+          "count": 4,
+          "vmSize": "Standard_D4s_v3",
+          "availabilityProfile": "VirtualMachineScaleSets",
+          "storageProfile": "ManagedDisks"
+        }
+      ],
+      "linuxProfile": {
+        "adminUsername": "admin",
+        "ssh": {
+          "publicKeys": [
+            {
+              "keyData": ""
+            }
+          ]
+        }
+      },
+      "servicePrincipalProfile": {
+        "clientId": "",
+        "secret": ""
+      }
+    }
+  }

--- a/examples/customfiles/kubernetes-customfiles-podnodeselector.json
+++ b/examples/customfiles/kubernetes-customfiles-podnodeselector.json
@@ -28,7 +28,7 @@
             },
             { 
                 "source":"/Users/user/files/podnodeselector.yaml",
-                "dest":"/etc/kubernetes/podnodeselector..yaml"
+                "dest":"/etc/kubernetes/podnodeselector.yaml"
             }
         ]
       },

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -142,6 +142,8 @@ MASTER_MANIFESTS_CONFIG_PLACEHOLDER
 
 MASTER_ADDONS_CONFIG_PLACEHOLDER
 
+MASTER_CUSTOM_FILES_PLACEHOLDER
+
 - path: "/etc/systemd/system/hyperkube-extract.service"
   permissions: "0644"
   owner: "root"

--- a/pkg/acsengine/customfiles.go
+++ b/pkg/acsengine/customfiles.go
@@ -1,0 +1,51 @@
+package acsengine
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/Azure/acs-engine/pkg/api"
+)
+
+func kubernetesCustomFiles(profile *api.Properties) []api.CustomFile {
+	if profile.OrchestratorProfile.KubernetesConfig.CustomFiles != nil {
+		return *profile.OrchestratorProfile.KubernetesConfig.CustomFiles
+	}
+	return []api.CustomFile{}
+}
+
+func substituteConfigStringCustomFiles(input string, customFiles []api.CustomFile, placeholder string) string {
+
+	var config string
+	for _, customFile := range customFiles {
+		config += buildConfigStringCustomFiles(
+			customFile.Source,
+			customFile.Dest)
+
+	}
+	return strings.Replace(input, placeholder, config, -1)
+}
+
+func buildConfigStringCustomFiles(sourceFile string, destinationFile string) string {
+	contents := []string{
+		fmt.Sprintf("- path: %s", destinationFile),
+		"  permissions: \\\"0644\\\"",
+		"  encoding: gzip",
+		"  owner: \\\"root\\\"",
+		"  content: !!binary |",
+		fmt.Sprintf("    %s\\n\\n", getBase64CustomFile(sourceFile)),
+	}
+
+	return strings.Join(contents, "\\n")
+}
+
+func getBase64CustomFile(cfFilepath string) string {
+	dat, err := ioutil.ReadFile(cfFilepath)
+	if err != nil {
+		panic(fmt.Sprintf("Could not read custom file: %s", err.Error()))
+	}
+	csStr := string(dat)
+	csStr = strings.Replace(csStr, "\r\n", "\n", -1)
+	return getBase64CustomScriptFromStr(csStr)
+}

--- a/pkg/acsengine/customfiles.go
+++ b/pkg/acsengine/customfiles.go
@@ -1,12 +1,21 @@
 package acsengine
 
 import (
+	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/Azure/acs-engine/pkg/api"
 )
+
+// CustomFileReader takes represents the source text of a file as an io.Reader and
+// the desired destination to add it to
+type CustomFileReader struct {
+	Source io.Reader
+	Dest   string
+}
 
 func kubernetesCustomFiles(profile *api.Properties) []api.CustomFile {
 	if profile.OrchestratorProfile.KubernetesConfig.CustomFiles != nil {
@@ -15,7 +24,22 @@ func kubernetesCustomFiles(profile *api.Properties) []api.CustomFile {
 	return []api.CustomFile{}
 }
 
-func substituteConfigStringCustomFiles(input string, customFiles []api.CustomFile, placeholder string) string {
+func customfilesIntoReaders(customFiles []api.CustomFile) ([]CustomFileReader, error) {
+	customFileReaders := make([]CustomFileReader, len(customFiles))
+	for idx, customFile := range customFiles {
+		file, err := os.Open(customFile.Source)
+		if err != nil {
+			return []CustomFileReader{}, err
+		}
+		customFileReaders[idx] = CustomFileReader{
+			Source: file,
+			Dest:   customFile.Dest,
+		}
+	}
+	return customFileReaders, nil
+}
+
+func substituteConfigStringCustomFiles(input string, customFiles []CustomFileReader, placeholder string) string {
 
 	var config string
 	for _, customFile := range customFiles {
@@ -27,25 +51,23 @@ func substituteConfigStringCustomFiles(input string, customFiles []api.CustomFil
 	return strings.Replace(input, placeholder, config, -1)
 }
 
-func buildConfigStringCustomFiles(sourceFile string, destinationFile string) string {
+func buildConfigStringCustomFiles(source io.Reader, destinationFile string) string {
 	contents := []string{
 		fmt.Sprintf("- path: %s", destinationFile),
 		"  permissions: \\\"0644\\\"",
 		"  encoding: gzip",
 		"  owner: \\\"root\\\"",
 		"  content: !!binary |",
-		fmt.Sprintf("    %s\\n\\n", getBase64CustomFile(sourceFile)),
+		fmt.Sprintf("    %s\\n\\n", getBase64CustomFile(source)),
 	}
 
 	return strings.Join(contents, "\\n")
 }
 
-func getBase64CustomFile(cfFilepath string) string {
-	dat, err := ioutil.ReadFile(cfFilepath)
-	if err != nil {
-		panic(fmt.Sprintf("Could not read custom file: %s", err.Error()))
-	}
-	csStr := string(dat)
-	csStr = strings.Replace(csStr, "\r\n", "\n", -1)
-	return getBase64CustomScriptFromStr(csStr)
+func getBase64CustomFile(source io.Reader) string {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(source)
+	cfStr := buf.String()
+	cfStr = strings.Replace(cfStr, "\r\n", "\n", -1)
+	return getBase64CustomScriptFromStr(cfStr)
 }

--- a/pkg/acsengine/customfiles.go
+++ b/pkg/acsengine/customfiles.go
@@ -17,9 +17,9 @@ type CustomFileReader struct {
 	Dest   string
 }
 
-func kubernetesCustomFiles(profile *api.Properties) []api.CustomFile {
-	if profile.OrchestratorProfile.KubernetesConfig.CustomFiles != nil {
-		return *profile.OrchestratorProfile.KubernetesConfig.CustomFiles
+func masterCustomFiles(profile *api.Properties) []api.CustomFile {
+	if profile.MasterProfile.CustomFiles != nil {
+		return *profile.MasterProfile.CustomFiles
 	}
 	return []api.CustomFile{}
 }

--- a/pkg/acsengine/customfiles_test.go
+++ b/pkg/acsengine/customfiles_test.go
@@ -1,0 +1,103 @@
+package acsengine
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Azure/acs-engine/pkg/api"
+)
+
+func TestCustomFilesIntoReadersNonExistingFile(t *testing.T) {
+
+	customFiles := []api.CustomFile{
+		{
+			Source: "no/path/doesnt/exist/nofile",
+			Dest:   "/tmp/output",
+		},
+	}
+	_, err := customfilesIntoReaders(customFiles)
+	if err == nil {
+		t.Fatalf("Error was not thrown when reading file in path: %s", customFiles[0].Source)
+	}
+
+}
+
+//What the output should look like for a file with content "test"
+var testFullStringSlice = []string{
+	fmt.Sprintf("- path: %s", "/tmp/test"),
+	"  permissions: \\\"0644\\\"",
+	"  encoding: gzip",
+	"  owner: \\\"root\\\"",
+	"  content: !!binary |",
+	fmt.Sprintf("    %s\\n\\n", "H4sIAAAAAAAA/ypJLS4BBAAA//8Mfn/YBAAAAA=="),
+}
+
+//What the output should look like for a file with content "filecontent"
+var fileContentFullStringSlice = []string{
+	fmt.Sprintf("- path: %s", "/tmp/test"),
+	"  permissions: \\\"0644\\\"",
+	"  encoding: gzip",
+	"  owner: \\\"root\\\"",
+	"  content: !!binary |",
+	fmt.Sprintf("    %s\\n\\n", "H4sIAAAAAAAA/0rLzElNzs8rSc0rAQQAAP//lfHhvwsAAAA="),
+}
+
+func TestSubstituteConfigStringCustomFiles(t *testing.T) {
+	//Set up string we are about to modify
+	str := `
+	some stuff
+
+	MASTER_CUSTOM_FILES_PLACEHOLDER
+
+	some more stuff
+	`
+	//Define the correct output string using the above defined slices
+	preCorrectStr := `
+	some stuff
+
+	%s
+
+	some more stuff
+	`
+	contents := fmt.Sprintf("%s%s", strings.Join(testFullStringSlice, "\\n"), strings.Join(fileContentFullStringSlice, "\\n"))
+	correctStr := fmt.Sprintf(preCorrectStr, contents)
+
+	//Add new readers with hard coded strings corresponding to correct output string
+	customFilesReader := []CustomFileReader{
+		{
+			Source: strings.NewReader("test"),
+			Dest:   "/tmp/test",
+		},
+		{
+			Source: strings.NewReader("filecontent"),
+			Dest:   "/tmp/test",
+		},
+	}
+
+	str = substituteConfigStringCustomFiles(str,
+		customFilesReader,
+		"MASTER_CUSTOM_FILES_PLACEHOLDER")
+
+	if str != correctStr {
+		t.Fatalf("Parsed string was not correct from substituteConfigStringCustomFiles")
+	}
+
+}
+
+func TestBuildConfigStringCustomFiles(t *testing.T) {
+	configStrOutput := buildConfigStringCustomFiles(strings.NewReader("test"), "/tmp/test")
+	correctOutput := strings.Join(testFullStringSlice, "\\n")
+	if configStrOutput != correctOutput {
+		t.Fatalf("Parsed string was not correct from buildConfigStringCustomFiles")
+	}
+}
+
+func TestGetBase64CustomFile(t *testing.T) {
+	b64outputStr := getBase64CustomFile(strings.NewReader("test"))
+	correctOutput := "H4sIAAAAAAAA/ypJLS4BBAAA//8Mfn/YBAAAAA=="
+	if b64outputStr != correctOutput {
+		t.Fatalf("b64 encoded and zipped string: \"test\" from getBase64CustomFile is not correct ")
+	}
+
+}

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/acs-engine/pkg/helpers"
 	"github.com/Azure/acs-engine/pkg/i18n"
 	"github.com/Masterminds/semver"
+	log "github.com/sirupsen/logrus"
 )
 
 // TemplateGenerator represents the object that performs the template generation.
@@ -491,6 +492,15 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 				"/etc/kubernetes/addons",
 				"MASTER_ADDONS_CONFIG_PLACEHOLDER",
 				profile.OrchestratorProfile.OrchestratorVersion)
+
+			// add custom files
+			customFilesReader, err := customfilesIntoReaders(masterCustomFiles(profile))
+			if err != nil {
+				log.Fatalf("Could not read custom files: %s", err.Error())
+			}
+			str = substituteConfigStringCustomFiles(str,
+				customFilesReader,
+				"MASTER_CUSTOM_FILES_PLACEHOLDER")
 
 			// return the custom data
 			return fmt.Sprintf("\"customData\": \"[base64(concat('%s'))]\",", str)

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -756,6 +756,18 @@ func convertKubeletConfigToVlabs(a *KubernetesConfig, v *vlabs.KubernetesConfig)
 	}
 }
 
+func convertCustomFilesToVlabs(a *MasterProfile, v *vlabs.MasterProfile) {
+	if a.CustomFiles != nil {
+		v.CustomFiles = &[]vlabs.CustomFile{}
+		for i := range *a.CustomFiles {
+			*v.CustomFiles = append(*v.CustomFiles, vlabs.CustomFile{
+				Dest:   (*a.CustomFiles)[i].Dest,
+				Source: (*a.CustomFiles)[i].Source,
+			})
+		}
+	}
+}
+
 func convertControllerManagerConfigToVlabs(a *KubernetesConfig, v *vlabs.KubernetesConfig) {
 	v.ControllerManagerConfig = map[string]string{}
 	for key, val := range a.ControllerManagerConfig {
@@ -897,6 +909,8 @@ func convertMasterProfileToVLabs(api *MasterProfile, vlabsProfile *vlabs.MasterP
 		vlabsProfile.ImageRef.Name = api.ImageRef.Name
 		vlabsProfile.ImageRef.ResourceGroup = api.ImageRef.ResourceGroup
 	}
+
+	convertCustomFilesToVlabs(api, vlabsProfile)
 }
 
 func convertKeyVaultSecretsToVlabs(api *KeyVaultSecrets, vlabsSecrets *vlabs.KeyVaultSecrets) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -704,7 +704,6 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 	convertAPIServerConfigToAPI(vlabs, api)
 	convertSchedulerConfigToAPI(vlabs, api)
 	convertPrivateClusterToAPI(vlabs, api)
-	convertCustomFilesToAPI(vlabs, api)
 }
 
 func setVlabsKubernetesDefaults(vp *vlabs.Properties, api *OrchestratorProfile) {
@@ -761,7 +760,7 @@ func convertAddonsToAPI(v *vlabs.KubernetesConfig, a *KubernetesConfig) {
 	}
 }
 
-func convertCustomFilesToAPI(v *vlabs.KubernetesConfig, a *KubernetesConfig) {
+func convertCustomFilesToAPI(v *vlabs.MasterProfile, a *MasterProfile) {
 	if v.CustomFiles != nil {
 		a.CustomFiles = &[]CustomFile{}
 		for i := range *v.CustomFiles {
@@ -915,6 +914,8 @@ func convertVLabsMasterProfile(vlabs *vlabs.MasterProfile, api *MasterProfile) {
 		api.ImageRef.Name = vlabs.ImageRef.Name
 		api.ImageRef.ResourceGroup = vlabs.ImageRef.ResourceGroup
 	}
+
+	convertCustomFilesToAPI(vlabs, api)
 }
 
 func convertV20160930AgentPoolProfile(v20160930 *v20160930.AgentPoolProfile, availabilityProfile string, api *AgentPoolProfile) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -704,6 +704,7 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 	convertAPIServerConfigToAPI(vlabs, api)
 	convertSchedulerConfigToAPI(vlabs, api)
 	convertPrivateClusterToAPI(vlabs, api)
+	convertCustomFilesToAPI(vlabs, api)
 }
 
 func setVlabsKubernetesDefaults(vp *vlabs.Properties, api *OrchestratorProfile) {
@@ -756,6 +757,18 @@ func convertAddonsToAPI(v *vlabs.KubernetesConfig, a *KubernetesConfig) {
 			for key, val := range v.Addons[i].Config {
 				a.Addons[i].Config[key] = val
 			}
+		}
+	}
+}
+
+func convertCustomFilesToAPI(v *vlabs.KubernetesConfig, a *KubernetesConfig) {
+	if v.CustomFiles != nil {
+		a.CustomFiles = &[]CustomFile{}
+		for i := range *v.CustomFiles {
+			*a.CustomFiles = append(*a.CustomFiles, CustomFile{
+				Dest:   (*v.CustomFiles)[i].Dest,
+				Source: (*v.CustomFiles)[i].Source,
+			})
 		}
 	}
 }

--- a/pkg/api/convertertoapi_test.go
+++ b/pkg/api/convertertoapi_test.go
@@ -230,3 +230,25 @@ func makeKubernetesPropertiesVlabs() *vlabs.Properties {
 	vp.OrchestratorProfile.OrchestratorType = "Kubernetes"
 	return vp
 }
+
+func TestConvertCustomFilesToAPI(t *testing.T) {
+	expectedApiCustomFiles := []CustomFile{
+		CustomFile{
+			Source: "/test/source",
+			Dest:   "/test/dest",
+		},
+	}
+	apiKubeConfig := KubernetesConfig{}
+
+	vp := &vlabs.KubernetesConfig{}
+	vp.CustomFiles = &[]vlabs.CustomFile{
+		vlabs.CustomFile{
+			Source: "/test/source",
+			Dest:   "/test/dest",
+		},
+	}
+	convertCustomFilesToAPI(vp, &apiKubeConfig)
+	if !equality.Semantic.DeepEqual(&expectedApiCustomFiles, apiKubeConfig.CustomFiles) {
+		t.Fatalf("convertCustomFilesToApi conversion of vlabs.KubernetesConfig did not convert correctly")
+	}
+}

--- a/pkg/api/convertertoapi_test.go
+++ b/pkg/api/convertertoapi_test.go
@@ -238,17 +238,17 @@ func TestConvertCustomFilesToAPI(t *testing.T) {
 			Dest:   "/test/dest",
 		},
 	}
-	apiKubeConfig := KubernetesConfig{}
+	masterProfile := MasterProfile{}
 
-	vp := &vlabs.KubernetesConfig{}
+	vp := &vlabs.MasterProfile{}
 	vp.CustomFiles = &[]vlabs.CustomFile{
 		{
 			Source: "/test/source",
 			Dest:   "/test/dest",
 		},
 	}
-	convertCustomFilesToAPI(vp, &apiKubeConfig)
-	if !equality.Semantic.DeepEqual(&expectedAPICustomFiles, apiKubeConfig.CustomFiles) {
-		t.Fatalf("convertCustomFilesToApi conversion of vlabs.KubernetesConfig did not convert correctly")
+	convertCustomFilesToAPI(vp, &masterProfile)
+	if !equality.Semantic.DeepEqual(&expectedAPICustomFiles, masterProfile.CustomFiles) {
+		t.Fatalf("convertCustomFilesToApi conversion of vlabs.MasterProfile did not convert correctly")
 	}
 }

--- a/pkg/api/convertertoapi_test.go
+++ b/pkg/api/convertertoapi_test.go
@@ -232,8 +232,8 @@ func makeKubernetesPropertiesVlabs() *vlabs.Properties {
 }
 
 func TestConvertCustomFilesToAPI(t *testing.T) {
-	expectedApiCustomFiles := []CustomFile{
-		CustomFile{
+	expectedAPICustomFiles := []CustomFile{
+		{
 			Source: "/test/source",
 			Dest:   "/test/dest",
 		},
@@ -242,13 +242,13 @@ func TestConvertCustomFilesToAPI(t *testing.T) {
 
 	vp := &vlabs.KubernetesConfig{}
 	vp.CustomFiles = &[]vlabs.CustomFile{
-		vlabs.CustomFile{
+		{
 			Source: "/test/source",
 			Dest:   "/test/dest",
 		},
 	}
 	convertCustomFilesToAPI(vp, &apiKubeConfig)
-	if !equality.Semantic.DeepEqual(&expectedApiCustomFiles, apiKubeConfig.CustomFiles) {
+	if !equality.Semantic.DeepEqual(&expectedAPICustomFiles, apiKubeConfig.CustomFiles) {
 		t.Fatalf("convertCustomFilesToApi conversion of vlabs.KubernetesConfig did not convert correctly")
 	}
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -318,7 +318,6 @@ type KubernetesConfig struct {
 	CtrlMgrNodeMonitorGracePeriod    string            `json:"ctrlMgrNodeMonitorGracePeriod,omitempty"`
 	CtrlMgrPodEvictionTimeout        string            `json:"ctrlMgrPodEvictionTimeout,omitempty"`
 	CtrlMgrRouteReconciliationPeriod string            `json:"ctrlMgrRouteReconciliationPeriod,omitempty"`
-	CustomFiles                      *[]CustomFile     `json:"customFiles,omitempty"`
 }
 
 // CustomFile has source as the full absolute source path to a file and dest
@@ -384,6 +383,7 @@ type MasterProfile struct {
 	Distro                   Distro            `json:"distro,omitempty"`
 	KubernetesConfig         *KubernetesConfig `json:"kubernetesConfig,omitempty"`
 	ImageRef                 *ImageReference   `json:"imageReference,omitempty"`
+	CustomFiles              *[]CustomFile     `json:"customFiles,omitempty"`
 
 	// Master LB public endpoint/FQDN with port
 	// The format will be FQDN:2376

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -318,6 +318,14 @@ type KubernetesConfig struct {
 	CtrlMgrNodeMonitorGracePeriod    string            `json:"ctrlMgrNodeMonitorGracePeriod,omitempty"`
 	CtrlMgrPodEvictionTimeout        string            `json:"ctrlMgrPodEvictionTimeout,omitempty"`
 	CtrlMgrRouteReconciliationPeriod string            `json:"ctrlMgrRouteReconciliationPeriod,omitempty"`
+	CustomFiles                      *[]CustomFile     `json:"customFiles,omitempty"`
+}
+
+// CustomFile has source as the full absolute source path to a file and dest
+// is the full absolute desired destination path to put the file on a master node
+type CustomFile struct {
+	Source string `json:"source,omitempty"`
+	Dest   string `json:"dest,omitempty"`
 }
 
 // BootstrapProfile represents the definition of the DCOS bootstrap node used to deploy the cluster

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -311,7 +311,6 @@ type KubernetesConfig struct {
 	CloudProviderRateLimit          bool              `json:"cloudProviderRateLimit,omitempty"`
 	CloudProviderRateLimitQPS       float64           `json:"cloudProviderRateLimitQPS,omitempty"`
 	CloudProviderRateLimitBucket    int               `json:"cloudProviderRateLimitBucket,omitempty"`
-	CustomFiles                     *[]CustomFile     `json:"customFiles,omitempty"`
 }
 
 // CustomFile has source as the full absolute source path to a file and dest
@@ -376,6 +375,7 @@ type MasterProfile struct {
 	Distro                   Distro            `json:"distro,omitempty"`
 	KubernetesConfig         *KubernetesConfig `json:"kubernetesConfig,omitempty"`
 	ImageRef                 *ImageReference   `json:"imageReference,omitempty"`
+	CustomFiles              *[]CustomFile     `json:"customFiles,omitempty"`
 
 	// subnet is internal
 	subnet string

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -311,6 +311,14 @@ type KubernetesConfig struct {
 	CloudProviderRateLimit          bool              `json:"cloudProviderRateLimit,omitempty"`
 	CloudProviderRateLimitQPS       float64           `json:"cloudProviderRateLimitQPS,omitempty"`
 	CloudProviderRateLimitBucket    int               `json:"cloudProviderRateLimitBucket,omitempty"`
+	CustomFiles                     *[]CustomFile     `json:"customFiles,omitempty"`
+}
+
+// CustomFile has source as the full absolute source path to a file and dest
+// is the full absolute desired destination path to put the file on a master node
+type CustomFile struct {
+	Source string `json:"source,omitempty"`
+	Dest   string `json:"dest,omitempty"`
 }
 
 // BootstrapProfile represents the definition of the DCOS bootstrap node used to deploy the cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds possibility to pass in custom files to the master nodes. The use case for this is when adding an admission control config file as 
```
"apiServerConfig": {
          "--admission-control-config-file":  "/etc/kubernetes/admissioncontrol.yaml"
        }
```
In that case, we need to provision the yaml file somehow. And since I did not find anyway to do this I added so it can be added to the `kubernetes.json`. It currently only works with the `vlabs` api version (which is the one we use). Since mapping is done between all the version more work might be required to support it or other api versions.

The way we now can use this in our `kubernetesConfig` is

 ```{
  "apiVersion": "vlabs",
  "properties": {
    "orchestratorProfile": {
      "orchestratorType": "Kubernetes",
      "orchestratorVersion": "1.10.0",
      "kubernetesConfig": {
        "apiServerConfig": {
          "--admission-control-config-file":  "/etc/kubernetes/admissioncontrol.yaml"
        },
        "customFiles":[
          {"source":"<path>/admissioncontrol.yaml",
           "dest":"/etc/kubernetes/admissioncontrol.yaml"
          },
          {"source":"<path>/podnodeselector.yaml",
           "dest":"/etc/kubernetes/podnodeselector.yaml"
          }
        ]
      }

...

```
where we need to use the full absolute path for both source and dest.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This PR might as mentioned not work for all api versions so are open for feedback regarding implementing for all the api versions it should work for.

**If applicable**:

**Release note**:
NONE 