### PR TITLE
Cleanup openshift file permissions and ownership.

### DIFF
--- a/parts/openshift/openshiftmasterscript.sh
+++ b/parts/openshift/openshiftmasterscript.sh
@@ -35,10 +35,6 @@ oc adm create-bootstrap-policy-file --filename=/etc/origin/master/policy.json
 
 ( cd / && base64 -d <<< {{ .ConfigBundle }} | tar -xz)
 
-chown -R etcd:etcd /etc/etcd
-chmod 0600 /etc/origin/master/htpasswd
-chmod 1777 /tmp
-
 cp /etc/origin/node/ca.crt /etc/pki/ca-trust/source/anchors/openshift-ca.crt
 update-ca-trust
 

--- a/pkg/openshift/certgen/config_test.go
+++ b/pkg/openshift/certgen/config_test.go
@@ -1,0 +1,90 @@
+package certgen
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Azure/acs-engine/pkg/openshift/filesystem"
+)
+
+type fakefilesystem map[string]filesystem.Fileinfo
+
+func (f fakefilesystem) WriteFile(filename string, data []byte, fi filesystem.Fileinfo) error {
+	f[filename] = fi
+	// fmt.Printf("Filename: %v	User: %s	Group: %s	Permissions: %04o   string: %v\n", filename, fi.User, fi.Group, fi.Mode, fi.Mode.String())
+	return nil
+}
+
+func (f fakefilesystem) Mkdir(filename string, fi filesystem.Fileinfo) error {
+	// fmt.Printf("Filename: %v	User: %s	Group: %s	Permissions: %04o   string: %v\n", filename, fi.User, fi.Group, fi.Mode, fi.Mode.String())
+	f[filename] = fi
+	return nil
+}
+
+func (fakefilesystem) Close() error {
+	return nil
+}
+
+var _ filesystem.Filesystem = &fakefilesystem{}
+
+func TestConfigFilePermissions(t *testing.T) {
+	c := Config{
+		Master: &Master{
+			Hostname: fmt.Sprintf("%s-master-%s-0", "test", "test"),
+			IPs: []net.IP{
+				net.ParseIP("10.0.0.1"),
+			},
+		},
+	}
+
+	err := c.PrepareMasterCerts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.PrepareMasterKubeConfigs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.PrepareMasterFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.PrepareBootstrapKubeConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create mock filesystem
+	fs := fakefilesystem{}
+
+	err = c.WriteMaster(fs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for fname, finfo := range fs {
+		fi := GetFileInfo(fname)
+		// fmt.Printf("fname=>[%s]\n", fname)
+		// Verify ownership and permissions are as expected
+		if fi.User != finfo.User {
+			t.Errorf("File: %s  User does not match.   user: %s  expected: %s", fname, finfo.User, fi.User)
+		}
+		if fi.Group != finfo.Group {
+			t.Errorf("File: %s  Group does not match.  group: %s  expected: %s", fname, finfo.Group, fi.Group)
+		}
+		if fi.Mode != 0 && fi.Mode != finfo.Mode {
+			t.Errorf("File: %s  Mode does not match.   mode: %04o  expected: %04o", fname, finfo.Mode, fi.Mode)
+		}
+		// Check for .key does _not_ have read or write
+		if strings.HasSuffix(fname, ".key") && finfo.Mode&077 != 0 {
+			t.Errorf("File: %s  Found Read or Write on key file. mode: %04o  expected: 0600", fname, finfo.Mode)
+		}
+		if fname == "tmp" && fi.Mode != os.FileMode(01777) {
+			t.Errorf("File: %s  /tmp should have 1777 file mode.", fname)
+		}
+	}
+}

--- a/pkg/openshift/certgen/files.go
+++ b/pkg/openshift/certgen/files.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/base64"
+	"os"
 	"regexp"
 	"strings"
 	"text/template"
@@ -12,6 +13,50 @@ import (
 	"github.com/Azure/acs-engine/pkg/openshift/filesystem"
 	"golang.org/x/crypto/bcrypt"
 )
+
+type modeinfo struct {
+	path  *regexp.Regexp
+	mode  os.FileMode
+	user  string
+	group string
+}
+
+// These ownerships are processed in order
+var ownerships = []modeinfo{
+	// etc/etcd directory
+	{path: regexp.MustCompile(`^etc/etcd$`), mode: 0755, user: "etcd", group: "etcd"},
+	// tmp directory
+	{path: regexp.MustCompile(`^tmp$`), mode: 01777, user: "root", group: "root"},
+	//start files
+	{path: regexp.MustCompile(`^etc/etcd/.*\.key$`), mode: 0600, user: "etcd", group: "etcd"},
+	{path: regexp.MustCompile(`^etc/etcd/.*$`), user: "etcd", group: "etcd"},
+	{path: regexp.MustCompile(`.*\.key$`), mode: 0600},
+	{path: regexp.MustCompile(`.*\.kubeconfig$`), mode: 0600},
+	{path: regexp.MustCompile(`^etc/origin/master/htpasswd$`), mode: 0600},
+}
+
+// GetFileInfo returns the permissions and ownership of the file if defined
+func GetFileInfo(filename string) filesystem.Fileinfo {
+	// If filename matches a specific path then set the correct User, Group, and Mode
+	f := filesystem.Fileinfo{User: "root", Group: "root", Mode: 0644}
+	for _, owner := range ownerships {
+
+		if owner.path.MatchString(filename) {
+			if owner.user != "" {
+				f.User = owner.user
+			}
+			if owner.group != "" {
+				f.Group = owner.group
+			}
+			if owner.mode != 0 {
+				f.Mode = owner.mode
+			}
+			break
+		}
+	}
+
+	return f
+}
 
 // PrepareMasterFiles creates the shared authentication and encryption secrets
 func (c *Config) PrepareMasterFiles() error {
@@ -33,6 +78,28 @@ func (c *Config) PrepareMasterFiles() error {
 
 // WriteMasterFiles writes the templated master config
 func (c *Config) WriteMasterFiles(fs filesystem.Filesystem) error {
+
+	// create special case directories
+	specialCaseDirs := map[string]filesystem.Fileinfo{
+		"tmp": {
+			User:  "root",
+			Group: "root",
+			Mode:  os.FileMode(01777),
+		},
+		"etc/etcd": {
+			Mode:  os.FileMode(0755),
+			User:  "etcd",
+			Group: "etcd",
+		},
+	}
+
+	for na, fi := range specialCaseDirs {
+		err := fs.Mkdir(na, fi)
+		if err != nil {
+			return err
+		}
+	}
+
 	for _, name := range templates.AssetNames() {
 		if !strings.HasPrefix(name, "master/") {
 			continue
@@ -56,7 +123,10 @@ func (c *Config) WriteMasterFiles(fs filesystem.Filesystem) error {
 			return err
 		}
 
-		err = fs.WriteFile(strings.TrimPrefix(name, "master/"), b.Bytes(), 0644)
+		fname := strings.TrimPrefix(name, "master/")
+		fi := GetFileInfo(fname)
+
+		err = fs.WriteFile(fname, b.Bytes(), fi)
 		if err != nil {
 			return err
 		}
@@ -87,7 +157,10 @@ func (c *Config) WriteNodeFiles(fs filesystem.Filesystem) error {
 			return err
 		}
 
-		err = fs.WriteFile(strings.TrimPrefix(name, "node/"), b.Bytes(), 0644)
+		fname := strings.TrimPrefix(name, "node/")
+		fi := GetFileInfo(fname)
+
+		err = fs.WriteFile(fname, b.Bytes(), fi)
 		if err != nil {
 			return err
 		}

--- a/pkg/openshift/certgen/kubeconfig.go
+++ b/pkg/openshift/certgen/kubeconfig.go
@@ -3,6 +3,7 @@ package certgen
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/Azure/acs-engine/pkg/openshift/filesystem"
@@ -267,7 +268,7 @@ func (c *Config) WriteMasterKubeConfigs(fs filesystem.Filesystem) error {
 		if err != nil {
 			return err
 		}
-		err = fs.WriteFile(filename, b, 0600)
+		err = fs.WriteFile(filename, b, filesystem.Fileinfo{User: "root", Group: "root", Mode: os.FileMode(0600)})
 		if err != nil {
 			return err
 		}
@@ -282,5 +283,6 @@ func (c *Config) WriteBootstrapKubeConfig(fs filesystem.Filesystem) error {
 	if err != nil {
 		return err
 	}
-	return fs.WriteFile("etc/origin/node/bootstrap.kubeconfig", b, 0600)
+
+	return fs.WriteFile("etc/origin/node/bootstrap.kubeconfig", b, filesystem.Fileinfo{User: "root", Group: "root", Mode: os.FileMode(0600)})
 }

--- a/pkg/openshift/certgen/tls.go
+++ b/pkg/openshift/certgen/tls.go
@@ -107,8 +107,8 @@ func writeCert(fs filesystem.Filesystem, filename string, cert *x509.Certificate
 	if err != nil {
 		return err
 	}
-
-	return fs.WriteFile(filename, b, 0644)
+	fi := GetFileInfo(filename)
+	return fs.WriteFile(filename, b, fi)
 }
 
 func privateKeyAsBytes(key *rsa.PrivateKey) ([]byte, error) {
@@ -128,7 +128,8 @@ func writePrivateKey(fs filesystem.Filesystem, filename string, key *rsa.Private
 		return err
 	}
 
-	return fs.WriteFile(filename, b, 0600)
+	fi := GetFileInfo(filename)
+	return fs.WriteFile(filename, b, fi)
 }
 
 func writePublicKey(fs filesystem.Filesystem, filename string, key *rsa.PublicKey) error {
@@ -143,8 +144,8 @@ func writePublicKey(fs filesystem.Filesystem, filename string, key *rsa.PublicKe
 	if err != nil {
 		return err
 	}
-
-	return fs.WriteFile(filename, buf.Bytes(), 0644)
+	fi := GetFileInfo(filename)
+	return fs.WriteFile(filename, buf.Bytes(), fi)
 }
 
 // PrepareMasterCerts creates the master certs
@@ -461,8 +462,9 @@ func (c *Config) WriteMasterCerts(fs filesystem.Filesystem) error {
 			return err
 		}
 	}
-
-	return fs.WriteFile("etc/origin/master/ca.serial.txt", []byte(fmt.Sprintf("%02X\n", c.serial.Get())), 0644)
+	fname := "etc/origin/master/ca.serial.txt"
+	fi := GetFileInfo(fname)
+	return fs.WriteFile(fname, []byte(fmt.Sprintf("%02X\n", c.serial.Get())), fi)
 }
 
 // WriteBootstrapCerts writes the node bootstrap certs


### PR DESCRIPTION
@kargakis @jim-minter 
This is cleanup around the openshiftmaster.sh. 

- Remove permissions from openshiftmaster.sh
- place permissions for specific files in pkg/openshift/filesystem/filesystem.go
- added a few tests in attempt to verify these permissions

Fixes #2683 