### PR TITLE
acs-engine Docker Image Rework

### DIFF
--- a/releases/Dockerfile.linux
+++ b/releases/Dockerfile.linux
@@ -1,6 +1,6 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
-ARG ACSENGINE_VERSION
+ARG ACSENGINE_VERSION=0.16.0
 ARG BUILD_DATE
 
 # Metadata as defined at http://label-schema.org
@@ -17,15 +17,16 @@ LABEL maintainer="Microsoft" \
       org.label-schema.vcs-url="https://github.com/Azure/acs-engine.git" \
       org.label-schema.docker.cmd="docker run -v \${PWD}:/acs-engine/workspace -it --rm microsoft/acs-engine:$ACSENGINE_VERSION"
 
-RUN apk add --update bash curl && \
-    rm -rf /var/cache/apk/* 
-     
-RUN curl -L "https://github.com/Azure/acs-engine/releases/download/v${ACSENGINE_VERSION}/acs-engine-v${ACSENGINE_VERSION}-linux-amd64.tar.gz" | tar xvz -C ~ && \
-    chown -R root:root ~/acs-engine-v${ACSENGINE_VERSION}-linux-amd64 && \
-    ln -s ~/acs-engine-v${ACSENGINE_VERSION}-linux-amd64/acs-engine /usr/local/bin/acs-engine && \
-    chmod +x /usr/local/bin/acs-engine && \
-    echo 'PS1="acs-engine# "' > ~/.bashrc
+ADD "https://github.com/Azure/acs-engine/releases/download/v${ACSENGINE_VERSION}/acs-engine-v${ACSENGINE_VERSION}-linux-amd64.tar.gz" /tmp/acs-engine.tgz
+
+RUN mkdir /opt/ && \
+    tar xvzf /tmp/acs-engine.tgz -C /opt/ && \
+    rm /tmp/acs-engine.tgz && \
+    chown -R root:root /opt/acs-engine-v${ACSENGINE_VERSION}-linux-amd64 && \
+    ln -s /opt/acs-engine-v${ACSENGINE_VERSION}-linux-amd64/acs-engine /usr/local/bin/acs-engine && \
+    chmod +x /usr/local/bin/acs-engine
 
 WORKDIR /acs-engine/workspace
 
-CMD bash
+ENTRYPOINT [ "acs-engine" ]
+CMD [ "--help" ]

--- a/releases/README.Dockerfile.md
+++ b/releases/README.Dockerfile.md
@@ -2,12 +2,12 @@
 
 **Bash**
 ```bash
-$ VERSION=0.8.0
+$ VERSION=0.16.0
 $ docker build --no-cache --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --build-arg ACSENGINE_VERSION="$VERSION" -t microsoft/acs-engine:$VERSION --file ./Dockerfile.linux .
 ```
 **PowerShell**
 ```powershell
-PS> $VERSION="0.8.0"
+PS> $VERSION="0.16.0"
 PS> docker build --no-cache --build-arg BUILD_DATE=$(Get-Date((Get-Date).ToUniversalTime()) -UFormat "%Y-%m-%dT%H:%M:%SZ") --build-arg ACSENGINE_VERSION="$VERSION" -t microsoft/acs-engine:$VERSION --file .\Dockerfile.linux .
 ```
 
@@ -15,12 +15,12 @@ PS> docker build --no-cache --build-arg BUILD_DATE=$(Get-Date((Get-Date).ToUnive
 
 **Bash**
 ```bash
-$ docker image inspect microsoft/acs-engine:0.8.0 --format "{{json .Config.Labels}}" | jq
+$ docker image inspect microsoft/acs-engine:0.16.0 --format "{{json .Config.Labels}}" | jq
 {
   "maintainer": "Microsoft",
   "org.label-schema.build-date": "2017-10-25T04:35:06Z",
   "org.label-schema.description": "The Azure Container Service Engine (acs-engine) generates ARM (Azure Resource Manager) templates for Docker enabled clusters on Microsoft Azure with your choice of DCOS, Kubernetes, or Swarm orchestrators.",
-  "org.label-schema.docker.cmd": "docker run -v ${PWD}:/acs-engine/workspace -it --rm microsoft/acs-engine:0.8.0",
+  "org.label-schema.docker.cmd": "docker run -v ${PWD}:/acs-engine/workspace -it --rm microsoft/acs-engine:0.16.0",
   "org.label-schema.license": "MIT",
   "org.label-schema.name": "Azure Container Service Engine (acs-engine)",
   "org.label-schema.schema-version": "1.0",
@@ -28,18 +28,18 @@ $ docker image inspect microsoft/acs-engine:0.8.0 --format "{{json .Config.Label
   "org.label-schema.usage": "https://github.com/Azure/acs-engine/blob/master/docs/acsengine.md",
   "org.label-schema.vcs-url": "https://github.com/Azure/acs-engine.git",
   "org.label-schema.vendor": "Microsoft",
-  "org.label-schema.version": "0.8.0"
+  "org.label-schema.version": "0.16.0"
 }
 ```
 
 **PowerShell**
 ```powershell
-PS> docker image inspect microsoft/acs-engine:0.8.0 --format "{{json .Config.Labels}}" | ConvertFrom-Json | ConvertTo-Json
+PS> docker image inspect microsoft/acs-engine:0.16.0 --format "{{json .Config.Labels}}" | ConvertFrom-Json | ConvertTo-Json
 {
     "maintainer":  "Microsoft",
     "org.label-schema.build-date":  "2017-10-25T04:35:06Z",
     "org.label-schema.description":  "The Azure Container Service Engine (acs-engine) generates ARM (Azure Resource Manager) templates for Docker enabled clusters on Microsoft Azure with your choice of DCOS, Kubernetes, or Swarm orchestrators.",
-    "org.label-schema.docker.cmd":  "docker run -v ${PWD}:/acs-engine/workspace -it --rm microsoft/acs-engine:0.8.0",
+    "org.label-schema.docker.cmd":  "docker run -v ${PWD}:/acs-engine/workspace -it --rm microsoft/acs-engine:0.16.0",
     "org.label-schema.license":  "MIT",
     "org.label-schema.name":  "Azure Container Service Engine (acs-engine)",
     "org.label-schema.schema-version":  "1.0",
@@ -47,12 +47,12 @@ PS> docker image inspect microsoft/acs-engine:0.8.0 --format "{{json .Config.Lab
     "org.label-schema.usage":  "https://github.com/Azure/acs-engine/blob/master/docs/acsengine.md",
     "org.label-schema.vcs-url":  "https://github.com/Azure/acs-engine.git",
     "org.label-schema.vendor":  "Microsoft",
-    "org.label-schema.version":  "0.8.0"
+    "org.label-schema.version":  "0.16.0"
 }
 ```
 
 # Run Docker image
 
 ```
-$ docker run -v ${PWD}:/acs-engine/workspace -it --rm microsoft/acs-engine:0.8.0
+$ docker run -v ${PWD}:/acs-engine/workspace -it --rm microsoft/acs-engine:0.16.0
 ```


### PR DESCRIPTION
This commit reworks Dockerfile.linux to make it more in-line with Docker
and Linux best practices.

* Set entrypoint to acs-engine
* Set default parameters to show acs-engine help
* Set default ACSENGINE_VERSION to latest release
* Remove unnecessary curl install
* Remove unnecessary bash install
* Use /opt/ as intall dir rather than root home
* Newer version of alpine
* Update README to use latest release version

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
