### PR TITLE
Add the new signing key for the azure cli package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,12 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > mic
     && apt-get update \
     && apt-get -y install dotnet-sdk-2.1.2
 
-# See: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest#install-on-debianubuntu-with-apt-get
+# See: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt
 RUN apt-get update \
     && apt-get install apt-transport-https \
     && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" > /etc/apt/sources.list.d/azure-cli.list \
     && apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893 \
+    && curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
     && apt-get update \
     && apt-get install azure-cli
 


### PR DESCRIPTION
**What this PR does / why we need it**: PR adds the new signing key for the azure cli package as it's going to replace the old one at the end of May 2018. 

**Which issue this PR fixes**: fixes #2760  