### PR TITLE
Add crd ciliumendpoints.cilium.io to cilium clusterrole

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-cilium-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-cilium-daemonset.yaml
@@ -295,5 +295,6 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumendpoints
   verbs:
   - "*"


### PR DESCRIPTION
Seeing the following errors in the cilium daemonset pod logs

```
level=warning msg="Error deleting invalid CEP during update" containerID=7c568c2ecb controller="sync-to-k8s-ciliumendpoint (42910)" endpointID=42910 error="ciliumendpoints.cilium.io \"heapster-74c5b5d595-qlvhr\" is forbidden: User \"system:serviceaccount:kube-system:cilium\" cannot delete ciliumendpoints.cilium.io in the namespace \"kube-system\"" policyRevision=0
```

Added ciliumendpoints to clusterrole to fix

cc @jessfraz 