### PR TITLE
kubernetes dashboard addon updated with minimal permissions and https

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-kubernetes-dashboard-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-kubernetes-dashboard-deployment.yaml
@@ -8,18 +8,52 @@ metadata:
   name: kubernetes-dashboard
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: kubernetes-dashboard
+  name: kubernetes-dashboard-minimal
+  namespace: kube-system
+  labels:
+    k8s-app: kubernetes-dashboard
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["kubernetes-dashboard-key-holder"]
+  verbs: ["get", "update", "delete"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["kubernetes-dashboard-settings"]
+  verbs: ["get", "update"]
+- apiGroups: [""]
+  resources: ["services"]
+  resourceNames: ["heapster"]
+  verbs: ["proxy"]
+- apiGroups: [""]
+  resources: ["services/proxy"]
+  resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubernetes-dashboard-minimal
+  namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
+  kind: Role
+  name: kubernetes-dashboard-minimal
 subjects:
 - kind: ServiceAccount
   name: kubernetes-dashboard
@@ -35,8 +69,8 @@ metadata:
   namespace: kube-system
 spec:
   ports:
-  - port: 80
-    targetPort: 9090
+  - port: 443
+    targetPort: 8443
   selector:
     k8s-app: kubernetes-dashboard
   type: NodePort
@@ -62,18 +96,20 @@ spec:
     spec:
       containers:
       - args:
+        - --auto-generate-certificates
         - --heapster-host=http://heapster.kube-system:80
         image: <kubernetesDashboardSpec>
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
             path: "/"
-            port: 9090
+            port: 8443
+            scheme: HTTPS
           initialDelaySeconds: 30
           timeoutSeconds: 30
         name: kubernetes-dashboard
         ports:
-        - containerPort: 9090
+        - containerPort: 8443
           protocol: TCP
         resources:
           requests:
@@ -82,6 +118,12 @@ spec:
           limits:
             cpu: <kubernetesDashboardCPULimit>
             memory: <kubernetesDashboardMemoryLimit>
+        volumeMounts:
+         - name: kubernetes-dashboard-certs
+           mountPath: /certs
+      volumes:
+        - name: kubernetes-dashboard-certs
+          emptyDir: {}
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
         beta.kubernetes.io/os: linux


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: 

PR #2571 and #1947 were not carried over into the kubernetes dashboard addon when v1.10 became the default. Just compare the dashboard in `/parts/k8s/addons/1.9` to `/parts/k8s/addons`

Both of these are required for a secure dashboard.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

Adds #2571 and #1947 back into the latest dashboard

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
