### PR TITLE
Remove default vnet and route table creation when using Azure CNI.

### DIFF
--- a/parts/iaasoutputs.t
+++ b/parts/iaasoutputs.t
@@ -2,6 +2,10 @@
         "type": "string",
         "value": "[variables('resourceGroup')]"
     },
+    "vnetResourceGroup": {
+        "type": "string",
+        "value": "[variables('virtualNetworkResourceGroupName')]"
+    },
     "subnetName": {
         "type": "string",
         "value": "[variables('subnetName')]"

--- a/parts/k8s/kubernetesbase.t
+++ b/parts/k8s/kubernetesbase.t
@@ -70,52 +70,54 @@
     {{if not IsHostedMaster}}
       ,{{template "k8s/kubernetesmasterresources.t" .}}
     {{else}}
-    ,{
-      "apiVersion": "[variables('apiVersionDefault')]",
-      "dependsOn": [
-        "[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgName'))]"
-    {{if not IsAzureCNI}}
-        ,
-        "[concat('Microsoft.Network/routeTables/', variables('routeTableName'))]"
-    {{end}}
-      ],
-      "location": "[variables('location')]",
-      "name": "[variables('virtualNetworkName')]",
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "[variables('vnetCidr')]"
+      {{if not IsCustomVNET}}
+      ,{
+        "apiVersion": "[variables('apiVersionDefault')]",
+        "dependsOn": [
+          "[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgName'))]"
+      {{if not IsAzureCNI}}
+          ,
+          "[concat('Microsoft.Network/routeTables/', variables('routeTableName'))]"
+      {{end}}
+        ],
+        "location": "[variables('location')]",
+        "name": "[variables('virtualNetworkName')]",
+        "properties": {
+          "addressSpace": {
+            "addressPrefixes": [
+              "[variables('vnetCidr')]"
+            ]
+          },
+          "subnets": [
+            {
+              "name": "[variables('subnetName')]",
+              "properties": {
+                "addressPrefix": "[variables('subnet')]",
+                "networkSecurityGroup": {
+                  "id": "[variables('nsgID')]"
+                }
+      {{if not IsAzureCNI}}
+                ,
+                "routeTable": {
+                  "id": "[variables('routeTableID')]"
+                }
+      {{end}}
+              }
+            }
           ]
         },
-        "subnets": [
-          {
-            "name": "[variables('subnetName')]",
-            "properties": {
-              "addressPrefix": "[variables('subnet')]",
-              "networkSecurityGroup": {
-                "id": "[variables('nsgID')]"
-              }
-    {{if not IsAzureCNI}}
-              ,
-              "routeTable": {
-                "id": "[variables('routeTableID')]"
-              }
+        "type": "Microsoft.Network/virtualNetworks"
+      }
     {{end}}
-            }
-          }
-        ]
-      },
-      "type": "Microsoft.Network/virtualNetworks"
-    },
     {{if not IsAzureCNI}}
-    {
+    ,{
       "apiVersion": "[variables('apiVersionDefault')]",
       "location": "[variables('location')]",
       "name": "[variables('routeTableName')]",
       "type": "Microsoft.Network/routeTables"
-    },
+    }
     {{end}}
-    {
+    ,{
       "apiVersion": "[variables('apiVersionDefault')]",
       "location": "[variables('location')]",
       "name": "[variables('nsgName')]",

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -276,12 +276,21 @@
   {{end}}
 {{else}}
     "subnet": "[parameters('masterSubnet')]",
+  {{if IsCustomVNET}}
+    "vnetSubnetID": "[parameters('{{ (index .AgentPoolProfiles 0).Name }}VnetSubnetID')]",
+    "subnetNameResourceSegmentIndex": 10,
+    "subnetName": "[split(variables('vnetSubnetID'), '/')[variables('subnetNameResourceSegmentIndex')]]",
+    "vnetNameResourceSegmentIndex": 8,
+    "virtualNetworkName": "[split(variables('vnetSubnetID'), '/')[variables('vnetNameResourceSegmentIndex')]]",
+    "vnetResourceGroupNameResourceSegmentIndex": 4,
+    "virtualNetworkResourceGroupName": "[split(variables('vnetSubnetID'), '/')[variables('vnetResourceGroupNameResourceSegmentIndex')]]",
+  {{else}}
     "subnetName": "[concat(variables('orchestratorName'), '-subnet')]",
-    "virtualNetworkName": "[concat(variables('orchestratorName'), '-vnet-', variables('nameSuffix'))]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "vnetSubnetID": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
     "virtualNetworkName": "[concat(variables('orchestratorName'), '-vnet-', variables('nameSuffix'))]",
     "virtualNetworkResourceGroupName": "''",
+  {{end}}
 {{end}}
     "vnetCidr": "[parameters('vnetCidr')]",
     "kubeDNSServiceIP": "[parameters('kubeDNSServiceIP')]",

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -1939,6 +1939,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"subtract": func(a, b int) int {
 			return a - b
 		},
+		"IsCustomVNET": func() bool {
+			return isCustomVNET(cs.Properties.AgentPoolProfiles)
+		},
 	}
 }
 
@@ -2119,6 +2122,18 @@ func getDCOSDefaultClusterPackageListGUID(orchestratorType string, orchestratorV
 
 func isNSeriesSKU(profile *api.AgentPoolProfile) bool {
 	return strings.Contains(profile.VMSize, "Standard_N")
+}
+
+func isCustomVNET(a []*api.AgentPoolProfile) bool {
+	if a != nil {
+		for _, agentPoolProfile := range a {
+			if !agentPoolProfile.IsCustomVNET() {
+				return false
+			}
+		}
+		return true
+	}
+	return false
 }
 
 func getGPUDriversInstallScript(profile *api.AgentPoolProfile) string {

--- a/pkg/acsengine/engine_test.go
+++ b/pkg/acsengine/engine_test.go
@@ -546,3 +546,38 @@ func TestIsNSeriesSKU(t *testing.T) {
 		}
 	}
 }
+
+func TestIsCustomVNET(t *testing.T) {
+
+	a := []*api.AgentPoolProfile{
+		{
+			VnetSubnetID: "subnetlink1",
+		},
+		{
+			VnetSubnetID: "subnetlink2",
+		},
+	}
+
+	if !isCustomVNET(a) {
+		t.Fatalf("Expected isCustomVNET to be true when subnet exists for all agent pool profile")
+	}
+
+	a = []*api.AgentPoolProfile{
+		{
+			VnetSubnetID: "subnetlink1",
+		},
+		{
+			VnetSubnetID: "",
+		},
+	}
+
+	if isCustomVNET(a) {
+		t.Fatalf("Expected isCustomVNET to be false when subnet exists for some agent pool profile")
+	}
+
+	a = nil
+
+	if isCustomVNET(a) {
+		t.Fatalf("Expected isCustomVNET to be false when agent pool profiles is nil")
+	}
+}

--- a/pkg/api/converterfromagentpoolonlyapi.go
+++ b/pkg/api/converterfromagentpoolonlyapi.go
@@ -189,9 +189,20 @@ func convertOrchestratorProfileToV20180331AgentPoolOnly(orchestratorProfile *Orc
 
 	if orchestratorProfile.KubernetesConfig != nil {
 		k := orchestratorProfile.KubernetesConfig
-		if k.NetworkPlugin != "" || k.ServiceCIDR != "" || k.DNSServiceIP != "" || k.DockerBridgeSubnet != "" {
+		if k.NetworkPlugin != "" {
 			networkProfile = &v20180331.NetworkProfile{}
 			networkProfile.NetworkPlugin = v20180331.NetworkPlugin(k.NetworkPlugin)
+			networkProfile.ServiceCidr = k.ServiceCIDR
+			networkProfile.DNSServiceIP = k.DNSServiceIP
+			networkProfile.DockerBridgeCidr = k.DockerBridgeSubnet
+		} else if k.NetworkPolicy != "" {
+			networkProfile = &v20180331.NetworkProfile{}
+			// ACS-E uses "none" in the old un-versioned model to represent kubenet.
+			if k.NetworkPolicy == "none" {
+				networkProfile.NetworkPlugin = v20180331.Kubenet
+			} else {
+				networkProfile.NetworkPlugin = v20180331.NetworkPlugin(k.NetworkPolicy)
+			}
 			networkProfile.ServiceCidr = k.ServiceCIDR
 			networkProfile.DNSServiceIP = k.DNSServiceIP
 			networkProfile.DockerBridgeCidr = k.DockerBridgeSubnet

--- a/pkg/api/converterfromagentpoolonlyapi_test.go
+++ b/pkg/api/converterfromagentpoolonlyapi_test.go
@@ -68,7 +68,7 @@ func TestConvertOrchestratorProfileToV20180331AgentPoolOnly(t *testing.T) {
 		t.Error("error in orchestrator profile networkProfile conversion")
 	}
 
-	// only networkProfile networkPolicy field is defined in kubernetesConfig
+	// only networkProfile networkPlugin field is defined in kubernetesConfig
 	kubernetesConfig = &KubernetesConfig{
 		NetworkPlugin: networkPlugin,
 	}

--- a/pkg/api/converterfromagentpoolonlyapi_test.go
+++ b/pkg/api/converterfromagentpoolonlyapi_test.go
@@ -11,6 +11,7 @@ import (
 func TestConvertOrchestratorProfileToV20180331AgentPoolOnly(t *testing.T) {
 	orchestratorVersion := "1.7.9"
 	networkPlugin := "azure"
+	networkPolicy := "azure"
 	serviceCIDR := "10.0.0.0/8"
 	dnsServiceIP := "10.0.0.10"
 	dockerBridgeSubnet := "172.17.0.1/16"
@@ -99,6 +100,39 @@ func TestConvertOrchestratorProfileToV20180331AgentPoolOnly(t *testing.T) {
 		t.Error("error in orchestrator profile dockerBridgeCidr conversion")
 	}
 
+	// legacy kubernetesConfig contains NetworkPolicy instead of NetworkPlugin
+	kubernetesConfig = &KubernetesConfig{
+		NetworkPolicy:      networkPolicy,
+		ServiceCIDR:        serviceCIDR,
+		DNSServiceIP:       dnsServiceIP,
+		DockerBridgeSubnet: dockerBridgeSubnet,
+	}
+	api = &OrchestratorProfile{
+		OrchestratorVersion: orchestratorVersion,
+		KubernetesConfig:    kubernetesConfig,
+	}
+
+	version, p = convertOrchestratorProfileToV20180331AgentPoolOnly(api)
+
+	if version != orchestratorVersion {
+		t.Error("error in orchestrator profile orchestratorVersion conversion")
+	}
+
+	if string(p.NetworkPlugin) != networkPlugin {
+		t.Error("error in orchestrator profile networkPlugin conversion")
+	}
+
+	if p.ServiceCidr != serviceCIDR {
+		t.Error("error in orchestrator profile serviceCidr conversion")
+	}
+
+	if p.DNSServiceIP != dnsServiceIP {
+		t.Error("error in orchestrator profile dnsServiceIP conversion")
+	}
+
+	if p.DockerBridgeCidr != dockerBridgeSubnet {
+		t.Error("error in orchestrator profile dockerBridgeCidr conversion")
+	}
 }
 
 func TestConvertAgentPoolProfileToV20180331AgentPoolOnly(t *testing.T) {

--- a/pkg/api/convertertoagentpoolonlyapi.go
+++ b/pkg/api/convertertoagentpoolonlyapi.go
@@ -230,7 +230,7 @@ func convertV20170831AgentPoolOnlyOrchestratorProfile(kubernetesVersion string) 
 			EnableRbac:          helpers.PointerToBool(false),
 			EnableSecureKubelet: helpers.PointerToBool(false),
 			// set network default for un-versioned model
-			NetworkPolicy:      string(v20180331.Kubenet),
+			NetworkPlugin:      string(v20180331.Kubenet),
 			ClusterSubnet:      DefaultKubernetesClusterSubnet,
 			ServiceCIDR:        DefaultKubernetesServiceCIDR,
 			DNSServiceIP:       DefaultKubernetesDNSServiceIP,

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -760,12 +760,10 @@ func (o *OrchestratorProfile) IsDCOS() bool {
 
 // IsAzureCNI returns true if Azure CNI network plugin is enabled
 func (o *OrchestratorProfile) IsAzureCNI() bool {
-	switch o.OrchestratorType {
-	case Kubernetes:
+	if o.KubernetesConfig != nil {
 		return o.KubernetesConfig.NetworkPlugin == "azure"
-	default:
-		return false
 	}
+	return false
 }
 
 // RequireRouteTable returns true if this deployment requires routing table

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -26,6 +26,35 @@ const exampleAPIModel = `{
 }
 `
 
+func TestIsAzureCNI(t *testing.T) {
+	k := &KubernetesConfig{
+		NetworkPlugin: "azure",
+	}
+
+	o := &OrchestratorProfile{
+		KubernetesConfig: k,
+	}
+	if !o.IsAzureCNI() {
+		t.Fatalf("unable to detect orchestrator profile is using Azure CNI from NetworkPlugin=%s", o.KubernetesConfig.NetworkPlugin)
+	}
+
+	k = &KubernetesConfig{
+		NetworkPlugin: "none",
+	}
+
+	o = &OrchestratorProfile{
+		KubernetesConfig: k,
+	}
+	if o.IsAzureCNI() {
+		t.Fatalf("unable to detect orchestrator profile is not using Azure CNI from NetworkPlugin=%s", o.KubernetesConfig.NetworkPlugin)
+	}
+
+	o = &OrchestratorProfile{}
+	if o.IsAzureCNI() {
+		t.Fatalf("unable to detect orchestrator profile is not using Azure CNI from nil KubernetesConfig")
+	}
+}
+
 func TestIsDCOS(t *testing.T) {
 	dCOSProfile := &OrchestratorProfile{
 		OrchestratorType: "DCOS",


### PR DESCRIPTION
Remove default vnet and route table creation when using Azure CNI.

Also correct the VNET/Subnet/Vnet resource group in output so they can be consumed by HCP later in its controller manger configuration.

This is the change in ACS-E side. Verified in manual test.