### PR TITLE
[WIP] : Moving agent pool variable in its own json object

### DIFF
--- a/parts/agentoutputs.t
+++ b/parts/agentoutputs.t
@@ -2,21 +2,21 @@
   {{ if and (not IsKubernetes) (not IsOpenShift)}}
     "{{.Name}}FQDN": {
         "type": "string",
-        "value": "[reference(concat('Microsoft.Network/publicIPAddresses/', variables('{{.Name}}IPAddressName'))).dnsSettings.fqdn]"
+        "value": "[reference(concat('Microsoft.Network/publicIPAddresses/', variables('{{.Name}}Config').IPAddressName)).dnsSettings.fqdn]"
     },
   {{end}}
 {{end}}
 {{if and .IsAvailabilitySets .IsStorageAccount}}
   "{{.Name}}StorageAccountOffset": {
       "type": "int",
-      "value": "[variables('{{.Name}}StorageAccountOffset')]"
+      "value": "[variables('{{.Name}}Config').StorageAccountOffset]"
     },
     "{{.Name}}StorageAccountCount": {
       "type": "int",
-      "value": "[variables('{{.Name}}StorageAccountsCount')]"
+      "value": "[variables('{{.Name}}Config').StorageAccountsCount]"
     },
     "{{.Name}}SubnetName": {
       "type": "string",
-      "value": "[variables('{{.Name}}SubnetName')]"
+      "value": "[variables('{{.Name}}Config').SubnetName]"
     },
 {{end}}

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -1,7 +1,7 @@
     {
       "apiVersion": "[variables('apiVersionDefault')]",
       "copy": {
-        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
+        "count": "[sub(variables('{{.Name}}Config').Count, variables('{{.Name}}Config').Offset)]",
         "name": "loop"
       },
       "dependsOn": [
@@ -23,7 +23,7 @@
 {{end}}
       ],
       "location": "[variables('location')]",
-      "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
+      "name": "[concat(variables('{{.Name}}Config').VMNamePrefix, 'nic-', copyIndex(variables('{{.Name}}Config').Offset))]",
       "properties": {
 {{if not IsOpenShift}}
 {{if .IsCustomVNET}}
@@ -50,7 +50,7 @@
               {{end}}
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
-                "id": "[variables('{{$.Name}}VnetSubnetID')]"
+                "id": "[variables('{{$.Name}}Config').VnetSubnetID]"
               }
 {{if eq $.Role "infra"}}
               ,
@@ -75,7 +75,7 @@
 {{if .IsManagedDisks}}
    {
       "location": "[variables('location')]",
-      "name": "[variables('{{.Name}}AvailabilitySet')]",
+      "name": "[variables('{{.Name}}Config').AvailabilitySet]",
       "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
       "properties":
         {
@@ -90,7 +90,7 @@
     {
       "apiVersion": "[variables('apiVersionStorage')]",
       "copy": {
-        "count": "[variables('{{.Name}}StorageAccountsCount')]",
+        "count": "[variables('{{.Name}}Config').StorageAccountsCount]",
         "name": "loop"
       },
       {{if not IsHostedMaster}}
@@ -101,9 +101,9 @@
         {{end}}
       {{end}}
       "location": "[variables('location')]",
-      "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
+      "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').AccountName)]",
       "properties": {
-        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}Config').VMSize].storageAccountType]"
       },
       "type": "Microsoft.Storage/storageAccounts"
     },
@@ -111,7 +111,7 @@
     {
       "apiVersion": "[variables('apiVersionStorage')]",
       "copy": {
-        "count": "[variables('{{.Name}}StorageAccountsCount')]",
+        "count": "[variables('{{.Name}}Config').StorageAccountsCount]",
         "name": "datadiskLoop"
       },
       {{if not IsHostedMaster}}
@@ -122,16 +122,16 @@
         {{end}}
       {{end}}
       "location": "[variables('location')]",
-      "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
+      "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').DataAccountName)]",
       "properties": {
-        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}Config').VMSize].storageAccountType]"
       },
       "type": "Microsoft.Storage/storageAccounts"
     },
     {{end}}
     {
       "location": "[variables('location')]",
-      "name": "[variables('{{.Name}}AvailabilitySet')]",
+      "name": "[variables('{{.Name}}Config').AvailabilitySet]",
       "apiVersion": "[variables('apiVersionDefault')]",
       "properties": {},
       "type": "Microsoft.Compute/availabilitySets"
@@ -144,29 +144,29 @@
       "apiVersion": "[variables('apiVersionDefault')]",
     {{end}}
       "copy": {
-        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
+        "count": "[sub(variables('{{.Name}}Config').Count, variables('{{.Name}}Config').Offset)]",
         "name": "vmLoopNode"
       },
       "dependsOn": [
 {{if .IsStorageAccount}}
-        "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
+        "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Config').Offset),variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Config').Offset),variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').AccountName)]",
 
   {{if .HasDisks}}
-        "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
+        "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(copyIndex(variables('{{.Name}}Config').Offset),variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(copyIndex(variables('{{.Name}}Config').Offset),variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').DataAccountName)]",
   {{end}}
 {{end}}
-        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
-        "[concat('Microsoft.Compute/availabilitySets/', variables('{{.Name}}AvailabilitySet'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}Config').VMNamePrefix, 'nic-', copyIndex(variables('{{.Name}}Config').Offset))]",
+        "[concat('Microsoft.Compute/availabilitySets/', variables('{{.Name}}Config').AvailabilitySet)]"
       ],
       "tags":
       {
-        "creationSource" : "[concat(variables('generatorCode'), '-', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
+        "creationSource" : "[concat(variables('generatorCode'), '-', variables('{{.Name}}Config').VMNamePrefix, copyIndex(variables('{{.Name}}Config').Offset))]",
         "resourceNameSuffix" : "[variables('nameSuffix')]",
         "orchestrator" : "[variables('orchestratorNameVersionTag')]",
         "poolName" : "{{.Name}}"
       },
       "location": "[variables('location')]",
-      "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
+      "name": "[concat(variables('{{.Name}}Config').VMNamePrefix, copyIndex(variables('{{.Name}}Config').Offset))]",
       {{if UseManagedIdentity}}
       "identity": {
         "type": "systemAssigned"
@@ -174,28 +174,28 @@
       {{end}}
       {{if and IsOpenShift (not (UseAgentCustomImage .))}}
       "plan": {
-        "name": "[variables('{{.Name}}osImageSKU')]",
-        "publisher": "[variables('{{.Name}}osImagePublisher')]",
-        "product": "[variables('{{.Name}}osImageOffer')]"
+        "name": "[variables('{{.Name}}Config').osImageSKU]",
+        "publisher": "[variables('{{.Name}}Config').osImagePublisher]",
+        "product": "[variables('{{.Name}}Config').osImageOffer]"
       },
       {{end}}
       "properties": {
         "availabilitySet": {
-          "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('{{.Name}}AvailabilitySet'))]"
+          "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('{{.Name}}Config').AvailabilitySet)]"
         },
         "hardwareProfile": {
-          "vmSize": "[variables('{{.Name}}VMSize')]"
+          "vmSize": "[variables('{{.Name}}Config').VMSize]"
         },
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset'))))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('{{.Name}}Config').VMNamePrefix, 'nic-', copyIndex(variables('{{.Name}}Config').Offset)))]"
             }
           ]
         },
         "osProfile": {
           "adminUsername": "[variables('username')]",
-          "computername": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
+          "computername": "[concat(variables('{{.Name}}Config').VMNamePrefix, copyIndex(variables('{{.Name}}Config').Offset))]",
           {{if not IsOpenShift}}
           {{GetKubernetesAgentCustomData .}}
           {{end}}
@@ -221,21 +221,21 @@
           {{end}}
           "imageReference": {
             {{if UseAgentCustomImage .}}
-            "id": "[resourceId(variables('{{.Name}}osImageResourceGroup'), 'Microsoft.Compute/images', variables('{{.Name}}osImageName'))]"
+            "id": "[resourceId(variables('{{.Name}}Config').osImageResourceGroup, 'Microsoft.Compute/images', variables('{{.Name}}Config').osImageName)]"
             {{else}}
-            "offer": "[variables('{{.Name}}osImageOffer')]",
-            "publisher": "[variables('{{.Name}}osImagePublisher')]",
-            "sku": "[variables('{{.Name}}osImageSKU')]",
-            "version": "[variables('{{.Name}}osImageVersion')]"
+            "offer": "[variables('{{.Name}}Config').osImageOffer]",
+            "publisher": "[variables('{{.Name}}Config').osImagePublisher]",
+            "sku": "[variables('{{.Name}}Config').osImageSKU]",
+            "version": "[variables('{{.Name}}Config').osImageVersion]"
             {{end}}
           },
           "osDisk": {
             "createOption": "FromImage"
             ,"caching": "ReadWrite"
           {{if .IsStorageAccount}}
-            ,"name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')),'-osdisk')]"
+            ,"name": "[concat(variables('{{.Name}}Config').VMNamePrefix, copyIndex(variables('{{.Name}}Config').Offset),'-osdisk')]"
             ,"vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-osdisk.vhd')]"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Config').Offset),variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Config').Offset),variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').AccountName),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}Config').VMNamePrefix, copyIndex(variables('{{.Name}}Config').Offset), '-osdisk.vhd')]"
             }
           {{end}}
           {{if ne .OSDiskSizeGB 0}}
@@ -250,28 +250,28 @@
     {
       "apiVersion": "2014-10-01-preview",
       "copy": {
-         "count": "[variables('{{.Name}}Count')]",
+         "count": "[variables('{{.Name}}Config').Count]",
          "name": "vmLoopNode"
        },
-      "name": "[guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(), 'vmidentity'))]",
+      "name": "[guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}Config').VMNamePrefix, copyIndex(), 'vmidentity'))]",
       "type": "Microsoft.Authorization/roleAssignments",
       "properties": {
         "roleDefinitionId": "[variables('readerRoleDefinitionId')]",
-        "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex()), '2017-03-30', 'Full').identity.principalId]"
+        "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}Config').VMNamePrefix, copyIndex()), '2017-03-30', 'Full').identity.principalId]"
       }
     },
      {
        "type": "Microsoft.Compute/virtualMachines/extensions",
-       "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(), '/ManagedIdentityExtension')]",
+       "name": "[concat(variables('{{.Name}}Config').VMNamePrefix, copyIndex(), '/ManagedIdentityExtension')]",
        "copy": {
-         "count": "[variables('{{.Name}}Count')]",
+         "count": "[variables('{{.Name}}Config').Count]",
          "name": "vmLoopNode"
        },
        "apiVersion": "2015-05-01-preview",
        "location": "[resourceGroup().location]",
        "dependsOn": [
-         "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex())]",
-         "[concat('Microsoft.Authorization/roleAssignments/', guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(), 'vmidentity')))]"
+         "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}Config').VMNamePrefix, copyIndex())]",
+         "[concat('Microsoft.Authorization/roleAssignments/', guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}Config').VMNamePrefix, copyIndex(), 'vmidentity')))]"
        ],
        "properties": {
          "publisher": "Microsoft.ManagedIdentity",
@@ -288,19 +288,19 @@
      {
       "apiVersion": "[variables('apiVersionDefault')]",
       "copy": {
-        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
+        "count": "[sub(variables('{{.Name}}Config').Count, variables('{{.Name}}Config').Offset)]",
         "name": "vmLoopNode"
       },
       "dependsOn": [
         {{if UseManagedIdentity}}
-        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(), '/extensions/ManagedIdentityExtension')]"
+        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}Config').VMNamePrefix, copyIndex(), '/extensions/ManagedIdentityExtension')]"
         {{else}}
-        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]"
+        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}Config').VMNamePrefix, copyIndex(variables('{{.Name}}Config').Offset))]"
         {{end}}
       ],
       "location": "[variables('location')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')),'/cse', '-agent-', copyIndex(variables('{{.Name}}Offset')))]",
+      "name": "[concat(variables('{{.Name}}Config').VMNamePrefix, copyIndex(variables('{{.Name}}Config').Offset),'/cse', '-agent-', copyIndex(variables('{{.Name}}Config').Offset))]",
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
         "type": "CustomScript",

--- a/parts/k8s/kubernetesagentresourcesvmss.t
+++ b/parts/k8s/kubernetesagentresourcesvmss.t
@@ -2,7 +2,7 @@
   {
     "apiVersion": "[variables('apiVersionStorage')]",
     "copy": {
-      "count": "[variables('{{.Name}}StorageAccountsCount')]",
+      "count": "[variables('{{.Name}}Config').StorageAccountsCount]",
       "name": "loop"
     },
     {{if not IsHostedMaster}}
@@ -13,9 +13,9 @@
       {{end}}
     {{end}}
     "location": "[variables('location')]",
-    "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
+    "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').AccountName)]",
     "properties": {
-      "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+      "accountType": "[variables('vmSizesMap')[variables('{{.Name}}Config').VMSize].storageAccountType]"
     },
     "type": "Microsoft.Storage/storageAccounts"
   },
@@ -23,7 +23,7 @@
   {
     "apiVersion": "[variables('apiVersionStorage')]",
     "copy": {
-      "count": "[variables('{{.Name}}StorageAccountsCount')]",
+      "count": "[variables('{{.Name}}Config').StorageAccountsCount]",
       "name": "datadiskLoop"
     },
     {{if not IsHostedMaster}}
@@ -34,9 +34,9 @@
       {{end}}
     {{end}}
     "location": "[variables('location')]",
-    "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
+    "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').DataAccountName)]",
     "properties": {
-      "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+      "accountType": "[variables('vmSizesMap')[variables('{{.Name}}Config').VMSize].storageAccountType]"
     },
     "type": "Microsoft.Storage/storageAccounts"
   },
@@ -45,11 +45,11 @@
 {{if UseManagedIdentity}}
   {
     "apiVersion": "2014-10-01-preview",
-    "name": "[guid(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}VMNamePrefix'), 'vmidentity'))]",
+    "name": "[guid(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}Config').VMNamePrefix, 'vmidentity'))]",
     "type": "Microsoft.Authorization/roleAssignments",
     "properties": {
       "roleDefinitionId": "[variables('readerRoleDefinitionId')]",
-      "principalId": "[reference(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}VMNamePrefix')), '2017-03-30', 'Full').identity.principalId]"
+      "principalId": "[reference(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}Config').VMNamePrefix), '2017-03-30', 'Full').identity.principalId]"
     }
   },
 {{end}}
@@ -62,21 +62,21 @@
       "[variables('vnetID')]"
     {{end}}
     {{if .IsStorageAccount}}
-        ,"[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]"
+        ,"[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').AccountName)]"
     {{if .HasDisks}}
-        ,"[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]"
+        ,"[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').DataAccountName)]"
     {{end}}
     {{end}}
     ],
     "tags":
     {
-      "creationSource" : "[concat(variables('generatorCode'), '-', variables('{{.Name}}VMNamePrefix'))]",
+      "creationSource" : "[concat(variables('generatorCode'), '-', variables('{{.Name}}Config').VMNamePrefix)]",
       "resourceNameSuffix" : "[variables('nameSuffix')]",
       "orchestrator" : "[variables('orchestratorNameVersionTag')]",
       "poolName" : "{{.Name}}"
     },
     "location": "[variables('location')]",
-    "name": "[variables('{{.Name}}VMNamePrefix')]",
+    "name": "[variables('{{.Name}}Config').VMNamePrefix]",
     {{if UseManagedIdentity}}
     "identity": {
       "type": "systemAssigned"
@@ -84,8 +84,8 @@
     {{end}}
     "sku": {
       "tier": "Standard",
-      "capacity": "[variables('{{.Name}}Count')]",
-      "name": "[variables('{{.Name}}VMSize')]"
+      "capacity": "[variables('{{.Name}}Config').Count]",
+      "name": "[variables('{{.Name}}Config').VMSize]"
     },
     "properties": {
       "overprovision": false,
@@ -96,7 +96,7 @@
         "networkProfile": {
           "networkInterfaceConfigurations": [
             {
-              "name": "[variables('{{.Name}}VMNamePrefix')]",
+              "name": "[variables('{{.Name}}Config').VMNamePrefix]",
               "properties": {
                 "primary": true,
                 {{if .IsCustomVNET}}
@@ -129,7 +129,7 @@
         },
         "osProfile": {
           "adminUsername": "[variables('username')]",
-          "computerNamePrefix": "[variables('{{.Name}}VMNamePrefix')]",
+          "computerNamePrefix": "[variables('{{.Name}}Config').VMNamePrefix]",
           {{GetKubernetesAgentCustomData .}}
           "linuxConfiguration": {
               "disablePasswordAuthentication": "true",
@@ -153,21 +153,21 @@
           {{end}}
           "imageReference": {
             {{if UseAgentCustomImage .}}
-            "id": "[resourceId(variables('{{.Name}}osImageResourceGroup'), 'Microsoft.Compute/images', variables('{{.Name}}osImageName'))]"
+            "id": "[resourceId(variables('{{.Name}}Config').osImageResourceGroup, 'Microsoft.Compute/images', variables('{{.Name}}Config').osImageName)]"
             {{else}}
-            "offer": "[variables('{{.Name}}osImageOffer')]",
-            "publisher": "[variables('{{.Name}}osImagePublisher')]",
-            "sku": "[variables('{{.Name}}osImageSKU')]",
-            "version": "[variables('{{.Name}}osImageVersion')]"
+            "offer": "[variables('{{.Name}}Config').osImageOffer]",
+            "publisher": "[variables('{{.Name}}Config').osImagePublisher]",
+            "sku": "[variables('{{.Name}}Config').osImageSKU]",
+            "version": "[variables('{{.Name}}Config').osImageVersion]"
             {{end}}
           },
           "osDisk": {
             "createOption": "FromImage",
             "caching": "ReadWrite"
           {{if .IsStorageAccount}}
-            ,"name": "[concat(variables('{{.Name}}VMNamePrefix'),'-osdisk')]"
+            ,"name": "[concat(variables('{{.Name}}Config').VMNamePrefix,'-osdisk')]"
             ,"vhdContainers": [
-              "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(0,variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(0,variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk')]"
+              "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(0,variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(0,variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').AccountName),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk')]"
             ]
           {{end}}
           {{if ne .OSDiskSizeGB 0}}

--- a/parts/k8s/kubernetesagentvars.t
+++ b/parts/k8s/kubernetesagentvars.t
@@ -1,34 +1,45 @@
-{{if .IsStorageAccount}}
-    "{{.Name}}StorageAccountOffset": "[mul(variables('maxStorageAccountsPerAgent'),variables('{{.Name}}Index'))]",
-    "{{.Name}}StorageAccountsCount": "[add(div(variables('{{.Name}}Count'), variables('maxVMsPerStorageAccount')), mod(add(mod(variables('{{.Name}}Count'), variables('maxVMsPerStorageAccount')),2), add(mod(variables('{{.Name}}Count'), variables('maxVMsPerStorageAccount')),1)))]",
+{{ range $index, $agent := .AgentPoolProfiles }}
+"{{.Name}}Config": {
+    "Index": {{$index}},
+    {{if .IsStorageAccount}}
+        {{if .HasDisks}}
+        "DataAccountName": "[concat(variables('storageAccountBaseName'), 'data{{$index}}')]",
+        {{end}}
+        "AccountName": "[concat(variables('storageAccountBaseName'), 'agnt{{$index}}')]",
+    {{end}}
+    {{if .IsStorageAccount}}
+        "StorageAccountOffset": "[mul(variables('maxStorageAccountsPerAgent'),variables('{{.Name}}Config').Index)]",
+        "StorageAccountsCount": "[add(div(variables('{{.Name}}Config').Count, variables('maxVMsPerStorageAccount')), mod(add(mod(variables('{{.Name}}Config').Count, variables('maxVMsPerStorageAccount')),2), add(mod(variables('{{.Name}}Config').Count, variables('maxVMsPerStorageAccount')),1)))]",
+    {{end}}
+        "Count": "[parameters('{{.Name}}Count')]",
+    {{if .IsAvailabilitySets}}
+        "Offset": "[parameters('{{.Name}}Offset')]",
+        "AvailabilitySet": "[concat('{{.Name}}-availabilitySet-', variables('nameSuffix'))]",
+    {{end}}
+    {{if .IsWindows}}
+        "winResourceNamePrefix" : "[substring(variables('nameSuffix'), 0, 5)]",
+        "VMNamePrefix": "[concat(variables('winResourceNamePrefix'), variables('orchestratorName'), add(900, {{ $index }}))]",
+    {{else}}
+    {{if .IsAvailabilitySets}}
+        "VMNamePrefix": "[concat(variables('orchestratorName'), '-{{.Name}}-', variables('nameSuffix'), '-')]",
+    {{else}}
+        "VMNamePrefix": "[concat(variables('orchestratorName'), '-{{.Name}}-', variables('nameSuffix'), '-vmss')]",
+    {{end}}
+    {{end}}
+        "VMSize": "[parameters('{{.Name}}VMSize')]",
+    {{if .IsCustomVNET}}
+        "VnetSubnetID": "[parameters('{{.Name}}VnetSubnetID')]",
+        "SubnetName": "[parameters('{{.Name}}VnetSubnetID')]",
+        "VnetParts": "[split(parameters('{{.Name}}VnetSubnetID'),'/subnets/')]",
+    {{else}}
+        "VnetSubnetID": "[variables('vnetSubnetID')]",
+        "SubnetName": "[variables('subnetName')]",
+    {{end}}
+        "osImageOffer": "[parameters('{{.Name}}osImageOffer')]",
+        "osImageSKU": "[parameters('{{.Name}}osImageSKU')]",
+        "osImagePublisher": "[parameters('{{.Name}}osImagePublisher')]",
+        "osImageVersion": "[parameters('{{.Name}}osImageVersion')]",
+        "osImageName": "[parameters('{{.Name}}osImageName')]",
+        "osImageResourceGroup": "[parameters('{{.Name}}osImageResourceGroup')]"
+},
 {{end}}
-    "{{.Name}}Count": "[parameters('{{.Name}}Count')]",
-{{if .IsAvailabilitySets}}
-    "{{.Name}}Offset": "[parameters('{{.Name}}Offset')]",
-    "{{.Name}}AvailabilitySet": "[concat('{{.Name}}-availabilitySet-', variables('nameSuffix'))]",
-{{end}}
-{{if .IsWindows}}
-    "winResourceNamePrefix" : "[substring(variables('nameSuffix'), 0, 5)]",
-    "{{.Name}}VMNamePrefix": "[concat(variables('winResourceNamePrefix'), variables('orchestratorName'), add(900,variables('{{.Name}}Index')))]",
-{{else}}
-{{if .IsAvailabilitySets}}
-    "{{.Name}}VMNamePrefix": "[concat(variables('orchestratorName'), '-{{.Name}}-', variables('nameSuffix'), '-')]",
-{{else}}
-    "{{.Name}}VMNamePrefix": "[concat(variables('orchestratorName'), '-{{.Name}}-', variables('nameSuffix'), '-vmss')]",
-{{end}}
-{{end}}
-    "{{.Name}}VMSize": "[parameters('{{.Name}}VMSize')]",
-{{if .IsCustomVNET}}
-    "{{.Name}}VnetSubnetID": "[parameters('{{.Name}}VnetSubnetID')]",
-    "{{.Name}}SubnetName": "[parameters('{{.Name}}VnetSubnetID')]",
-    "{{.Name}}VnetParts": "[split(parameters('{{.Name}}VnetSubnetID'),'/subnets/')]",
-{{else}}
-    "{{.Name}}VnetSubnetID": "[variables('vnetSubnetID')]",
-    "{{.Name}}SubnetName": "[variables('subnetName')]",
-{{end}}
-    "{{.Name}}osImageOffer": "[parameters('{{.Name}}osImageOffer')]",
-    "{{.Name}}osImageSKU": "[parameters('{{.Name}}osImageSKU')]",
-    "{{.Name}}osImagePublisher": "[parameters('{{.Name}}osImagePublisher')]",
-    "{{.Name}}osImageVersion": "[parameters('{{.Name}}osImageVersion')]",
-    "{{.Name}}osImageName": "[parameters('{{.Name}}osImageName')]",
-    "{{.Name}}osImageResourceGroup": "[parameters('{{.Name}}osImageResourceGroup')]",

--- a/parts/k8s/kubernetesbase.t
+++ b/parts/k8s/kubernetesbase.t
@@ -38,16 +38,7 @@
     {{template "k8s/kubernetesparams.t" .}}
   },
   "variables": {
-    {{range $index, $agent := .AgentPoolProfiles}}
-        "{{.Name}}Index": {{$index}},
-        {{template "k8s/kubernetesagentvars.t" .}}
-        {{if .IsStorageAccount}}
-          {{if .HasDisks}}
-            "{{.Name}}DataAccountName": "[concat(variables('storageAccountBaseName'), 'data{{$index}}')]",
-          {{end}}
-          "{{.Name}}AccountName": "[concat(variables('storageAccountBaseName'), 'agnt{{$index}}')]",
-        {{end}}
-    {{end}}
+    {{template "k8s/kubernetesagentvars.t" .}}
     {{template "k8s/kubernetesmastervars.t" .}}
   },
   "resources": [

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -18,7 +18,7 @@
     {
       "apiVersion": "[variables('apiVersionDefault')]",
       "copy": {
-        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
+        "count": "[sub(variables('{{.Name}}Config').Count, variables('{{.Name}}Config').Offset)]",
         "name": "loop"
       },
       "dependsOn": [
@@ -29,7 +29,7 @@
 {{end}}
       ],
       "location": "[variables('location')]",
-      "name": "[concat(variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
+      "name": "[concat(variables('{{.Name}}Config').VMNamePrefix, 'nic-', copyIndex(variables('{{.Name}}Config').Offset))]",
       "properties": {
 {{if .IsCustomVNET}}
 	    "networkSecurityGroup": {
@@ -63,7 +63,7 @@
 {{if .IsManagedDisks}}
    {
       "location": "[variables('location')]",
-      "name": "[variables('{{.Name}}AvailabilitySet')]",
+      "name": "[variables('{{.Name}}Config').AvailabilitySet]",
       "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
       "properties":
         {
@@ -78,7 +78,7 @@
     {
       "apiVersion": "[variables('apiVersionStorage')]",
       "copy": {
-        "count": "[variables('{{.Name}}StorageAccountsCount')]",
+        "count": "[variables('{{.Name}}Config').StorageAccountsCount]",
         "name": "loop"
       },
       {{if not IsHostedMaster}}
@@ -89,9 +89,9 @@
         {{end}}
       {{end}}
       "location": "[variables('location')]",
-      "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
+      "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').AccountName)]",
       "properties": {
-        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}Config').VMSize].storageAccountType]"
       },
       "type": "Microsoft.Storage/storageAccounts"
     },
@@ -99,7 +99,7 @@
     {
       "apiVersion": "[variables('apiVersionStorage')]",
       "copy": {
-        "count": "[variables('{{.Name}}StorageAccountsCount')]",
+        "count": "[variables('{{.Name}}Config').StorageAccountsCount]",
         "name": "datadiskLoop"
       },
       {{if not IsHostedMaster}}
@@ -110,16 +110,16 @@
         {{end}}
       {{end}}
       "location": "[variables('location')]",
-      "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
+      "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').DataAccountName)]",
       "properties": {
-        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}Config').VMSize].storageAccountType]"
       },
       "type": "Microsoft.Storage/storageAccounts"
     },
     {{end}}
     {
       "location": "[variables('location')]",
-      "name": "[variables('{{.Name}}AvailabilitySet')]",
+      "name": "[variables('{{.Name}}Config').AvailabilitySet]",
       "apiVersion": "[variables('apiVersionDefault')]",
       "properties": {},
       "type": "Microsoft.Compute/availabilitySets"
@@ -132,28 +132,28 @@
         "apiVersion": "[variables('apiVersionDefault')]",
       {{end}}
       "copy": {
-        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
+        "count": "[sub(variables('{{.Name}}Config').Count, variables('{{.Name}}Config').Offset)]",
         "name": "vmLoopNode"
       },
       "dependsOn": [
 {{if .IsStorageAccount}}
-        "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
+        "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Config').Offset),variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Config').Offset),variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').AccountName)]",
   {{if .HasDisks}}
-        "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
+        "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(copyIndex(variables('{{.Name}}Config').Offset),variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(copyIndex(variables('{{.Name}}Config').Offset),variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').DataAccountName)]",
   {{end}}
 {{end}}
-        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset')))]",
-        "[concat('Microsoft.Compute/availabilitySets/', variables('{{.Name}}AvailabilitySet'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', variables('{{.Name}}Config').VMNamePrefix, 'nic-', copyIndex(variables('{{.Name}}Config').Offset))]",
+        "[concat('Microsoft.Compute/availabilitySets/', variables('{{.Name}}Config').AvailabilitySet)]"
       ],
       "tags":
       {
-        "creationSource" : "[concat(variables('generatorCode'), '-', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
+        "creationSource" : "[concat(variables('generatorCode'), '-', variables('{{.Name}}Config').VMNamePrefix, copyIndex(variables('{{.Name}}Config').Offset))]",
         "resourceNameSuffix" : "[variables('winResourceNamePrefix')]",
         "orchestrator" : "[variables('orchestratorNameVersionTag')]",
         "poolName" : "{{.Name}}"
       },
       "location": "[variables('location')]",
-      "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
+      "name": "[concat(variables('{{.Name}}Config').VMNamePrefix, copyIndex(variables('{{.Name}}Config').Offset))]",
       {{if UseManagedIdentity}}
       "identity": {
         "type": "systemAssigned"
@@ -161,20 +161,20 @@
       {{end}}
       "properties": {
         "availabilitySet": {
-          "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('{{.Name}}AvailabilitySet'))]"
+          "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('{{.Name}}Config').AvailabilitySet)]"
         },
         "hardwareProfile": {
-          "vmSize": "[variables('{{.Name}}VMSize')]"
+          "vmSize": "[variables('{{.Name}}Config').VMSize]"
         },
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('{{.Name}}VMNamePrefix'), 'nic-', copyIndex(variables('{{.Name}}Offset'))))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('{{.Name}}Config').VMNamePrefix, 'nic-', copyIndex(variables('{{.Name}}Config').Offset)))]"
             }
           ]
         },
         "osProfile": {
-          "computername": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
+          "computername": "[concat(variables('{{.Name}}Config').VMNamePrefix, copyIndex(variables('{{.Name}}Config').Offset))]",
           {{GetKubernetesWindowsAgentCustomData .}}
           "adminUsername": "[variables('windowsAdminUsername')]",
           "adminPassword": "[variables('windowsAdminPassword')]"
@@ -195,9 +195,9 @@
             "createOption": "FromImage"
             ,"caching": "ReadWrite"
 {{if .IsStorageAccount}}
-            ,"name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')),'-osdisk')]"
+            ,"name": "[concat(variables('{{.Name}}Config').VMNamePrefix, copyIndex(variables('{{.Name}}Config').Offset),'-osdisk')]"
             ,"vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-osdisk.vhd')]"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Config').Offset),variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Config').Offset),variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').AccountName),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}Config').VMNamePrefix, copyIndex(variables('{{.Name}}Config').Offset), '-osdisk.vhd')]"
             }
 {{end}}
 {{if ne .OSDiskSizeGB 0}}
@@ -212,28 +212,28 @@
     {
       "apiVersion": "2014-10-01-preview",
       "copy": {
-         "count": "[variables('{{.Name}}Count')]",
+         "count": "[variables('{{.Name}}Config').Count]",
          "name": "vmLoopNode"
        },
-      "name": "[guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(),'vmidentity'))]",
+      "name": "[guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}Config').VMNamePrefix, copyIndex(),'vmidentity'))]",
       "type": "Microsoft.Authorization/roleAssignments",
       "properties": {
         "roleDefinitionId": "[variables('readerRoleDefinitionId')]",
-        "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex()), '2017-03-30', 'Full').identity.principalId]"
+        "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}Config').VMNamePrefix, copyIndex()), '2017-03-30', 'Full').identity.principalId]"
       }
     },
       {
         "type": "Microsoft.Compute/virtualMachines/extensions",
-        "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(), '/ManagedIdentityExtension')]",
+        "name": "[concat(variables('{{.Name}}Config').VMNamePrefix, copyIndex(), '/ManagedIdentityExtension')]",
         "copy": {
-          "count": "[variables('{{.Name}}Count')]",
+          "count": "[variables('{{.Name}}Config').Count]",
           "name": "vmLoopNode"
         },
         "apiVersion": "2015-05-01-preview",
         "location": "[resourceGroup().location]",
         "dependsOn": [
-          "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex())]",
-          "[concat('Microsoft.Authorization/roleAssignments/', guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(), 'vmidentity')))]"
+          "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}Config').VMNamePrefix, copyIndex())]",
+          "[concat('Microsoft.Authorization/roleAssignments/', guid(concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}Config').VMNamePrefix, copyIndex(), 'vmidentity')))]"
         ],
         "properties": {
           "publisher": "Microsoft.ManagedIdentity",
@@ -250,19 +250,19 @@
     {
       "apiVersion": "[variables('apiVersionDefault')]",
       "copy": {
-        "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
+        "count": "[sub(variables('{{.Name}}Config').Count, variables('{{.Name}}Config').Offset)]",
         "name": "vmLoopNode"
       },
       "dependsOn": [
         {{if UseManagedIdentity}}
-        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(), '/extensions/ManagedIdentityExtension')]"
+        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}Config').VMNamePrefix, copyIndex(), '/extensions/ManagedIdentityExtension')]"
         {{else}}
-        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]"
+        "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}Config').VMNamePrefix, copyIndex(variables('{{.Name}}Config').Offset))]"
         {{end}}
       ],
       "location": "[variables('location')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '/cse')]",
+      "name": "[concat(variables('{{.Name}}Config').VMNamePrefix, copyIndex(variables('{{.Name}}Config').Offset), '/cse')]",
       "properties": {
         "publisher": "Microsoft.Compute",
         "type": "CustomScriptExtension",

--- a/parts/k8s/kuberneteswinagentresourcesvmss.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmss.t
@@ -2,7 +2,7 @@
   {
     "apiVersion": "[variables('apiVersionStorage')]",
     "copy": {
-      "count": "[variables('{{.Name}}StorageAccountsCount')]",
+      "count": "[variables('{{.Name}}Config').StorageAccountsCount]",
       "name": "loop"
     },
     {{if not IsHostedMaster}}
@@ -13,9 +13,9 @@
       {{end}}
     {{end}}
     "location": "[variables('location')]",
-    "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
+    "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').AccountName)]",
     "properties": {
-      "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+      "accountType": "[variables('vmSizesMap')[variables('{{.Name}}Config').VMSize].storageAccountType]"
     },
     "type": "Microsoft.Storage/storageAccounts"
   },
@@ -23,7 +23,7 @@
   {
     "apiVersion": "[variables('apiVersionStorage')]",
     "copy": {
-      "count": "[variables('{{.Name}}StorageAccountsCount')]",
+      "count": "[variables('{{.Name}}Config').StorageAccountsCount]",
       "name": "datadiskLoop"
     },
     {{if not IsHostedMaster}}
@@ -34,9 +34,9 @@
       {{end}}
     {{end}}
     "location": "[variables('location')]",
-    "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
+    "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').DataAccountName)]",
     "properties": {
-      "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+      "accountType": "[variables('vmSizesMap')[variables('{{.Name}}Config').VMSize].storageAccountType]"
     },
     "type": "Microsoft.Storage/storageAccounts"
   },
@@ -45,11 +45,11 @@
 {{if UseManagedIdentity}}
   {
     "apiVersion": "2014-10-01-preview",
-    "name": "[guid(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}VMNamePrefix'), 'vmidentity'))]",
+    "name": "[guid(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}Config').VMNamePrefix, 'vmidentity'))]",
     "type": "Microsoft.Authorization/roleAssignments",
     "properties": {
       "roleDefinitionId": "[variables('readerRoleDefinitionId')]",
-      "principalId": "[reference(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}VMNamePrefix')), '2017-03-30', 'Full').identity.principalId]"
+      "principalId": "[reference(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}Config').VMNamePrefix), '2017-03-30', 'Full').identity.principalId]"
     }
   },
 {{end}}
@@ -62,21 +62,21 @@
       "[variables('vnetID')]"
     {{end}}
     {{if .IsStorageAccount}}
-        ,"[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]"
+        ,"[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').AccountName)]"
     {{if .HasDisks}}
-        ,"[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]"
+        ,"[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}Config').StorageAccountOffset),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').DataAccountName)]"
     {{end}}
     {{end}}
     ],
     "tags":
     {
-      "creationSource" : "[concat(variables('generatorCode'), '-', variables('{{.Name}}VMNamePrefix'))]",
+      "creationSource" : "[concat(variables('generatorCode'), '-', variables('{{.Name}}Config').VMNamePrefix)]",
       "resourceNameSuffix" : "[variables('winResourceNamePrefix')]",
       "orchestrator" : "[variables('orchestratorNameVersionTag')]",
       "poolName" : "{{.Name}}"
     },
     "location": "[variables('location')]",
-    "name": "[variables('{{.Name}}VMNamePrefix')]",
+    "name": "[variables('{{.Name}}Config').VMNamePrefix]",
     {{if UseManagedIdentity}}
     "identity": {
       "type": "systemAssigned"
@@ -84,8 +84,8 @@
     {{end}}
     "sku": {
       "tier": "Standard",
-      "capacity": "[variables('{{.Name}}Count')]",
-      "name": "[variables('{{.Name}}VMSize')]"
+      "capacity": "[variables('{{.Name}}Config').Count]",
+      "name": "[variables('{{.Name}}Config').VMSize]"
     },
     "properties": {
       "overprovision": false,
@@ -96,7 +96,7 @@
         "networkProfile": {
           "networkInterfaceConfigurations": [
             {
-              "name": "[variables('{{.Name}}VMNamePrefix')]",
+              "name": "[variables('{{.Name}}Config').VMNamePrefix]",
               "properties": {
                 "primary": true,
                 {{if .IsCustomVNET}}
@@ -145,9 +145,9 @@
             "createOption": "FromImage",
             "caching": "ReadWrite"
           {{if .IsStorageAccount}}
-            ,"name": "[concat(variables('{{.Name}}VMNamePrefix'),'-osdisk')]"
+            ,"name": "[concat(variables('{{.Name}}Config').VMNamePrefix,'-osdisk')]"
             ,"vhdContainers": [
-              "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(0,variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(0,variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk')]"
+              "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(0,variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(0,variables('{{.Name}}Config').StorageAccountOffset),variables('storageAccountPrefixesCount'))],variables('{{.Name}}Config').AccountName),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk')]"
             ]
           {{end}}
           {{if ne .OSDiskSizeGB 0}}


### PR DESCRIPTION

**What this PR does / why we need it**
fixes #2553. Bypasses the limit of 256 variables in a deployment.
Allows to declare more agent pools.

- [x]  move the agentPoolProfile variables into its own json object.
- [x] adapt all `variable()` references in the k8s arm templates
- [ ]  test backward compatibility for k8s (ie. deploy with previous version, upgrade with this branch)

TODO : 
- [ ]  review go code to make sure it does not reference any agent pool variables from go
- [ ] adapt all `variable()` references in the dcos arm templates
- [ ] adapt all `variable()` references in the swarnarm templates

Note : 
Helpful regex to find all occurences of a variable in the go templates (in this specific case but can be adjusted for future work)

find `(variables\('\{\{\.Name\}\})([a-zA-Z]*)'\)` and replace with `$1Config').$2` 

For example, the above finds and replaces occurences of 

`variables('{{.Name}}SomeProperty')` 
with   
`variables('{{.Name}}Config').SomeProperty`
which is helpful when moving SomeProperty one level down into a json object.

