### PR TITLE
don’t delete cluster if failed deployment

### DIFF
--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	Regions           []string      `envconfig:"REGIONS"`                                                               // A whitelist of availableregions
 	ClusterDefinition string        `envconfig:"CLUSTER_DEFINITION" required:"true" default:"examples/kubernetes.json"` // ClusterDefinition is the path on disk to the json template these are normally located in examples/
 	CleanUpOnExit     bool          `envconfig:"CLEANUP_ON_EXIT" default:"true"`                                        // if set the tests will not clean up rgs when tests finish
+	CleanUpIfFail     bool          `envconfig:"CLEANUP_IF_FAIL" default:"true"`
 	RetainSSH         bool          `envconfig:"RETAIN_SSH" default:"true"`
 	Timeout           time.Duration `envconfig:"TIMEOUT" default:"10m"`
 	CurrentWorkingDir string

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -114,7 +114,8 @@ func main() {
 		rgs = cliProvisioner.ResourceGroups
 		eng = cliProvisioner.Engine
 		if err != nil {
-			teardown()
+			// TODO enable configurable teardown if a deployment fails
+			// teardown()
 			log.Fatalf("Error while trying to provision cluster:%s", err)
 		}
 		if cfg.SoakClusterName != "" {

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -114,8 +114,9 @@ func main() {
 		rgs = cliProvisioner.ResourceGroups
 		eng = cliProvisioner.Engine
 		if err != nil {
-			// TODO enable configurable teardown if a deployment fails
-			// teardown()
+			if cfg.CleanUpIfFail {
+				teardown()
+			}
 			log.Fatalf("Error while trying to provision cluster:%s", err)
 		}
 		if cfg.SoakClusterName != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Enable resource group retention of failed E2E deployments

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
