### PR TITLE
Fix deploy using client-id and client-secret

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -241,6 +241,11 @@ func autofillApimodel(dc *deployCmd) {
 				Secret:   secret,
 				ObjectID: servicePrincipalObjectID,
 			}
+		} else if dc.containerService.Properties.ServicePrincipalProfile == nil && dc.ClientID.String() != "" && dc.ClientSecret != "" {
+			dc.containerService.Properties.ServicePrincipalProfile = &api.ServicePrincipalProfile{
+				ClientID: dc.ClientID.String(),
+				Secret:   dc.ClientSecret,
+			}
 		}
 	}
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -216,7 +216,7 @@ func autofillApimodel(dc *deployCmd) {
 
 	if !useManagedIdentity {
 		spp := dc.containerService.Properties.ServicePrincipalProfile
-		if spp != nil && spp.ClientID == "" && spp.Secret == "" && spp.KeyvaultSecretRef == nil {
+		if spp != nil && spp.ClientID == "" && spp.Secret == "" && spp.KeyvaultSecretRef == nil && (dc.ClientID.String() == "" || dc.ClientID.String() == "00000000-0000-0000-0000-000000000000") && dc.ClientSecret == "" {
 			log.Warnln("apimodel: ServicePrincipalProfile was missing or empty, creating application...")
 
 			// TODO: consider caching the creds here so they persist between subsequent runs of 'deploy'
@@ -241,7 +241,7 @@ func autofillApimodel(dc *deployCmd) {
 				Secret:   secret,
 				ObjectID: servicePrincipalObjectID,
 			}
-		} else if dc.containerService.Properties.ServicePrincipalProfile == nil && dc.ClientID.String() != "" && dc.ClientSecret != "" {
+		} else if (dc.containerService.Properties.ServicePrincipalProfile == nil || ((dc.containerService.Properties.ServicePrincipalProfile.ClientID == "" || dc.containerService.Properties.ServicePrincipalProfile.ClientID == "00000000-0000-0000-0000-000000000000") && dc.containerService.Properties.ServicePrincipalProfile.Secret == "")) && dc.ClientID.String() != "" && dc.ClientSecret != "" {
 			dc.containerService.Properties.ServicePrincipalProfile = &api.ServicePrincipalProfile{
 				ClientID: dc.ClientID.String(),
 				Secret:   dc.ClientSecret,

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -148,7 +148,53 @@ func TestAPIModelWithoutServicePrincipalProfileAndClientIdAndSecretInCmd(t *test
 
 	defer os.RemoveAll(deployCmd.outputDirectory)
 
-	if deployCmd.containerService.Properties.ServicePrincipalProfile == nil {
+	if deployCmd.containerService.Properties.ServicePrincipalProfile == nil || deployCmd.containerService.Properties.ServicePrincipalProfile.ClientID == "" || deployCmd.containerService.Properties.ServicePrincipalProfile.Secret == "" {
+		t.Fatalf("expected service principal profile to be populated from deployment command arguments")
+	}
+
+	if deployCmd.containerService.Properties.ServicePrincipalProfile.ClientID != TestClientIDInCmd.String() {
+		t.Fatalf("expected service principal profile client id to be %s but got %s", TestClientIDInCmd.String(), deployCmd.containerService.Properties.ServicePrincipalProfile.ClientID)
+	}
+
+	if deployCmd.containerService.Properties.ServicePrincipalProfile.Secret != TestClientSecretInCmd {
+		t.Fatalf("expected service principal profile client secret to be %s but got %s", TestClientSecretInCmd, deployCmd.containerService.Properties.ServicePrincipalProfile.Secret)
+	}
+}
+
+func TestAPIModelWithEmptyServicePrincipalProfileAndClientIdAndSecretInCmd(t *testing.T) {
+	apiloader := &api.Apiloader{
+		Translator: nil,
+	}
+
+	apimodel := getAPIModel(ExampleAPIModelWithDNSPrefix, false, "", "")
+	TestClientIDInCmd, err := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
+	if err != nil {
+		t.Fatalf("Invalid ClientID in Test: %s", err)
+	}
+
+	TestClientSecretInCmd := "DEC923E3-1EF1-4745-9516-37906D56DEC4"
+
+	cs, ver, err := apiloader.DeserializeContainerService([]byte(apimodel), false, false, nil)
+	if err != nil {
+		t.Fatalf("unexpected error deserializing the example apimodel: %s", err)
+	}
+	deployCmd := &deployCmd{
+		apimodelPath:     "./this/is/unused.json",
+		outputDirectory:  "_test_output",
+		forceOverwrite:   true,
+		location:         "westus",
+		containerService: cs,
+		apiVersion:       ver,
+
+		client: &armhelpers.MockACSEngineClient{},
+	}
+	deployCmd.ClientID = TestClientIDInCmd
+	deployCmd.ClientSecret = TestClientSecretInCmd
+	autofillApimodel(deployCmd)
+
+	defer os.RemoveAll(deployCmd.outputDirectory)
+
+	if deployCmd.containerService.Properties.ServicePrincipalProfile == nil || deployCmd.containerService.Properties.ServicePrincipalProfile.ClientID == "" || deployCmd.containerService.Properties.ServicePrincipalProfile.Secret == "" {
 		t.Fatalf("expected service principal profile to be populated from deployment command arguments")
 	}
 
@@ -192,6 +238,47 @@ func TestAPIModelWithoutServicePrincipalProfileAndWithoutClientIdAndSecretInCmd(
 
 }
 
+func TestAPIModelWithEmptyServicePrincipalProfileAndWithoutClientIdAndSecretInCmd(t *testing.T) {
+	apiloader := &api.Apiloader{
+		Translator: nil,
+	}
+
+	apimodel := getAPIModel(ExampleAPIModelWithDNSPrefix, false, "", "")
+
+	cs, ver, err := apiloader.DeserializeContainerService([]byte(apimodel), false, false, nil)
+	if err != nil {
+		t.Fatalf("unexpected error deserializing the example apimodel: %s", err)
+	}
+	deployCmd := &deployCmd{
+		apimodelPath:     "./this/is/unused.json",
+		outputDirectory:  "_test_output",
+		forceOverwrite:   true,
+		location:         "westus",
+		containerService: cs,
+		apiVersion:       ver,
+
+		client: &armhelpers.MockACSEngineClient{},
+	}
+	autofillApimodel(deployCmd)
+
+	defer os.RemoveAll(deployCmd.outputDirectory)
+
+	if deployCmd.containerService.Properties.ServicePrincipalProfile == nil {
+		t.Fatalf("expected service principal profile to be Empty and not nil for unmanaged identity, where client id and secret are not supplied in api model and deployment command")
+	}
+
+	// mockclient returns "app-id" for ClientID when empty
+	if deployCmd.containerService.Properties.ServicePrincipalProfile.ClientID != "app-id" {
+		t.Fatalf("expected service principal profile client id to be empty but got %s", deployCmd.containerService.Properties.ServicePrincipalProfile.ClientID)
+	}
+
+	// mockcliet returns "client-secret" when empty
+	if deployCmd.containerService.Properties.ServicePrincipalProfile.Secret != "client-secret" {
+		t.Fatalf("expected service principal profile client secret to be empty but got %s", deployCmd.containerService.Properties.ServicePrincipalProfile.Secret)
+	}
+
+}
+
 func testAutodeployCredentialHandling(t *testing.T, useManagedIdentity bool, clientID, clientSecret string) {
 	apiloader := &api.Apiloader{
 		Translator: nil,
@@ -210,6 +297,7 @@ func testAutodeployCredentialHandling(t *testing.T, useManagedIdentity bool, cli
 		apimodelPath:    "./this/is/unused.json",
 		dnsPrefix:       "dnsPrefix1",
 		outputDirectory: "_test_output",
+		forceOverwrite:  true,
 		location:        "westus",
 
 		containerService: cs,

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/acs-engine/pkg/api"
 	"github.com/Azure/acs-engine/pkg/armhelpers"
+	"github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -40,6 +41,19 @@ const ExampleAPIModelWithDNSPrefix = `{
   }
   `
 
+const ExampleAPIModelWithoutServicePrincipalProfile = `{
+	"apiVersion": "vlabs",
+	"properties": {
+		  "orchestratorProfile": { "orchestratorType": "Kubernetes", "kubernetesConfig": { "useManagedIdentity": %s, "etcdVersion" : "2.3.8" } },
+	  "masterProfile": { "count": 1, "dnsPrefix": "mytestcluster", "vmSize": "Standard_D2_v2" },
+	  "agentPoolProfiles": [ { "name": "linuxpool1", "count": 2, "vmSize": "Standard_D2_v2", "availabilityProfile": "AvailabilitySet" } ],
+	  "windowsProfile": { "adminUsername": "azureuser", "adminPassword": "replacepassword1234$" },
+	  "linuxProfile": { "adminUsername": "azureuser", "ssh": { "publicKeys": [ { "keyData": "" } ] }
+	  }
+	}
+  }
+  `
+
 func getExampleAPIModel(useManagedIdentity bool, clientID, clientSecret string) string {
 	return getAPIModel(ExampleAPIModel, useManagedIdentity, clientID, clientSecret)
 }
@@ -50,6 +64,12 @@ func getAPIModel(baseAPIModel string, useManagedIdentity bool, clientID, clientS
 		strconv.FormatBool(useManagedIdentity),
 		clientID,
 		clientSecret)
+}
+
+func getAPIModelWithoutServicePrincipalProfile(baseAPIModel string, useManagedIdentity bool) string {
+	return fmt.Sprintf(
+		baseAPIModel,
+		strconv.FormatBool(useManagedIdentity))
 }
 
 func TestAutofillApimodelWithoutManagedIdentityCreatesCreds(t *testing.T) {
@@ -77,6 +97,7 @@ func TestAutoSufixWithDnsPrefixInApiModel(t *testing.T) {
 	deployCmd := &deployCmd{
 		apimodelPath:     "./this/is/unused.json",
 		outputDirectory:  "_test_output",
+		forceOverwrite:   true,
 		location:         "westus",
 		autoSuffix:       true,
 		containerService: cs,
@@ -90,6 +111,83 @@ func TestAutoSufixWithDnsPrefixInApiModel(t *testing.T) {
 
 	if deployCmd.containerService.Properties.MasterProfile.DNSPrefix == "mytestcluster" {
 		t.Fatalf("expected %s-{timestampsuffix} but got %s", "mytestcluster", deployCmd.containerService.Properties.MasterProfile.DNSPrefix)
+	}
+
+}
+
+func TestAPIModelWithoutServicePrincipalProfileAndClientIdAndSecretInCmd(t *testing.T) {
+	apiloader := &api.Apiloader{
+		Translator: nil,
+	}
+
+	apimodel := getAPIModelWithoutServicePrincipalProfile(ExampleAPIModelWithoutServicePrincipalProfile, false)
+	TestClientIDInCmd, err := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
+	if err != nil {
+		t.Fatalf("Invalid ClientID in Test: %s", err)
+	}
+
+	TestClientSecretInCmd := "DEC923E3-1EF1-4745-9516-37906D56DEC4"
+
+	cs, ver, err := apiloader.DeserializeContainerService([]byte(apimodel), false, false, nil)
+	if err != nil {
+		t.Fatalf("unexpected error deserializing the example apimodel: %s", err)
+	}
+	deployCmd := &deployCmd{
+		apimodelPath:     "./this/is/unused.json",
+		outputDirectory:  "_test_output",
+		forceOverwrite:   true,
+		location:         "westus",
+		containerService: cs,
+		apiVersion:       ver,
+
+		client: &armhelpers.MockACSEngineClient{},
+	}
+	deployCmd.ClientID = TestClientIDInCmd
+	deployCmd.ClientSecret = TestClientSecretInCmd
+	autofillApimodel(deployCmd)
+
+	defer os.RemoveAll(deployCmd.outputDirectory)
+
+	if deployCmd.containerService.Properties.ServicePrincipalProfile == nil {
+		t.Fatalf("expected service principal profile to be populated from deployment command arguments")
+	}
+
+	if deployCmd.containerService.Properties.ServicePrincipalProfile.ClientID != TestClientIDInCmd.String() {
+		t.Fatalf("expected service principal profile client id to be %s but got %s", TestClientIDInCmd.String(), deployCmd.containerService.Properties.ServicePrincipalProfile.ClientID)
+	}
+
+	if deployCmd.containerService.Properties.ServicePrincipalProfile.Secret != TestClientSecretInCmd {
+		t.Fatalf("expected service principal profile client secret to be %s but got %s", TestClientSecretInCmd, deployCmd.containerService.Properties.ServicePrincipalProfile.Secret)
+	}
+}
+
+func TestAPIModelWithoutServicePrincipalProfileAndWithoutClientIdAndSecretInCmd(t *testing.T) {
+	apiloader := &api.Apiloader{
+		Translator: nil,
+	}
+
+	apimodel := getAPIModelWithoutServicePrincipalProfile(ExampleAPIModelWithoutServicePrincipalProfile, false)
+
+	cs, ver, err := apiloader.DeserializeContainerService([]byte(apimodel), false, false, nil)
+	if err != nil {
+		t.Fatalf("unexpected error deserializing the example apimodel: %s", err)
+	}
+	deployCmd := &deployCmd{
+		apimodelPath:     "./this/is/unused.json",
+		outputDirectory:  "_test_output",
+		forceOverwrite:   true,
+		location:         "westus",
+		containerService: cs,
+		apiVersion:       ver,
+
+		client: &armhelpers.MockACSEngineClient{},
+	}
+	autofillApimodel(deployCmd)
+
+	defer os.RemoveAll(deployCmd.outputDirectory)
+
+	if deployCmd.containerService.Properties.ServicePrincipalProfile != nil {
+		t.Fatalf("expected service principal profile to be nil for unmanaged identity, where client id and secret are not supplied in api model and deployment command")
 	}
 
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Fix Issue #2657 

**Which issue this PR fixes** *(optional, in `fixes #2657` format, will close that issue when PR gets merged)*: fixes #2657 `#2657`

**Special notes for your reviewer**: 
* Added condition to check if Client Id and Secret are specified in the deployment command
* Added tests to cover conditions when Client Id and Client secret are provided in the deployment command, and when id and secret are not specified in either the api model or deployment command

**If applicable**:
- [ ] documentation
- [x] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
