### PR TITLE
Set Windows Azure CNI config

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -22,7 +22,7 @@ const (
 	// AzureCniPluginVer specifies version of Azure CNI plugin, which has been mirrored from
 	// https://github.com/Azure/azure-container-networking/releases/download/${AZURE_PLUGIN_VER}/azure-vnet-cni-linux-amd64-${AZURE_PLUGIN_VER}.tgz
 	// to https://acs-mirror.azureedge.net/cni/
-	AzureCniPluginVer = "v1.0.2"
+	AzureCniPluginVer = "v1.0.4"
 	// CNIPluginVer specifies the version of CNI implementation
 	// https://github.com/containernetworking/plugins
 	CNIPluginVer = "v0.7.0"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables kubernetes DNS and endpoint policies in Azure CNI.

**Special notes for your reviewer**:
This PR requires Azure CNI v1.0.4. Please do not merge until Azure CNI v1.0.4 is released.
Required Azure CNI PR: https://github.com/Azure/azure-container-networking/pull/127
