### PR TITLE
Remove storageAccounts from K8s VMSS

### DIFF
--- a/examples/kubernetes-vmss/kubernetes.json
+++ b/examples/kubernetes-vmss/kubernetes.json
@@ -18,7 +18,8 @@
         "name": "agentpool1",
         "count": 3,
         "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "VirtualMachineScaleSets"
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "storageProfile": "ManagedDisks"
       }
     ],
     "linuxProfile": {

--- a/parts/k8s/kubernetesagentresourcesvmss.t
+++ b/parts/k8s/kubernetesagentresourcesvmss.t
@@ -1,47 +1,3 @@
-{{if .IsStorageAccount}}
-  {
-    "apiVersion": "[variables('apiVersionStorage')]",
-    "copy": {
-      "count": "[variables('{{.Name}}StorageAccountsCount')]",
-      "name": "loop"
-    },
-    {{if not IsHostedMaster}}
-      {{if not IsPrivateCluster}}
-        "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
-        ],
-      {{end}}
-    {{end}}
-    "location": "[variables('location')]",
-    "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
-    "properties": {
-      "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
-    },
-    "type": "Microsoft.Storage/storageAccounts"
-  },
-  {{if .HasDisks}}
-  {
-    "apiVersion": "[variables('apiVersionStorage')]",
-    "copy": {
-      "count": "[variables('{{.Name}}StorageAccountsCount')]",
-      "name": "datadiskLoop"
-    },
-    {{if not IsHostedMaster}}
-      {{if not IsPrivateCluster}}
-        "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
-        ],
-      {{end}}
-    {{end}}
-    "location": "[variables('location')]",
-    "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
-    "properties": {
-      "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
-    },
-    "type": "Microsoft.Storage/storageAccounts"
-  },
-  {{end}}
-{{end}}
 {{if UseManagedIdentity}}
   {
     "apiVersion": "2014-10-01-preview",
@@ -60,12 +16,6 @@
       "[variables('nsgID')]"
     {{else}}
       "[variables('vnetID')]"
-    {{end}}
-    {{if .IsStorageAccount}}
-        ,"[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]"
-    {{if .HasDisks}}
-        ,"[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]"
-    {{end}}
     {{end}}
     ],
     "tags":
@@ -164,12 +114,6 @@
           "osDisk": {
             "createOption": "FromImage",
             "caching": "ReadWrite"
-          {{if .IsStorageAccount}}
-            ,"name": "[concat(variables('{{.Name}}VMNamePrefix'),'-osdisk')]"
-            ,"vhdContainers": [
-              "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(0,variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(0,variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk')]"
-            ]
-          {{end}}
           {{if ne .OSDiskSizeGB 0}}
             ,"diskSizeGB": {{.OSDiskSizeGB}}
           {{end}}

--- a/parts/k8s/kuberneteswinagentresourcesvmss.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmss.t
@@ -1,47 +1,3 @@
-{{if .IsStorageAccount}}
-  {
-    "apiVersion": "[variables('apiVersionStorage')]",
-    "copy": {
-      "count": "[variables('{{.Name}}StorageAccountsCount')]",
-      "name": "loop"
-    },
-    {{if not IsHostedMaster}}
-      {{if not IsPrivateCluster}}
-        "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
-        ],
-      {{end}}
-    {{end}}
-    "location": "[variables('location')]",
-    "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
-    "properties": {
-      "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
-    },
-    "type": "Microsoft.Storage/storageAccounts"
-  },
-  {{if .HasDisks}}
-  {
-    "apiVersion": "[variables('apiVersionStorage')]",
-    "copy": {
-      "count": "[variables('{{.Name}}StorageAccountsCount')]",
-      "name": "datadiskLoop"
-    },
-    {{if not IsHostedMaster}}
-      {{if not IsPrivateCluster}}
-        "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
-        ],
-      {{end}}
-    {{end}}
-    "location": "[variables('location')]",
-    "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
-    "properties": {
-      "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
-    },
-    "type": "Microsoft.Storage/storageAccounts"
-  },
-  {{end}}
-{{end}}
 {{if UseManagedIdentity}}
   {
     "apiVersion": "2014-10-01-preview",
@@ -60,12 +16,6 @@
       "[variables('nsgID')]"
     {{else}}
       "[variables('vnetID')]"
-    {{end}}
-    {{if .IsStorageAccount}}
-        ,"[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]"
-    {{if .HasDisks}}
-        ,"[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(add(div(0,variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('dataStorageAccountPrefixSeed')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]"
-    {{end}}
     {{end}}
     ],
     "tags":
@@ -144,12 +94,6 @@
           "osDisk": {
             "createOption": "FromImage",
             "caching": "ReadWrite"
-          {{if .IsStorageAccount}}
-            ,"name": "[concat(variables('{{.Name}}VMNamePrefix'),'-osdisk')]"
-            ,"vhdContainers": [
-              "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(0,variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(0,variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk')]"
-            ]
-          {{end}}
           {{if ne .OSDiskSizeGB 0}}
             ,"diskSizeGB": {{.OSDiskSizeGB}}
           {{end}}

--- a/pkg/acsengine/testdata/disks-managed/kubernetes-vmss.json
+++ b/pkg/acsengine/testdata/disks-managed/kubernetes-vmss.json
@@ -5,10 +5,7 @@
     "provisioningState": "",
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.10",
-      "kubernetesConfig": {
-        "useInstanceMetadata": false
-      }
+      "orchestratorRelease": "1.10"
     },
     "masterProfile": {
       "count": 1,

--- a/pkg/acsengine/testdata/largeclusters/kubernetes-vmss.json
+++ b/pkg/acsengine/testdata/largeclusters/kubernetes-vmss.json
@@ -3,10 +3,7 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorRelease": "1.10",
-      "kubernetesConfig": {
-        "useInstanceMetadata": false
-      }
+      "orchestratorRelease": "1.10"
     },
     "masterProfile": {
       "count": 1,
@@ -18,73 +15,85 @@
         "name": "agentpool1",
         "count": 3,
         "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "VirtualMachineScaleSets"
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "storageProfile": "ManagedDisks"
       },
       {
         "name": "agentpool2",
         "count": 3,
         "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "VirtualMachineScaleSets"
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "storageProfile": "ManagedDisks"
       },
       {
         "name": "agentpool3",
         "count": 100,
         "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "VirtualMachineScaleSets"
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "storageProfile": "ManagedDisks"
       },
       {
         "name": "agentpool4",
         "count": 100,
         "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "VirtualMachineScaleSets"
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "storageProfile": "ManagedDisks"
       },
       {
         "name": "agentpool5",
         "count": 100,
         "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "VirtualMachineScaleSets"
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "storageProfile": "ManagedDisks"
       },
       {
         "name": "agentpool6",
         "count": 100,
         "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "VirtualMachineScaleSets"
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "storageProfile": "ManagedDisks"
       },
       {
         "name": "agentpool7",
         "count": 100,
         "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "VirtualMachineScaleSets"
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "storageProfile": "ManagedDisks"
       },
       {
         "name": "agentpool8",
         "count": 100,
         "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "VirtualMachineScaleSets"
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "storageProfile": "ManagedDisks"
       },
       {
         "name": "agentpool9",
         "count": 100,
         "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "VirtualMachineScaleSets"
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "storageProfile": "ManagedDisks"
       },
       {
         "name": "agentpool10",
         "count": 100,
         "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "VirtualMachineScaleSets"
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "storageProfile": "ManagedDisks"
       },
       {
         "name": "agentpool11",
         "count": 100,
         "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "VirtualMachineScaleSets"
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "storageProfile": "ManagedDisks"
       },
       {
         "name": "agentpool12",
         "count": 100,
         "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "VirtualMachineScaleSets"
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "storageProfile": "ManagedDisks"
       }
     ],
     "linuxProfile": {

--- a/pkg/acsengine/testdata/windows/kubernetes-vmss.json
+++ b/pkg/acsengine/testdata/windows/kubernetes-vmss.json
@@ -19,7 +19,8 @@
         "count": 3,
         "vmSize": "Standard_D2_v2",
         "availabilityProfile": "VirtualMachineScaleSets",
-        "osType": "Windows"
+        "osType": "Windows",
+        "storageProfile": "ManagedDisks"
       }
     ],
     "windowsProfile": {

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -558,6 +558,10 @@ func (a *Properties) Validate(isUpdate bool) error {
 			}
 		}
 
+		if a.OrchestratorProfile.OrchestratorType == Kubernetes && (agentPoolProfile.AvailabilityProfile == VirtualMachineScaleSets || len(agentPoolProfile.AvailabilityProfile) == 0) && agentPoolProfile.StorageProfile == StorageAccount {
+			return fmt.Errorf("VirtualMachineScaleSets does not support %s disks.  Please specify \"storageProfile\": \"%s\" (recommended) or \"availabilityProfile\": \"%s\"", StorageAccount, ManagedDisks, AvailabilitySet)
+		}
+
 		if a.OrchestratorProfile.OrchestratorType == Kubernetes {
 			if i == 0 {
 				continue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Storage accounts doesn't allow attaching AzureDisks. This PR removes storage accounts from VMSS and adds validation for it.

/cc @feiskyer 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes #2824 
