### PR TITLE
kms using deprecated systemd convenience

### DIFF
--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -334,11 +334,7 @@ function ensureDocker() {
     systemctlEnableAndStart docker
 }
 function ensureKMS() {
-    systemctlEnableAndCheck kms
-    # only start if a reboot is not required
-    if ! $REBOOTREQUIRED; then
-        systemctl restart kms
-    fi
+    systemctlEnableAndStart kms
 }
 
 function ensureKubelet() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: ensures that KMS service starts at boot

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2842

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
startup k8s kms service at boot
```
