### PR TITLE
apply back-compat networkPolicy to unversioned api

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -120,6 +120,12 @@ const (
 	DefaultMetricsServerAddonName = "metrics-server"
 	// DefaultPrivateClusterEnabled determines the acs-engine provided default for enabling kubernetes Private Cluster
 	DefaultPrivateClusterEnabled = false
+	// NetworkPolicyAzure is the string expression for the deprecated NetworkPolicy usage pattern "azure"
+	NetworkPolicyAzure = "azure"
+	// NetworkPolicyNone is the string expression for the deprecated NetworkPolicy usage pattern "none"
+	NetworkPolicyNone = "none"
+	// NetworkPluginKubenet is the string expression for the kubenet NetworkPlugin config
+	NetworkPluginKubenet = "kubenet"
 )
 
 const (

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -655,6 +655,7 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 	api.ClusterSubnet = vlabs.ClusterSubnet
 	api.DNSServiceIP = vlabs.DNSServiceIP
 	api.ServiceCIDR = vlabs.ServiceCidr
+	api.NetworkPlugin = vlabs.NetworkPlugin
 	api.ContainerRuntime = vlabs.ContainerRuntime
 	api.MaxPods = vlabs.MaxPods
 	api.DockerBridgeSubnet = vlabs.DockerBridgeSubnet

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -697,16 +697,19 @@ func setVlabsKubernetesDefaults(vp *vlabs.Properties, api *OrchestratorProfile) 
 	if api.KubernetesConfig == nil {
 		api.KubernetesConfig = &KubernetesConfig{}
 	}
-	// Included here for backwards compatibility with deprecated NetworkPolicy usage patterns
-	if vp.OrchestratorProfile.KubernetesConfig.NetworkPolicy == NetworkPolicyAzure {
-		api.KubernetesConfig.NetworkPlugin = vp.OrchestratorProfile.KubernetesConfig.NetworkPolicy
-		api.KubernetesConfig.NetworkPolicy = "" // no-op but included for emphasis
-	} else if vp.OrchestratorProfile.KubernetesConfig.NetworkPolicy == NetworkPolicyNone {
-		api.KubernetesConfig.NetworkPlugin = NetworkPluginKubenet
-		api.KubernetesConfig.NetworkPolicy = "" // no-op but included for emphasis
-	} else {
-		api.KubernetesConfig.NetworkPlugin = vp.OrchestratorProfile.KubernetesConfig.NetworkPlugin
-		api.KubernetesConfig.NetworkPolicy = vp.OrchestratorProfile.KubernetesConfig.NetworkPolicy
+
+	if vp.OrchestratorProfile.KubernetesConfig != nil {
+		// Included here for backwards compatibility with deprecated NetworkPolicy usage patterns
+		if vp.OrchestratorProfile.KubernetesConfig.NetworkPolicy == NetworkPolicyAzure {
+			api.KubernetesConfig.NetworkPlugin = vp.OrchestratorProfile.KubernetesConfig.NetworkPolicy
+			api.KubernetesConfig.NetworkPolicy = "" // no-op but included for emphasis
+		} else if vp.OrchestratorProfile.KubernetesConfig.NetworkPolicy == NetworkPolicyNone {
+			api.KubernetesConfig.NetworkPlugin = NetworkPluginKubenet
+			api.KubernetesConfig.NetworkPolicy = "" // no-op but included for emphasis
+		} else {
+			api.KubernetesConfig.NetworkPlugin = vp.OrchestratorProfile.KubernetesConfig.NetworkPlugin
+			api.KubernetesConfig.NetworkPolicy = vp.OrchestratorProfile.KubernetesConfig.NetworkPolicy
+		}
 	}
 	if api.KubernetesConfig.NetworkPlugin == "" {
 		if vp.HasWindows() {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -655,8 +655,6 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 	api.ClusterSubnet = vlabs.ClusterSubnet
 	api.DNSServiceIP = vlabs.DNSServiceIP
 	api.ServiceCIDR = vlabs.ServiceCidr
-	api.NetworkPolicy = vlabs.NetworkPolicy
-	api.NetworkPlugin = vlabs.NetworkPlugin
 	api.ContainerRuntime = vlabs.ContainerRuntime
 	api.MaxPods = vlabs.MaxPods
 	api.DockerBridgeSubnet = vlabs.DockerBridgeSubnet
@@ -698,6 +696,17 @@ func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *Kubernetes
 func setVlabsKubernetesDefaults(vp *vlabs.Properties, api *OrchestratorProfile) {
 	if api.KubernetesConfig == nil {
 		api.KubernetesConfig = &KubernetesConfig{}
+	}
+	// Included here for backwards compatibility with deprecated NetworkPolicy usage patterns
+	if vp.OrchestratorProfile.KubernetesConfig.NetworkPolicy == NetworkPolicyAzure {
+		api.KubernetesConfig.NetworkPlugin = vp.OrchestratorProfile.KubernetesConfig.NetworkPolicy
+		api.KubernetesConfig.NetworkPolicy = "" // no-op but included for emphasis
+	} else if vp.OrchestratorProfile.KubernetesConfig.NetworkPolicy == NetworkPolicyNone {
+		api.KubernetesConfig.NetworkPlugin = NetworkPluginKubenet
+		api.KubernetesConfig.NetworkPolicy = "" // no-op but included for emphasis
+	} else {
+		api.KubernetesConfig.NetworkPlugin = vp.OrchestratorProfile.KubernetesConfig.NetworkPlugin
+		api.KubernetesConfig.NetworkPolicy = vp.OrchestratorProfile.KubernetesConfig.NetworkPolicy
 	}
 	if api.KubernetesConfig.NetworkPlugin == "" {
 		if vp.HasWindows() {

--- a/pkg/api/convertertoapi_test.go
+++ b/pkg/api/convertertoapi_test.go
@@ -184,7 +184,7 @@ func TestConvertVLabsOrchestratorProfile(t *testing.T) {
 					OrchestratorType: OpenShift,
 					OpenShiftConfig: &vlabs.OpenShiftConfig{
 						KubernetesConfig: &vlabs.KubernetesConfig{
-							NetworkPolicy:    "azure",
+							NetworkPlugin:    "azure",
 							ContainerRuntime: "docker",
 						},
 					},
@@ -194,12 +194,12 @@ func TestConvertVLabsOrchestratorProfile(t *testing.T) {
 				OrchestratorType:    OpenShift,
 				OrchestratorVersion: common.OpenShiftDefaultVersion,
 				KubernetesConfig: &KubernetesConfig{
-					NetworkPolicy:    "azure",
+					NetworkPlugin:    "azure",
 					ContainerRuntime: "docker",
 				},
 				OpenShiftConfig: &OpenShiftConfig{
 					KubernetesConfig: &KubernetesConfig{
-						NetworkPolicy:    "azure",
+						NetworkPlugin:    "azure",
 						ContainerRuntime: "docker",
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This is a follow-on of #2813 

Some operations (e.g., scale) use the "unversioned " api (e.g., the superset API type specification that merges all versioned API type specifications) to express cluster configuration. The recent breakout of `networkPolicy` into `networkPlugin` + `networkPolicy` must be implemented rationally in the unversioned api.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
apply back-compat networkPolicy to unversioned api
```