### PR TITLE
get FD count for managed disk based on region

### DIFF
--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -87,7 +87,7 @@
       "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
       "properties":
         {
-            "platformFaultDomainCount": "{{ GetPlatformFaultDomainCountForManagedDisks [variables('location')] }}",
+            "platformFaultDomainCount": {{ GetPlatformFaultDomainCountForManagedDisks "[variables('location')]" }},
             "platformUpdateDomainCount": 3,
 		"managed" : "true"
         },

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -87,7 +87,7 @@
       "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
       "properties":
         {
-            "platformFaultDomainCount": {{ GetPlatformFaultDomainCountForManagedDisks "[variables('location')]" }},
+            "platformFaultDomainCount": {{ GetPlatformFaultDomainCountForManagedDisks }},
             "platformUpdateDomainCount": 3,
 		"managed" : "true"
         },

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -87,7 +87,7 @@
       "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
       "properties":
         {
-            "platformFaultDomainCount": 2,
+            "platformFaultDomainCount": "{{ GetPlatformFaultDomainCountForManagedDisks [variables('location')] }}",
             "platformUpdateDomainCount": 3,
 		"managed" : "true"
         },

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -5,7 +5,7 @@
       "name": "[variables('masterAvailabilitySet')]",
       "properties":
         {
-            "platformFaultDomainCount": "{{ GetPlatformFaultDomainCountForManagedDisks [variables('location')] }}",
+            "platformFaultDomainCount": {{ GetPlatformFaultDomainCountForManagedDisks "[variables('location')]" }},
             "platformUpdateDomainCount": 3,
 		        "managed" : true
         },

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -5,7 +5,7 @@
       "name": "[variables('masterAvailabilitySet')]",
       "properties":
         {
-            "platformFaultDomainCount": {{ GetPlatformFaultDomainCountForManagedDisks "[variables('location')]" }},
+            "platformFaultDomainCount": {{ GetPlatformFaultDomainCountForManagedDisks }},
             "platformUpdateDomainCount": 3,
 		        "managed" : true
         },

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -5,7 +5,7 @@
       "name": "[variables('masterAvailabilitySet')]",
       "properties":
         {
-            "platformFaultDomainCount": 2,
+            "platformFaultDomainCount": "{{ GetPlatformFaultDomainCountForManagedDisks [variables('location')] }}",
             "platformUpdateDomainCount": 3,
 		        "managed" : true
         },

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -67,7 +67,7 @@
       "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
       "properties":
         {
-            "platformFaultDomainCount": 2,
+            "platformFaultDomainCount": "{{ GetPlatformFaultDomainCountForManagedDisks [variables('location')] }}",
             "platformUpdateDomainCount": 3,
 		        "managed" : "true"
         },

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -67,7 +67,7 @@
       "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
       "properties":
         {
-            "platformFaultDomainCount": "{{ GetPlatformFaultDomainCountForManagedDisks [variables('location')] }}",
+            "platformFaultDomainCount": {{ GetPlatformFaultDomainCountForManagedDisks "[variables('location')]" }},
             "platformUpdateDomainCount": 3,
 		        "managed" : "true"
         },

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -67,7 +67,7 @@
       "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
       "properties":
         {
-            "platformFaultDomainCount": {{ GetPlatformFaultDomainCountForManagedDisks "[variables('location')]" }},
+            "platformFaultDomainCount": {{ GetPlatformFaultDomainCountForManagedDisks }},
             "platformUpdateDomainCount": 3,
 		        "managed" : "true"
         },

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -1227,7 +1227,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		},
 		"GetPlatformFaultDomainCountForManagedDisks": func() int {
 			switch cs.Location {
-			case "eastus", "eastus2", "westus", "centralus", "northcentralus", "southcentralus", "northeurope", "westeurope":
+			case "eastus", "eastus2", "westus", "centralus", "northcentralus", "southcentralus", "northeurope", "westeurope", "canadacentral":
 				return 3
 			case "centraluseuap":
 				return 1

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -1229,6 +1229,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			switch cs.Location {
 			case "eastus", "eastus2", "westus", "centralus", "northcentralus", "southcentralus", "northeurope", "westeurope":
 				return 3
+			case "centraluseuap":
+				return 1
 			default:
 				return 2
 			}

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -1225,5 +1225,13 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"shellQuote": func(s string) string {
 			return `'` + strings.Replace(s, `'`, `'\''`, -1) + `'`
 		},
+		"GetPlatformFaultDomainCountForManagedDisks": func() int {
+			switch cs.Location {
+			case "eastus", "eastus2", "westus", "centralus", "northcentralus", "southcentralus", "northeurope", "westeurope":
+				return 3
+			default:
+				return 2
+			}
+		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Assigns fault domain count for managed disk based on region support. See:

https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/managed-disks-common-fault-domain-region-list.md

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1509

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
get FD count for managed disk based on region
```