### PR TITLE
change the docker service sequence

### DIFF
--- a/parts/dcos/bstrap/dcoscustomdata111.t
+++ b/parts/dcos/bstrap/dcoscustomdata111.t
@@ -39,7 +39,6 @@ runcmd: PREPROVISION_EXTENSION
     - /opt/azure/containers/provision.sh
     - [ systemctl, start, dcos-docker-install.service ]
     - [ systemctl, restart, systemd-journald.service ]
-    - [ systemctl, restart, docker.service ]
     - [ bash, /tmp/dcos/dcos_install.sh, ROLENAME ]
     - [ bash, /opt/azure/dcos/diagnostics_fix.sh ]
 write_files:
@@ -53,7 +52,7 @@ write_files:
     StandardOutput=journal+console
     StandardError=journal+console
     ExecStartPre=/usr/bin/curl -fLsSv --retry 20 -Y 100000 -y 60 -o /var/tmp/d.deb https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_17.09.0~ce-0~ubuntu_amd64.deb
-    ExecStart=/usr/bin/bash -c "try=1;until dpkg -D3 -i /var/tmp/d.deb || ((try>9));do echo retry $((try++));sleep $((try*try));done;systemctl --now start docker;systemctl restart docker.socket"
+    ExecStart=/usr/bin/bash -c "try=1;until dpkg -D3 -i /var/tmp/d.deb || ((try>9));do echo retry $((try++));sleep $((try*try));done;systemctl restart docker.socket;systemctl --now start docker"
   path: /etc/systemd/system/dcos-docker-install.service
   permissions: '0644'
 - content: |


### PR DESCRIPTION
Restarting docker after docker.socket has been started creates an intermittent issue in docker.socket - port already in use.
Changing the starting sequence to docker.socket.service -> docker.sservice