### PR TITLE
[WIP] Connect to all etcd servers from k8s apiserver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,7 @@ jobs:
           echo 'export SUBSCRIPTION_ID=${SUBSCRIPTION_ID_E2E_KUBERNETES}' >> $BASH_ENV
           echo 'export CLIENT_ID=${SERVICE_PRINCIPAL_CLIENT_ID_E2E_KUBERNETES}' >> $BASH_ENV
           echo 'export CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET_E2E_KUBERNETES}' >> $BASH_ENV
+          echo 'export CLEANUP_ON_EXIT=false' >> $BASH_ENV # TODO remove this before merging!
       - run:
           name: compile
           command: make build-binary

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -147,7 +147,7 @@ func getEtcdMasters(cs *api.ContainerService) string {
 	if cs.Properties.MasterProfile != nil {
 		for i := 0; i < cs.Properties.MasterProfile.Count; i++ {
 			ret += "https://" + DefaultOrchestratorName + "-master-" + GenerateClusterID(cs.Properties) +
-				":" + strconv.Itoa(DefaultMasterEtcdClientPort) + ","
+				"-" + strconv.Itoa(i) + ":" + strconv.Itoa(DefaultMasterEtcdClientPort) + ","
 		}
 		if ret != "" {
 			return ret[:len(ret)-1]

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -144,12 +144,14 @@ func setAPIServerConfig(cs *api.ContainerService) {
 
 func getEtcdMasters(cs *api.ContainerService) string {
 	var ret string
-	for i := 0; i < cs.Properties.MasterProfile.Count; i++ {
-		ret += "https://" + DefaultOrchestratorName + "-master-" + GenerateClusterID(cs.Properties) +
-			":" + strconv.Itoa(DefaultMasterEtcdClientPort) + ","
-	}
-	if ret != "" {
-		return ret[:len(ret)-1]
+	if cs.Properties.MasterProfile != nil {
+		for i := 0; i < cs.Properties.MasterProfile.Count; i++ {
+			ret += "https://" + DefaultOrchestratorName + "-master-" + GenerateClusterID(cs.Properties) +
+				":" + strconv.Itoa(DefaultMasterEtcdClientPort) + ","
+		}
+		if ret != "" {
+			return ret[:len(ret)-1]
+		}
 	}
 	return ret
 }

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -148,5 +148,8 @@ func getEtcdMasters(cs *api.ContainerService) string {
 		ret += "https://" + DefaultOrchestratorName + "-master-" + GenerateClusterID(cs.Properties) +
 			":" + strconv.Itoa(DefaultMasterEtcdClientPort) + ","
 	}
-	return ret[:len(ret)-1]
+	if ret != "" {
+		return ret[:len(ret)-1]
+	}
+	return ret
 }

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -22,7 +22,7 @@ func setAPIServerConfig(cs *api.ContainerService) {
 		"--etcd-cafile":                "/etc/kubernetes/certs/ca.crt",
 		"--etcd-certfile":              "/etc/kubernetes/certs/etcdclient.crt",
 		"--etcd-keyfile":               "/etc/kubernetes/certs/etcdclient.key",
-		"--etcd-servers":               "https://127.0.0.1:" + strconv.Itoa(DefaultMasterEtcdClientPort),
+		"--etcd-servers":               getEtcdMasters(cs),
 		"--tls-cert-file":              "/etc/kubernetes/certs/apiserver.crt",
 		"--tls-private-key-file":       "/etc/kubernetes/certs/apiserver.key",
 		"--client-ca-file":             "/etc/kubernetes/certs/ca.crt",
@@ -140,4 +140,13 @@ func setAPIServerConfig(cs *api.ContainerService) {
 			delete(o.KubernetesConfig.APIServerConfig, key)
 		}
 	}
+}
+
+func getEtcdMasters(cs *api.ContainerService) string {
+	var ret string
+	for i := 0; i < cs.Properties.MasterProfile.Count; i++ {
+		ret += "https://" + DefaultOrchestratorName + "-master-" + GenerateClusterID(cs.Properties) +
+			":" + strconv.Itoa(DefaultMasterEtcdClientPort) + ","
+	}
+	return ret[:len(ret)-1]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Connect to all etcd servers from apiserver, not just localhost etcd peer

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2871

**Special notes for your reviewer**: //TODO:

- [ ] ensure that generated certs are able to communicate TLS on the private static IP address (cursory investigation suggests they currently are configured exclusively for `127.0.0.1`
- [ ] same as above for vm hostnames (e.g., `k8s-master-68246026-0`)

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)
- [ ] test w/ private cluster configuration

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Connect to all etcd servers from k8s apiserver
```