### PR TITLE
change networkPolicy to networkPlugin in Windows provisioning script.

### DIFF
--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -272,7 +272,7 @@ Install-VnetPlugins()
 }
 
 function
-Set-AzureNetworkPolicy()
+Set-AzureNetworkPlugin()
 {
     # Azure VNET network policy requires tunnel (hairpin) mode because policy is enforced in the host.
     Set-VnetPluginMode "tunnel"
@@ -296,12 +296,12 @@ Set-AzureCNIConfig()
 function
 Set-NetworkConfig
 {
-    Write-Log "Configuring networking with NetworkPolicy:$global:NetworkPolicy"
+    Write-Log "Configuring networking with NetworkPlugin:$global:NetworkPlugin"
 
     # Configure network policy.
-    if ($global:NetworkPolicy -eq "azure") {
+    if ($global:NetworkPlugin -eq "azure") {
         Install-VnetPlugins
-        Set-AzureNetworkPolicy
+        Set-AzureNetworkPlugin
         Set-AzureCNIConfig
     }
 }
@@ -349,15 +349,15 @@ c:\k\kubelet.exe --hostname-override=`$env:computername --pod-infra-container-im
 `$global:CNIConfig = "$global:CNIConfig"
 `$global:HNSModule = "$global:HNSModule"
 `$global:VolumePluginDir = "$global:VolumePluginDir"
-`$global:NetworkPolicy="$global:NetworkPolicy"
+`$global:NetworkPlugin="$global:NetworkPlugin"
 
 "@
 
-    if ($global:NetworkPolicy -eq "azure") {
+    if ($global:NetworkPlugin -eq "azure") {
         $global:KubeNetwork = "azure"
         $global:NetworkMode = "L2Tunnel"
         $kubeStartStr += @"
-Write-Host "NetworkPolicy azure, starting kubelet."
+Write-Host "NetworkPlugin azure, starting kubelet."
 $KubeletCommandLine
 
 "@


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR takes networkPlugin argument instead of networkPolicy to provision Windows clusters with Azure CNI.

**Which issue this PR fixes** : partially fixes #2868.
However, for a complete fix for #2868, we need Kubernetes to address https://github.com/kubernetes/kubernetes/issues/60884.