### PR TITLE
add VMAS scale up/down support for openshift

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -18,6 +19,7 @@ import (
 	"github.com/Azure/acs-engine/pkg/armhelpers/utils"
 	"github.com/Azure/acs-engine/pkg/helpers"
 	"github.com/Azure/acs-engine/pkg/i18n"
+	"github.com/Azure/acs-engine/pkg/openshift/filesystem"
 	"github.com/Azure/acs-engine/pkg/operations"
 	"github.com/leonelquinteros/gotext"
 
@@ -51,8 +53,8 @@ type scaleCmd struct {
 
 const (
 	scaleName             = "scale"
-	scaleShortDescription = "Scale an existing Kubernetes cluster"
-	scaleLongDescription  = "Scale an existing Kubernetes cluster by specifying increasing or decreasing the node count of an agentpool"
+	scaleShortDescription = "Scale an existing Kubernetes or OpenShift cluster"
+	scaleLongDescription  = "Scale an existing Kubernetes or OpenShift cluster by specifying increasing or decreasing the node count of an agentpool"
 )
 
 // NewScaleCmd run a command to upgrade a Kubernetes cluster
@@ -237,11 +239,31 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 				vmsToDelete = append(vmsToDelete, indexToVM[i])
 			}
 
-			if orchestratorInfo.OrchestratorType == api.Kubernetes {
-				err = sc.drainNodes(vmsToDelete)
+			switch orchestratorInfo.OrchestratorType {
+			case api.Kubernetes:
+				kubeConfig, err := acsengine.GenerateKubeConfig(sc.containerService.Properties, sc.location)
+				if err != nil {
+					log.Errorf("failed to generate kube config: %v", err)
+					return err
+				}
+				err = sc.drainNodes(kubeConfig, vmsToDelete)
 				if err != nil {
 					log.Errorf("Got error %+v, while draining the nodes to be deleted", err)
 					return err
+				}
+			case api.OpenShift:
+				bundle := bytes.NewReader(sc.containerService.Properties.OrchestratorProfile.OpenShiftConfig.ConfigBundles["master"])
+				fs, err := filesystem.NewTGZReader(bundle)
+				if err != nil {
+					return fmt.Errorf("failed to read master bundle: %v", err)
+				}
+				kubeConfig, err := fs.ReadFile("etc/origin/master/admin.kubeconfig")
+				if err != nil {
+					return fmt.Errorf("failed to read kube config: %v", err)
+				}
+				err = sc.drainNodes(string(kubeConfig), vmsToDelete)
+				if err != nil {
+					return fmt.Errorf("Got error %v, while draining the nodes to be deleted", err)
 				}
 			}
 
@@ -320,6 +342,14 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 	addValue(parametersJSON, sc.agentPool.Name+"Count", countForTemplate)
 
 	switch orchestratorInfo.OrchestratorType {
+	case api.OpenShift:
+		err = transformer.NormalizeForOpenShiftVMASScalingUp(sc.logger, sc.agentPool.Name, templateJSON)
+		if err != nil {
+			return fmt.Errorf("error tranforming the template for scaling template %s: %v", sc.apiModelPath, err)
+		}
+		if sc.agentPool.IsAvailabilitySets() {
+			addValue(parametersJSON, fmt.Sprintf("%sOffset", sc.agentPool.Name), highestUsedIndex+1)
+		}
 	case api.Kubernetes:
 		err = transformer.NormalizeForK8sVMASScalingUp(sc.logger, templateJSON)
 		if err != nil {
@@ -387,11 +417,7 @@ func addValue(m paramsMap, k string, v interface{}) {
 	}
 }
 
-func (sc *scaleCmd) drainNodes(vmsToDelete []string) error {
-	kubeConfig, err := acsengine.GenerateKubeConfig(sc.containerService.Properties, sc.location)
-	if err != nil {
-		log.Fatalf("failed to generate kube config: %v", err) // TODO: cleanup
-	}
+func (sc *scaleCmd) drainNodes(kubeConfig string, vmsToDelete []string) error {
 	masterURL := sc.masterFQDN
 	if !strings.HasPrefix(masterURL, "https://") {
 		masterURL = fmt.Sprintf("https://%s", masterURL)
@@ -401,7 +427,7 @@ func (sc *scaleCmd) drainNodes(vmsToDelete []string) error {
 	defer close(errChan)
 	for _, vmName := range vmsToDelete {
 		go func(vmName string) {
-			err = operations.SafelyDrainNode(sc.client, sc.logger,
+			err := operations.SafelyDrainNode(sc.client, sc.logger,
 				masterURL, kubeConfig, vmName, time.Duration(60)*time.Minute)
 			if err != nil {
 				log.Errorf("Failed to drain node %s, got error %v", vmName, err)

--- a/parts/openshift/openshiftnodescript.sh
+++ b/parts/openshift/openshiftnodescript.sh
@@ -23,3 +23,8 @@ update-ca-trust
 # note: ${SERVICE_TYPE}-node crash loops until master is up
 systemctl enable ${SERVICE_TYPE}-node.service
 systemctl start ${SERVICE_TYPE}-node.service &
+
+while [[ $(KUBECONFIG=/etc/origin/node/node.kubeconfig oc get node $(hostname) -o template \
+    --template '{{`{{range .status.conditions}}{{if eq .type "Ready"}}{{.status}}{{end}}{{end}}`}}') != True ]]; do
+    sleep 1
+done

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -832,12 +832,12 @@ func openShiftSetDefaultCerts(a *api.Properties) (bool, error) {
 	return true, nil
 }
 
-type writeFn func(filesystem.Filesystem) error
+type writeFn func(filesystem.Writer) error
 
 func getConfigBundle(write writeFn) ([]byte, error) {
 	b := &bytes.Buffer{}
 
-	fs, err := filesystem.NewTGZFile(b)
+	fs, err := filesystem.NewTGZWriter(b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -769,6 +769,11 @@ func setStorageDefaults(a *api.Properties) {
 }
 
 func openShiftSetDefaultCerts(a *api.Properties) (bool, error) {
+	if len(a.OrchestratorProfile.OpenShiftConfig.ConfigBundles["master"]) > 0 &&
+		len(a.OrchestratorProfile.OpenShiftConfig.ConfigBundles["bootstrap"]) > 0 {
+		return true, nil
+	}
+
 	c := certgen.Config{
 		Master: &certgen.Master{
 			Hostname: fmt.Sprintf("%s-master-%s-0", DefaultOpenshiftOrchestratorName, GenerateClusterID(a)),

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -769,8 +769,6 @@ func setStorageDefaults(a *api.Properties) {
 }
 
 func openShiftSetDefaultCerts(a *api.Properties) (bool, error) {
-	externalMasterHostname := fmt.Sprintf("%s.%s.cloudapp.azure.com", a.MasterProfile.DNSPrefix, a.AzProfile.Location)
-	routerLBHostname := fmt.Sprintf("%s-router.%s.cloudapp.azure.com", a.MasterProfile.DNSPrefix, a.AzProfile.Location)
 	c := certgen.Config{
 		Master: &certgen.Master{
 			Hostname: fmt.Sprintf("%s-master-%s-0", DefaultOpenshiftOrchestratorName, GenerateClusterID(a)),
@@ -779,7 +777,7 @@ func openShiftSetDefaultCerts(a *api.Properties) (bool, error) {
 			},
 			Port: 8443,
 		},
-		ExternalMasterHostname:  externalMasterHostname,
+		ExternalMasterHostname:  fmt.Sprintf("%s.%s.cloudapp.azure.com", a.MasterProfile.DNSPrefix, a.AzProfile.Location),
 		ClusterUsername:         a.OrchestratorProfile.OpenShiftConfig.ClusterUsername,
 		ClusterPassword:         a.OrchestratorProfile.OpenShiftConfig.ClusterPassword,
 		EnableAADAuthentication: a.OrchestratorProfile.OpenShiftConfig.EnableAADAuthentication,
@@ -792,8 +790,6 @@ func openShiftSetDefaultCerts(a *api.Properties) (bool, error) {
 			Location:        a.AzProfile.Location,
 		},
 	}
-	a.OrchestratorProfile.OpenShiftConfig.ExternalMasterHostname = externalMasterHostname
-	a.OrchestratorProfile.OpenShiftConfig.RouterLBHostname = routerLBHostname
 
 	err := c.PrepareMasterCerts()
 	if err != nil {

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -1949,8 +1949,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 				Location               string
 			}{
 				ConfigBundle:           base64.StdEncoding.EncodeToString(cs.Properties.OrchestratorProfile.OpenShiftConfig.ConfigBundles["master"]),
-				ExternalMasterHostname: cs.Properties.OrchestratorProfile.OpenShiftConfig.ExternalMasterHostname,
-				RouterLBHostname:       cs.Properties.OrchestratorProfile.OpenShiftConfig.RouterLBHostname,
+				ExternalMasterHostname: fmt.Sprintf("%s.%s.cloudapp.azure.com", cs.Properties.MasterProfile.DNSPrefix, cs.Properties.AzProfile.Location),
+				RouterLBHostname:       fmt.Sprintf("%s-router.%s.cloudapp.azure.com", cs.Properties.MasterProfile.DNSPrefix, cs.Properties.AzProfile.Location),
 				Location:               cs.Properties.AzProfile.Location,
 			})
 			return b.String(), err

--- a/pkg/acsengine/transform/transform_test.go
+++ b/pkg/acsengine/transform/transform_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Azure/acs-engine/pkg/helpers"
 	"github.com/Azure/acs-engine/pkg/i18n"
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 )
@@ -61,6 +62,69 @@ func TestNormalizeForK8sVMASScalingUpWithVnet(t *testing.T) {
 	e = transformer.NormalizeForK8sVMASScalingUp(logger, templateMap)
 	Expect(e).To(BeNil())
 	ValidateTemplate(templateMap, expectedFileContents, "TestNormalizeForK8sVMASScalingUpWithVnet")
+}
+
+func TestNormalizeForOpenShiftVMASScalingUp(t *testing.T) {
+	RegisterTestingT(t)
+
+	tests := []struct {
+		agentPoolName       string
+		templateMap         map[string]interface{}
+		expectedTemplateMap map[string]interface{}
+		expectedErr         bool
+	}{
+		{
+			// a badly constructed input should result in an error, not a panic
+			expectedErr: true,
+		},
+		{
+			agentPoolName: "compute",
+			templateMap: map[string]interface{}{
+				"resources": []interface{}{
+					map[string]interface{}{
+						"name": "foo",
+					},
+					map[string]interface{}{
+						"name": "barVMNamePrefix",
+						"dependsOn": []interface{}{
+							"foo",
+						},
+					},
+					map[string]interface{}{
+						"name": "computeVMNamePrefix",
+						"dependsOn": []interface{}{
+							"foo",
+							"barVMNamePrefix",
+							"computeVMNamePrefix",
+						},
+					},
+				},
+				"outputs": []interface{}{
+					"junk",
+				},
+			},
+			expectedTemplateMap: map[string]interface{}{
+				"resources": []interface{}{
+					map[string]interface{}{
+						"name": "computeVMNamePrefix",
+						"dependsOn": []interface{}{
+							"computeVMNamePrefix",
+						},
+					},
+				},
+				"outputs": []interface{}{},
+			},
+		},
+	}
+
+	transformer := &Transformer{}
+
+	for i, test := range tests {
+		fmt.Fprintf(GinkgoWriter, "test %d\n", i)
+		err := transformer.NormalizeForOpenShiftVMASScalingUp(nil, test.agentPoolName, test.templateMap)
+		Expect(err != nil).To(Equal(test.expectedErr))
+		Expect(test.templateMap).To(BeEquivalentTo(test.expectedTemplateMap))
+	}
 }
 
 func TestNormalizeResourcesForK8sMasterUpgrade(t *testing.T) {

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -661,6 +661,7 @@ func convertOpenShiftConfigToVLabs(api *OpenShiftConfig, vl *vlabs.OpenShiftConf
 	vl.ClusterUsername = api.ClusterUsername
 	vl.ClusterPassword = api.ClusterPassword
 	vl.EnableAADAuthentication = api.EnableAADAuthentication
+	vl.ConfigBundles = api.ConfigBundles
 }
 
 func convertDcosConfigToVLabs(api *DcosConfig, vl *vlabs.DcosConfig) {
@@ -987,6 +988,7 @@ func convertAgentPoolProfileToVLabs(api *AgentPoolProfile, p *vlabs.AgentPoolPro
 		p.ImageRef.Name = api.ImageRef.Name
 		p.ImageRef.ResourceGroup = api.ImageRef.ResourceGroup
 	}
+	p.Role = vlabs.AgentPoolProfileRole(api.Role)
 }
 
 func convertDiagnosticsProfileToV20160930(api *DiagnosticsProfile, dp *v20160930.DiagnosticsProfile) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -649,6 +649,7 @@ func convertVLabsOpenShiftConfig(vlabs *vlabs.OpenShiftConfig, api *OpenShiftCon
 	api.ClusterUsername = vlabs.ClusterUsername
 	api.ClusterPassword = vlabs.ClusterPassword
 	api.EnableAADAuthentication = vlabs.EnableAADAuthentication
+	api.ConfigBundles = vlabs.ConfigBundles
 }
 
 func convertVLabsKubernetesConfig(vlabs *vlabs.KubernetesConfig, api *KubernetesConfig) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -345,9 +345,7 @@ type OpenShiftConfig struct {
 	// EnableAADAuthentication is temporary, do not rely on it.
 	EnableAADAuthentication bool `json:"enableAADAuthentication,omitempty"`
 
-	ConfigBundles          map[string][]byte `json:"-"`
-	ExternalMasterHostname string            `json:"-"`
-	RouterLBHostname       string            `json:"-"`
+	ConfigBundles map[string][]byte `json:"-"`
 }
 
 // MasterProfile represents the definition of the master cluster

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -345,7 +345,7 @@ type OpenShiftConfig struct {
 	// EnableAADAuthentication is temporary, do not rely on it.
 	EnableAADAuthentication bool `json:"enableAADAuthentication,omitempty"`
 
-	ConfigBundles map[string][]byte `json:"-"`
+	ConfigBundles map[string][]byte `json:"configBundles,omitempty"`
 }
 
 // MasterProfile represents the definition of the master cluster

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -338,6 +338,8 @@ type OpenShiftConfig struct {
 
 	// EnableAADAuthentication is temporary, do not rely on it.
 	EnableAADAuthentication bool `json:"enableAADAuthentication,omitempty"`
+
+	ConfigBundles map[string][]byte `json:"configBundles,omitempty"`
 }
 
 // MasterProfile represents the definition of the master cluster

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -280,7 +280,10 @@ func validateImageNameAndGroup(name, resourceGroup string) error {
 }
 
 // Validate implements APIObject
-func (m *MasterProfile) Validate() error {
+func (m *MasterProfile) Validate(o *OrchestratorProfile) error {
+	if o.OrchestratorType == OpenShift && m.Count != 1 {
+		return errors.New("openshift can only deployed with one master")
+	}
 	if m.ImageRef != nil {
 		if err := validateImageNameAndGroup(m.ImageRef.Name, m.ImageRef.ResourceGroup); err != nil {
 			return err
@@ -454,7 +457,7 @@ func (a *Properties) Validate(isUpdate bool) error {
 	if e := a.validateAddons(); e != nil {
 		return e
 	}
-	if e := a.MasterProfile.Validate(); e != nil {
+	if e := a.MasterProfile.Validate(a.OrchestratorProfile); e != nil {
 		return e
 	}
 	if e := validateUniqueProfileNames(a.AgentPoolProfiles); e != nil {

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -829,6 +829,56 @@ func TestValidateImageNameAndGroup(t *testing.T) {
 	}
 }
 
+func TestMasterProfileValidate(t *testing.T) {
+	tests := []struct {
+		orchestratorType string
+		masterProfile    MasterProfile
+		expectedErr      string
+	}{
+		{
+			masterProfile: MasterProfile{
+				DNSPrefix: "bad!",
+			},
+			expectedErr: "DNS name 'bad!' is invalid. The DNS name must contain between 3 and 45 characters.  The name can contain only letters, numbers, and hyphens.  The name must start with a letter and must end with a letter or a number (length was 4)",
+		},
+		{
+			masterProfile: MasterProfile{
+				DNSPrefix: "dummy",
+				Count:     1,
+			},
+		},
+		{
+			masterProfile: MasterProfile{
+				DNSPrefix: "dummy",
+				Count:     3,
+			},
+		},
+		{
+			orchestratorType: OpenShift,
+			masterProfile: MasterProfile{
+				DNSPrefix: "dummy",
+				Count:     1,
+			},
+		},
+		{
+			orchestratorType: OpenShift,
+			masterProfile: MasterProfile{
+				DNSPrefix: "dummy",
+				Count:     3,
+			},
+			expectedErr: "openshift can only deployed with one master",
+		},
+	}
+
+	for i, test := range tests {
+		err := test.masterProfile.Validate(&OrchestratorProfile{OrchestratorType: test.orchestratorType})
+		if test.expectedErr == "" && err != nil ||
+			test.expectedErr != "" && (err == nil || test.expectedErr != err.Error()) {
+			t.Errorf("test %d: unexpected error %q\n", i, err)
+		}
+	}
+}
+
 func TestOpenshiftValidate(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/openshift/certgen/config.go
+++ b/pkg/openshift/certgen/config.go
@@ -66,7 +66,7 @@ func (s *serial) Get() *big.Int {
 }
 
 // WriteMaster writes the config files for a Master node to a Filesystem.
-func (c *Config) WriteMaster(fs filesystem.Filesystem) error {
+func (c *Config) WriteMaster(fs filesystem.Writer) error {
 	err := c.WriteMasterCerts(fs)
 	if err != nil {
 		return err
@@ -96,7 +96,7 @@ func (c *Config) WriteMaster(fs filesystem.Filesystem) error {
 }
 
 // WriteNode writes the config files for bootstrapping a node to a Filesystem.
-func (c *Config) WriteNode(fs filesystem.Filesystem) error {
+func (c *Config) WriteNode(fs filesystem.Writer) error {
 	err := c.WriteBootstrapCerts(fs)
 	if err != nil {
 		return err

--- a/pkg/openshift/certgen/config_test.go
+++ b/pkg/openshift/certgen/config_test.go
@@ -28,7 +28,7 @@ func (fakefilesystem) Close() error {
 	return nil
 }
 
-var _ filesystem.Filesystem = &fakefilesystem{}
+var _ filesystem.Writer = &fakefilesystem{}
 
 func TestConfigFilePermissions(t *testing.T) {
 	c := Config{

--- a/pkg/openshift/certgen/files.go
+++ b/pkg/openshift/certgen/files.go
@@ -77,7 +77,7 @@ func (c *Config) PrepareMasterFiles() error {
 }
 
 // WriteMasterFiles writes the templated master config
-func (c *Config) WriteMasterFiles(fs filesystem.Filesystem) error {
+func (c *Config) WriteMasterFiles(fs filesystem.Writer) error {
 
 	// create special case directories
 	specialCaseDirs := map[string]filesystem.Fileinfo{
@@ -136,7 +136,7 @@ func (c *Config) WriteMasterFiles(fs filesystem.Filesystem) error {
 }
 
 // WriteNodeFiles writes the templated node config
-func (c *Config) WriteNodeFiles(fs filesystem.Filesystem) error {
+func (c *Config) WriteNodeFiles(fs filesystem.Writer) error {
 	for _, name := range templates.AssetNames() {
 		if !strings.HasPrefix(name, "node/") {
 			continue

--- a/pkg/openshift/certgen/kubeconfig.go
+++ b/pkg/openshift/certgen/kubeconfig.go
@@ -262,7 +262,7 @@ func (c *Config) PrepareBootstrapKubeConfig() error {
 }
 
 // WriteMasterKubeConfigs writes the master kubeconfigs
-func (c *Config) WriteMasterKubeConfigs(fs filesystem.Filesystem) error {
+func (c *Config) WriteMasterKubeConfigs(fs filesystem.Writer) error {
 	for filename, kubeconfig := range c.Master.kubeconfigs {
 		b, err := yaml.Marshal(&kubeconfig)
 		if err != nil {
@@ -278,7 +278,7 @@ func (c *Config) WriteMasterKubeConfigs(fs filesystem.Filesystem) error {
 }
 
 // WriteBootstrapKubeConfig writes the node bootstrap kubeconfig
-func (c *Config) WriteBootstrapKubeConfig(fs filesystem.Filesystem) error {
+func (c *Config) WriteBootstrapKubeConfig(fs filesystem.Writer) error {
 	b, err := yaml.Marshal(&c.Bootstrap)
 	if err != nil {
 		return err

--- a/pkg/openshift/certgen/tls.go
+++ b/pkg/openshift/certgen/tls.go
@@ -102,7 +102,7 @@ func certAsBytes(cert *x509.Certificate) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func writeCert(fs filesystem.Filesystem, filename string, cert *x509.Certificate) error {
+func writeCert(fs filesystem.Writer, filename string, cert *x509.Certificate) error {
 	b, err := certAsBytes(cert)
 	if err != nil {
 		return err
@@ -122,7 +122,7 @@ func privateKeyAsBytes(key *rsa.PrivateKey) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func writePrivateKey(fs filesystem.Filesystem, filename string, key *rsa.PrivateKey) error {
+func writePrivateKey(fs filesystem.Writer, filename string, key *rsa.PrivateKey) error {
 	b, err := privateKeyAsBytes(key)
 	if err != nil {
 		return err
@@ -132,7 +132,7 @@ func writePrivateKey(fs filesystem.Filesystem, filename string, key *rsa.Private
 	return fs.WriteFile(filename, b, fi)
 }
 
-func writePublicKey(fs filesystem.Filesystem, filename string, key *rsa.PublicKey) error {
+func writePublicKey(fs filesystem.Writer, filename string, key *rsa.PublicKey) error {
 	buf := &bytes.Buffer{}
 
 	b, err := x509.MarshalPKIXPublicKey(key)
@@ -411,7 +411,7 @@ func (c *Config) PrepareMasterCerts() error {
 }
 
 // WriteMasterCerts writes the master certs
-func (c *Config) WriteMasterCerts(fs filesystem.Filesystem) error {
+func (c *Config) WriteMasterCerts(fs filesystem.Writer) error {
 	for filename, ca := range c.cas {
 		err := writeCert(fs, fmt.Sprintf("%s.crt", filename), ca.cert)
 		if err != nil {
@@ -468,7 +468,7 @@ func (c *Config) WriteMasterCerts(fs filesystem.Filesystem) error {
 }
 
 // WriteBootstrapCerts writes the node bootstrap certs
-func (c *Config) WriteBootstrapCerts(fs filesystem.Filesystem) error {
+func (c *Config) WriteBootstrapCerts(fs filesystem.Writer) error {
 	err := writeCert(fs, "etc/origin/node/ca.crt", c.cas["etc/origin/master/ca"].cert)
 	if err != nil {
 		return err
@@ -483,7 +483,7 @@ func (c *Config) WriteBootstrapCerts(fs filesystem.Filesystem) error {
 }
 
 // WriteMasterKeypair writes the master service account keypair
-func (c *Config) WriteMasterKeypair(fs filesystem.Filesystem) error {
+func (c *Config) WriteMasterKeypair(fs filesystem.Writer) error {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return err

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -67,7 +67,7 @@ func (c *Config) GetKubeConfig() string {
 		masterTarball := filepath.Join(artifactsDir, "master.tar.gz")
 		out, err := exec.Command("tar", "-xzf", masterTarball, "-C", artifactsDir).CombinedOutput()
 		if err != nil {
-			log.Fatalf("Cannot untar master tarball: %v: %v", out, err)
+			log.Fatalf("Cannot untar master tarball: %v: %v", string(out), err)
 		}
 		kubeconfigPath = filepath.Join(artifactsDir, "etc", "origin", "master", "admin.kubeconfig")
 	}

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -212,7 +212,11 @@ func WaitOnReady(podPrefix, namespace string, successesNeeded int, sleep, durati
 			case <-ctx.Done():
 				errCh <- fmt.Errorf("Timeout exceeded (%s) while waiting for Pods (%s) to become ready in namespace (%s), got %d of %d required successful pods ready results", duration.String(), podPrefix, namespace, successCount, successesNeeded)
 			default:
-				ready, _ := AreAllPodsRunning(podPrefix, namespace)
+				ready, err := AreAllPodsRunning(podPrefix, namespace)
+				if err != nil {
+					errCh <- err
+					return
+				}
 				if ready {
 					successCount = successCount + 1
 					if successCount >= successesNeeded {

--- a/test/e2e/openshift/openshift_test.go
+++ b/test/e2e/openshift/openshift_test.go
@@ -56,6 +56,32 @@ var _ = Describe("Azure Container Cluster using the OpenShift Orchestrator", fun
 		Expect(ready).To(Equal(true))
 	})
 
+	It("should label nodes correctly", func() {
+		labels := map[string]map[string]string{
+			"master": {
+				"node-role.kubernetes.io/master": "true",
+				"openshift-infra":                "apiserver",
+			},
+			"compute": {
+				"node-role.kubernetes.io/compute": "true",
+				"region": "primary",
+			},
+			"infra": {
+				"region": "infra",
+			},
+		}
+		list, err := knode.Get()
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, node := range list.Nodes {
+			kind := strings.Split(node.Metadata.Name, "-")[1]
+			Expect(labels).To(HaveKey(kind))
+			for k, v := range labels[kind] {
+				Expect(node.Metadata.Labels).To(HaveKeyWithValue(k, v))
+			}
+		}
+	})
+
 	It("should be running the expected version", func() {
 		version, err := node.Version()
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
adds VMAS scale up/down support for openshift

`acs-engine scale --resource-group $RG --location $LOCATION --subscription-id $SUB --new-node-count $COUNT --deployment-dir _output/$RG --node-pool $POOL --master-FQDN https://$RG.$LOCATION.cloudapp.azure.com:8443/`
