### PR TITLE
use static default bool value for kubernetesClusterAutoscalerEnabled

### DIFF
--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -494,7 +494,7 @@
       "type": "string"
     },
     "kubernetesClusterAutoscalerEnabled": {
-      {{PopulateClassicModeDefaultValue "kubernetesClusterAutoscalerEnabled"}}
+      "defaultValue": false,
       "metadata": {
         "description": "Cluster autoscaler status"
       },

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -1759,12 +1759,6 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 					} else {
 						val = ""
 					}
-				case "kubernetesClusterAutoscalerEnabled":
-					if aS > -1 {
-						val = strconv.FormatBool(*clusterAutoscalerAddon.Enabled)
-					} else {
-						val = "false"
-					}
 				case "kubernetesClusterAutoscalerUseManagedIdentity":
 					if aS > -1 {
 						if cs.Properties.OrchestratorProfile.KubernetesConfig != nil && cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: fixes openshift E2E

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
