### PR TITLE
dcos: simplified node provisioning, use CDN

### DIFF
--- a/parts/dcos/bstrap/dcoscustomdata111.t
+++ b/parts/dcos/bstrap/dcoscustomdata111.t
@@ -35,24 +35,9 @@ runcmd: PREPROVISION_EXTENSION
 - systemctl disable --now unscd.service
 - systemctl stop --now unscd.service
 - /opt/azure/containers/provision.sh
-- systemctl start dcos-docker-install.service
-- systemctl restart systemd-journald.service
 - bash /tmp/dcos/dcos_install.sh ROLENAME
 - bash /opt/azure/dcos/diagnostics_fix.sh
 write_files:
-- content: |
-    [Unit]
-    After=network-online.target
-    Wants=network-online.target
-    [Service]
-    Type=oneshot
-    Environment=DEBIAN_FRONTEND=noninteractive
-    StandardOutput=journal+console
-    StandardError=journal+console
-    ExecStartPre=/usr/bin/curl -fLsSv --retry 20 -Y 100000 -y 60 -o /var/tmp/d.deb https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_17.09.0~ce-0~ubuntu_amd64.deb
-    ExecStart=/usr/bin/bash -c "try=1;until dpkg -D3 -i /var/tmp/d.deb || ((try>9));do echo retry $((try++));sleep $((try*try));done;systemctl restart docker.socket;systemctl --now start docker"
-  path: /etc/systemd/system/dcos-docker-install.service
-  permissions: '0644'
 - content: |
     [Service]
     Restart=always

--- a/parts/dcos/bstrap/dcosprovision.sh
+++ b/parts/dcos/bstrap/dcosprovision.sh
@@ -8,30 +8,30 @@ TMPDIR="/tmp/dcos"
 mkdir -p $TMPDIR
 
 # default dc/os component download address (Azure CDN)
-DOCKER_ENGINE_DOWNLOAD_URL=https://mesosphere.blob.core.windows.net/dcos-deps/docker-engine_1.13.1-0-ubuntu-xenial_amd64.deb
-LIBIPSET_DOWNLOAD_URL=https://az837203.vo.msecnd.net/dcos-deps/libipset3_6.29-1_amd64.deb
-IPSET_DOWNLOAD_URL=https://az837203.vo.msecnd.net/dcos-deps/ipset_6.29-1_amd64.deb
-UNZIP_DOWNLOAD_URL=https://az837203.vo.msecnd.net/dcos-deps/unzip_6.0-20ubuntu1_amd64.deb
-LIBLTDL_DOWNLOAD_URL=https://az837203.vo.msecnd.net/dcos-deps/libltdl7_2.4.6-0.1_amd64.deb
+LIBIPSET_DOWNLOAD_URL=https://dcos-mirror.azureedge.net/pkg/libipset3_6.29-1_amd64.deb
+IPSET_DOWNLOAD_URL=https://dcos-mirror.azureedge.net/pkg/ipset_6.29-1_amd64.deb
+UNZIP_DOWNLOAD_URL=https://dcos-mirror.azureedge.net/pkg/unzip_6.0-20ubuntu1_amd64.deb
+LIBLTDL_DOWNLOAD_URL=https://dcos-mirror.azureedge.net/pkg/libltdl7_2.4.6-0.1_amd64.deb
+DOCKER_CE_DOWNLOAD_URL=https://dcos-mirror.azureedge.net/pkg/docker-ce_17.09.0~ce-0~ubuntu_amd64.deb
 
 case $DCOS_ENVIRONMENT in
     # because of Chinese GreatWall Firewall, the default packages on Azure CDN is blocked. So the following Chinese local mirror url should be used instead.
     AzureChinaCloud)
-        DOCKER_ENGINE_DOWNLOAD_URL=http://acsengine.blob.core.chinacloudapi.cn/dcos/docker-engine_1.11.2-0~xenial_amd64.deb
         LIBIPSET_DOWNLOAD_URL=http://acsengine.blob.core.chinacloudapi.cn/dcos/libipset3_6.29-1_amd64.deb
         IPSET_DOWNLOAD_URL=http://acsengine.blob.core.chinacloudapi.cn/dcos/ipset_6.29-1_amd64.deb
         UNZIP_DOWNLOAD_URL=http://acsengine.blob.core.chinacloudapi.cn/dcos/unzip_6.0-20ubuntu1_amd64.deb
         LIBLTDL_DOWNLOAD_URL=http://acsengine.blob.core.chinacloudapi.cn/dcos/libltdl7_2.4.6-0.1_amd64.deb
+        DOCKER_CE_DOWNLOAD_URL=http://acsengine.blob.core.chinacloudapi.cn/dcos/docker-ce_17.09.0~ce-0~ubuntu_amd64.deb
     ;;
 esac
 
-curl -fLsSv --retry 20 -Y 100000 -y 60 -o $TMPDIR/d.deb $DOCKER_ENGINE_DOWNLOAD_URL &
 curl -fLsSv --retry 20 -Y 100000 -y 60 -o $TMPDIR/1.deb $LIBIPSET_DOWNLOAD_URL &
 curl -fLsSv --retry 20 -Y 100000 -y 60 -o $TMPDIR/2.deb $IPSET_DOWNLOAD_URL &
 curl -fLsSv --retry 20 -Y 100000 -y 60 -o $TMPDIR/3.deb $UNZIP_DOWNLOAD_URL &
 curl -fLsSv --retry 20 -Y 100000 -y 60 -o $TMPDIR/4.deb $LIBLTDL_DOWNLOAD_URL &
+curl -fLsSv --retry 20 -Y 100000 -y 60 -o $TMPDIR/5.deb $DOCKER_CE_DOWNLOAD_URL &
 curl -fLsSv --retry 20 -Y 100000 -y 60 -o $TMPDIR/dcos_install.sh http://BOOTSTRAP_IP:8086/dcos_install.sh &
 wait
 
-retrycmd_if_failure 10 10 120 dpkg -i $TMPDIR/{1,2,3,4}.deb
+retrycmd_if_failure 10 10 120 dpkg -i $TMPDIR/{1,2,3,4,5}.deb
 retrycmd_if_failure 10 10 120 apt-get install selinux-utils -y


### PR DESCRIPTION
Simplified node provisioning:
 - cleaned up unnecessary service
 - started using new CDN
