### PR TITLE
Delete role assignments when deleting a VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ test/e2e/openshift/translations/
 # test outputs
 cmd/_test_output
 
+.idea

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -267,7 +267,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 				}
 			}
 
-			errList := operations.ScaleDownVMs(sc.client, sc.logger, sc.resourceGroupName, vmsToDelete...)
+			errList := operations.ScaleDownVMs(sc.client, sc.logger, sc.SubscriptionID.String(), sc.resourceGroupName, vmsToDelete...)
 			if errList != nil {
 				errorMessage := ""
 				for element := errList.Front(); element != nil; element = element.Next() {

--- a/pkg/armhelpers/graph.go
+++ b/pkg/armhelpers/graph.go
@@ -37,6 +37,15 @@ func (az *AzureClient) CreateRoleAssignment(scope string, roleAssignmentName str
 	return az.authorizationClient.Create(scope, roleAssignmentName, parameters)
 }
 
+func (az *AzureClient) DeleteRoleAssignmentByID(roleAssignmentID string) (authorization.RoleAssignment, error) {
+	return az.authorizationClient.DeleteByID(roleAssignmentID)
+}
+
+func (az *AzureClient) ListRoleAssignmentsForPrincipal(scope string, principalID string) (authorization.RoleAssignmentListResult, error) {
+	filter := fmt.Sprintf("principalId eq '%s'", principalID)
+	return az.authorizationClient.ListForScope(scope, filter)
+}
+
 // CreateApp is a simpler method for creating an application
 func (az *AzureClient) CreateApp(appName, appURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (applicationID, servicePrincipalObjectID, servicePrincipalClientSecret string, err error) {
 	notBefore := time.Now()

--- a/pkg/armhelpers/graph.go
+++ b/pkg/armhelpers/graph.go
@@ -37,10 +37,12 @@ func (az *AzureClient) CreateRoleAssignment(scope string, roleAssignmentName str
 	return az.authorizationClient.Create(scope, roleAssignmentName, parameters)
 }
 
+// DeleteRoleAssignmentByID deletes a roleAssignment via its unique identifier
 func (az *AzureClient) DeleteRoleAssignmentByID(roleAssignmentID string) (authorization.RoleAssignment, error) {
 	return az.authorizationClient.DeleteByID(roleAssignmentID)
 }
 
+// List all role assignments for a principal (e.g. a VM) via the scope and the unique identifier of the principal
 func (az *AzureClient) ListRoleAssignmentsForPrincipal(scope string, principalID string) (authorization.RoleAssignmentListResult, error) {
 	filter := fmt.Sprintf("principalId eq '%s'", principalID)
 	return az.authorizationClient.ListForScope(scope, filter)

--- a/pkg/armhelpers/graph.go
+++ b/pkg/armhelpers/graph.go
@@ -42,7 +42,7 @@ func (az *AzureClient) DeleteRoleAssignmentByID(roleAssignmentID string) (author
 	return az.authorizationClient.DeleteByID(roleAssignmentID)
 }
 
-// List all role assignments for a principal (e.g. a VM) via the scope and the unique identifier of the principal
+// ListRoleAssignmentsForPrincipal (e.g. a VM) via the scope and the unique identifier of the principal
 func (az *AzureClient) ListRoleAssignmentsForPrincipal(scope string, principalID string) (authorization.RoleAssignmentListResult, error) {
 	filter := fmt.Sprintf("principalId eq '%s'", principalID)
 	return az.authorizationClient.ListForScope(scope, filter)

--- a/pkg/armhelpers/interfaces.go
+++ b/pkg/armhelpers/interfaces.go
@@ -70,6 +70,8 @@ type ACSEngineClient interface {
 	// RBAC
 	CreateRoleAssignment(scope string, roleAssignmentName string, parameters authorization.RoleAssignmentCreateParameters) (authorization.RoleAssignment, error)
 	CreateRoleAssignmentSimple(applicationID, roleID string) error
+	DeleteRoleAssignmentByID(roleAssignmentNameID string) (authorization.RoleAssignment, error)
+	ListRoleAssignmentsForPrincipal(scope string, principalID string) (authorization.RoleAssignmentListResult, error)
 
 	// MANAGED DISKS
 	DeleteManagedDisk(resourceGroupName string, diskName string, cancel <-chan struct{}) (<-chan disk.OperationStatusResponse, <-chan error)

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -285,7 +285,7 @@ func (mc *MockACSEngineClient) GetVirtualMachine(resourceGroup, name string) (co
 		poolnameString:           &poolname,
 	}
 
-	var vmIdentity *compute.VirtualMachineIdentity = nil
+	var vmIdentity *compute.VirtualMachineIdentity
 	if mc.ShouldSupportVMIdentity {
 		vmIdentity = &compute.VirtualMachineIdentity{PrincipalID: &principalID}
 	}
@@ -487,9 +487,9 @@ func (mc *MockACSEngineClient) ListRoleAssignmentsForPrincipal(scope string, pri
 	roleAssignments := []authorization.RoleAssignment{}
 
 	if mc.ShouldSupportVMIdentity {
-		var assignmentId = "role-assignment-id"
+		var assignmentID = "role-assignment-id"
 		var assignment = authorization.RoleAssignment{
-			ID: &assignmentId}
+			ID: &assignmentID}
 		roleAssignments = append(roleAssignments, assignment)
 	}
 

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -467,10 +467,12 @@ func (mc *MockACSEngineClient) ListDeploymentOperationsNextResults(lastResults r
 	return resources.DeploymentOperationsListResult{}, nil
 }
 
+// DeleteRoleAssignmentByID deletes a roleAssignment via its unique identifier
 func (mc *MockACSEngineClient) DeleteRoleAssignmentByID(roleAssignmentID string) (authorization.RoleAssignment, error) {
 	return authorization.RoleAssignment{}, nil
 }
 
+// List all role assignments for a principal (e.g. a VM) via the scope and the unique identifier of the principal
 func (mc *MockACSEngineClient) ListRoleAssignmentsForPrincipal(scope string, principalID string) (authorization.RoleAssignmentListResult, error) {
 	roleAssignments := []authorization.RoleAssignment{}
 	return authorization.RoleAssignmentListResult{

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -472,7 +472,7 @@ func (mc *MockACSEngineClient) DeleteRoleAssignmentByID(roleAssignmentID string)
 	return authorization.RoleAssignment{}, nil
 }
 
-// List all role assignments for a principal (e.g. a VM) via the scope and the unique identifier of the principal
+// ListRoleAssignmentsForPrincipal (e.g. a VM) via the scope and the unique identifier of the principal
 func (mc *MockACSEngineClient) ListRoleAssignmentsForPrincipal(scope string, principalID string) (authorization.RoleAssignmentListResult, error) {
 	roleAssignments := []authorization.RoleAssignment{}
 	return authorization.RoleAssignmentListResult{

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -274,6 +274,8 @@ func (mc *MockACSEngineClient) GetVirtualMachine(resourceGroup, name string) (co
 	resourceNameSuffix := "12345678"
 	poolname := "agentpool1"
 
+	principalID := "00000000-1111-2222-3333-444444444444"
+
 	tags := map[string]*string{
 		creationSourceString:     &creationSource,
 		orchestratorString:       &orchestrator,
@@ -284,6 +286,8 @@ func (mc *MockACSEngineClient) GetVirtualMachine(resourceGroup, name string) (co
 	return compute.VirtualMachine{
 		Name: &vm1Name,
 		Tags: &tags,
+		Identity: &compute.VirtualMachineIdentity{
+			PrincipalID: &principalID},
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
 			StorageProfile: &compute.StorageProfile{
 				OsDisk: &compute.OSDisk{
@@ -461,4 +465,14 @@ func (mc *MockACSEngineClient) ListDeploymentOperations(resourceGroupName string
 // ListDeploymentOperationsNextResults retrieves the next set of results, if any.
 func (mc *MockACSEngineClient) ListDeploymentOperationsNextResults(lastResults resources.DeploymentOperationsListResult) (result resources.DeploymentOperationsListResult, err error) {
 	return resources.DeploymentOperationsListResult{}, nil
+}
+
+func (mc *MockACSEngineClient) DeleteRoleAssignmentByID(roleAssignmentID string) (authorization.RoleAssignment, error) {
+	return authorization.RoleAssignment{}, nil
+}
+
+func (mc *MockACSEngineClient) ListRoleAssignmentsForPrincipal(scope string, principalID string) (authorization.RoleAssignmentListResult, error) {
+	roleAssignments := []authorization.RoleAssignment{}
+	return authorization.RoleAssignmentListResult{
+		Value: &roleAssignments}, nil
 }

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -32,6 +32,8 @@ type MockACSEngineClient struct {
 	FailDeleteNetworkInterface      bool
 	FailGetKubernetesClient         bool
 	FailListProviders               bool
+	ShouldSupportVMIdentity         bool
+	FailDeleteRoleAssignment        bool
 	MockKubernetesClient            *MockKubernetesClient
 }
 
@@ -283,11 +285,15 @@ func (mc *MockACSEngineClient) GetVirtualMachine(resourceGroup, name string) (co
 		poolnameString:           &poolname,
 	}
 
+	var vmIdentity *compute.VirtualMachineIdentity = nil
+	if mc.ShouldSupportVMIdentity {
+		vmIdentity = &compute.VirtualMachineIdentity{PrincipalID: &principalID}
+	}
+
 	return compute.VirtualMachine{
-		Name: &vm1Name,
-		Tags: &tags,
-		Identity: &compute.VirtualMachineIdentity{
-			PrincipalID: &principalID},
+		Name:     &vm1Name,
+		Tags:     &tags,
+		Identity: vmIdentity,
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
 			StorageProfile: &compute.StorageProfile{
 				OsDisk: &compute.OSDisk{
@@ -469,12 +475,24 @@ func (mc *MockACSEngineClient) ListDeploymentOperationsNextResults(lastResults r
 
 // DeleteRoleAssignmentByID deletes a roleAssignment via its unique identifier
 func (mc *MockACSEngineClient) DeleteRoleAssignmentByID(roleAssignmentID string) (authorization.RoleAssignment, error) {
+	if mc.FailDeleteRoleAssignment {
+		return authorization.RoleAssignment{}, fmt.Errorf("DeleteRoleAssignmentByID failed")
+	}
+
 	return authorization.RoleAssignment{}, nil
 }
 
 // ListRoleAssignmentsForPrincipal (e.g. a VM) via the scope and the unique identifier of the principal
 func (mc *MockACSEngineClient) ListRoleAssignmentsForPrincipal(scope string, principalID string) (authorization.RoleAssignmentListResult, error) {
 	roleAssignments := []authorization.RoleAssignment{}
+
+	if mc.ShouldSupportVMIdentity {
+		var assignmentId = "role-assignment-id"
+		var assignment = authorization.RoleAssignment{
+			ID: &assignmentId}
+		roleAssignments = append(roleAssignments, assignment)
+	}
+
 	return authorization.RoleAssignmentListResult{
 		Value: &roleAssignments}, nil
 }

--- a/pkg/operations/deletevm.go
+++ b/pkg/operations/deletevm.go
@@ -106,7 +106,7 @@ func CleanDeleteVirtualMachine(az armhelpers.ACSEngineClient, logger *log.Entry,
 		logger.Infof("deleting role assignment: %s", *roleAssignment.ID)
 		_, deleteRoleAssignmentErr := az.DeleteRoleAssignmentByID(*roleAssignment.ID)
 		if deleteRoleAssignmentErr != nil {
-			logger.Errorf("failed to delete role assignment: %s", *roleAssignment.ID, deleteRoleAssignmentErr.Error())
+			logger.Errorf("failed to delete role assignment: %s: %s", *roleAssignment.ID, deleteRoleAssignmentErr.Error())
 			return deleteRoleAssignmentErr
 		}
 	}

--- a/pkg/operations/deletevm.go
+++ b/pkg/operations/deletevm.go
@@ -8,8 +8,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	// AADRoleResourceGroupScopeTemplate is a template for a roleDefinition scope
+	AADRoleResourceGroupScopeTemplate = "/subscriptions/%s/resourceGroups/%s"
+)
+
 // CleanDeleteVirtualMachine deletes a VM and any associated OS disk
-func CleanDeleteVirtualMachine(az armhelpers.ACSEngineClient, logger *log.Entry, resourceGroup, name string) error {
+func CleanDeleteVirtualMachine(az armhelpers.ACSEngineClient, logger *log.Entry, subscriptionID, resourceGroup, name string) error {
 	logger.Infof("fetching VM: %s/%s", resourceGroup, name)
 	vm, err := az.GetVirtualMachine(resourceGroup, name)
 	if err != nil {
@@ -83,6 +88,26 @@ func CleanDeleteVirtualMachine(az armhelpers.ACSEngineClient, logger *log.Entry,
 			if err := <-diskErrChan; err != nil {
 				return err
 			}
+		}
+	}
+
+	// Role assignments are not deleted if the VM is destroyed, so we must cleanup ourselves!
+	// The role assignments should only be relevant if managed identities are used,
+	// but always cleaning them up is easier than adding rule based logic here and there.
+	scope := fmt.Sprintf(AADRoleResourceGroupScopeTemplate, subscriptionID, resourceGroup)
+	logger.Infof("fetching roleAssignments: %s with principal %s", scope, *vm.Identity.PrincipalID)
+	vmRoleAssignments, listRoleAssingmentsError := az.ListRoleAssignmentsForPrincipal(scope, *vm.Identity.PrincipalID)
+	if listRoleAssingmentsError != nil {
+		logger.Errorf("failed to list role assignments: %s/%s: %s", scope, *vm.Identity.PrincipalID, listRoleAssingmentsError.Error())
+		return listRoleAssingmentsError
+	}
+
+	for _, roleAssignment := range *vmRoleAssignments.Value {
+		logger.Infof("deleting role assignment: %s", *roleAssignment.ID)
+		_, deleteRoleAssignmentErr := az.DeleteRoleAssignmentByID(*roleAssignment.ID)
+		if deleteRoleAssignmentErr != nil {
+			logger.Errorf("failed to delete role assignment: %s", *roleAssignment.ID, deleteRoleAssignmentErr.Error())
+			return deleteRoleAssignmentErr
 		}
 	}
 

--- a/pkg/operations/kubernetesupgrade/upgradeagentnode.go
+++ b/pkg/operations/kubernetesupgrade/upgradeagentnode.go
@@ -30,6 +30,7 @@ type UpgradeAgentNode struct {
 	TemplateMap             map[string]interface{}
 	ParametersMap           map[string]interface{}
 	UpgradeContainerService *api.ContainerService
+	SubscriptionID          string
 	ResourceGroup           string
 	Client                  armhelpers.ACSEngineClient
 	kubeConfig              string
@@ -62,7 +63,7 @@ func (kan *UpgradeAgentNode) DeleteNode(vmName *string, drain bool) error {
 		}
 	}
 	// Delete VM in ARM
-	if err := operations.CleanDeleteVirtualMachine(kan.Client, kan.logger, kan.ResourceGroup, *vmName); err != nil {
+	if err := operations.CleanDeleteVirtualMachine(kan.Client, kan.logger, kan.SubscriptionID, kan.ResourceGroup, *vmName); err != nil {
 		return err
 	}
 	// Delete VM in api server

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -19,10 +19,11 @@ import (
 // ClusterTopology contains resources of the cluster the upgrade operation
 // is targeting
 type ClusterTopology struct {
-	DataModel     *api.ContainerService
-	Location      string
-	ResourceGroup string
-	NameSuffix    string
+	DataModel      *api.ContainerService
+	SubscriptionID string
+	Location       string
+	ResourceGroup  string
+	NameSuffix     string
 
 	AgentPoolsToUpgrade map[string]bool
 	AgentPools          map[string]*AgentPoolTopology
@@ -59,6 +60,7 @@ const MasterPoolName = "master"
 func (uc *UpgradeCluster) UpgradeCluster(subscriptionID uuid.UUID, kubeConfig, resourceGroup string,
 	cs *api.ContainerService, nameSuffix string, agentPoolsToUpgrade []string, acsengineVersion string) error {
 	uc.ClusterTopology = ClusterTopology{}
+	uc.SubscriptionID = subscriptionID.String()
 	uc.ResourceGroup = resourceGroup
 	uc.DataModel = cs
 	uc.NameSuffix = nameSuffix

--- a/pkg/operations/kubernetesupgrade/upgrademasternode.go
+++ b/pkg/operations/kubernetesupgrade/upgrademasternode.go
@@ -24,6 +24,7 @@ type UpgradeMasterNode struct {
 	TemplateMap             map[string]interface{}
 	ParametersMap           map[string]interface{}
 	UpgradeContainerService *api.ContainerService
+	SubscriptionID          string
 	ResourceGroup           string
 	Client                  armhelpers.ACSEngineClient
 	kubeConfig              string
@@ -35,7 +36,7 @@ type UpgradeMasterNode struct {
 // the node.
 // The 'drain' flag is not used for deleting master nodes.
 func (kmn *UpgradeMasterNode) DeleteNode(vmName *string, drain bool) error {
-	return operations.CleanDeleteVirtualMachine(kmn.Client, kmn.logger, kmn.ResourceGroup, *vmName)
+	return operations.CleanDeleteVirtualMachine(kmn.Client, kmn.logger, kmn.SubscriptionID, kmn.ResourceGroup, *vmName)
 }
 
 // CreateNode creates a new master/agent node with the targeted version of Kubernetes

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -96,6 +96,7 @@ func (ku *Upgrader) upgradeMasterNodes() error {
 	upgradeMasterNode.ParametersMap = parametersMap
 	upgradeMasterNode.UpgradeContainerService = ku.ClusterTopology.DataModel
 	upgradeMasterNode.ResourceGroup = ku.ClusterTopology.ResourceGroup
+	upgradeMasterNode.SubscriptionID = ku.ClusterTopology.SubscriptionID
 	upgradeMasterNode.Client = ku.Client
 	upgradeMasterNode.kubeConfig = ku.kubeConfig
 	if ku.stepTimeout == nil {
@@ -242,6 +243,7 @@ func (ku *Upgrader) upgradeAgentPools() error {
 		upgradeAgentNode.TemplateMap = templateMap
 		upgradeAgentNode.ParametersMap = parametersMap
 		upgradeAgentNode.UpgradeContainerService = ku.ClusterTopology.DataModel
+		upgradeAgentNode.SubscriptionID = ku.ClusterTopology.SubscriptionID
 		upgradeAgentNode.ResourceGroup = ku.ClusterTopology.ResourceGroup
 		upgradeAgentNode.Client = ku.Client
 		upgradeAgentNode.kubeConfig = ku.kubeConfig

--- a/pkg/operations/scaledownagentpool.go
+++ b/pkg/operations/scaledownagentpool.go
@@ -15,13 +15,13 @@ type VMScalingErrorDetails struct {
 
 // ScaleDownVMs removes the vms in the provided list. Returns a list with details on each failure.
 // all items in the list will always be of type *VMScalingErrorDetails
-func ScaleDownVMs(az armhelpers.ACSEngineClient, logger *log.Entry, resourceGroup string, vmNames ...string) *list.List {
+func ScaleDownVMs(az armhelpers.ACSEngineClient, logger *log.Entry, subscriptionID string, resourceGroup string, vmNames ...string) *list.List {
 	numVmsToDelete := len(vmNames)
 	errChan := make(chan *VMScalingErrorDetails, numVmsToDelete)
 	defer close(errChan)
 	for _, vmName := range vmNames {
 		go func(vmName string) {
-			err := CleanDeleteVirtualMachine(az, logger, resourceGroup, vmName)
+			err := CleanDeleteVirtualMachine(az, logger, subscriptionID, resourceGroup, vmName)
 			if err != nil {
 				errChan <- &VMScalingErrorDetails{Name: vmName, Error: err}
 				return

--- a/pkg/operations/scaledownagentpool_test.go
+++ b/pkg/operations/scaledownagentpool_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Scale down vms operation tests", func() {
 	It("Should return error messages for failing vms", func() {
 		mockClient := armhelpers.MockACSEngineClient{}
 		mockClient.FailGetVirtualMachine = true
-		errs := ScaleDownVMs(&mockClient, log.NewEntry(log.New()), "sid","rg", "vm1", "vm2", "vm3", "vm5")
+		errs := ScaleDownVMs(&mockClient, log.NewEntry(log.New()), "sid", "rg", "vm1", "vm2", "vm3", "vm5")
 		Expect(errs.Len()).To(Equal(4))
 		for e := errs.Front(); e != nil; e = e.Next() {
 			output := e.Value.(*VMScalingErrorDetails)

--- a/pkg/operations/scaledownagentpool_test.go
+++ b/pkg/operations/scaledownagentpool_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Scale down vms operation tests", func() {
 	It("Should return error messages for failing vms", func() {
 		mockClient := armhelpers.MockACSEngineClient{}
 		mockClient.FailGetVirtualMachine = true
-		errs := ScaleDownVMs(&mockClient, log.NewEntry(log.New()), "rg", "vm1", "vm2", "vm3", "vm5")
+		errs := ScaleDownVMs(&mockClient, log.NewEntry(log.New()), "sid","rg", "vm1", "vm2", "vm3", "vm5")
 		Expect(errs.Len()).To(Equal(4))
 		for e := errs.Front(); e != nil; e = e.Next() {
 			output := e.Value.(*VMScalingErrorDetails)
@@ -28,7 +28,7 @@ var _ = Describe("Scale down vms operation tests", func() {
 	})
 	It("Should return nil for errors if all deletes successful", func() {
 		mockClient := armhelpers.MockACSEngineClient{}
-		errs := ScaleDownVMs(&mockClient, log.NewEntry(log.New()), "rg", "k8s-agent-F8EADCCF-0", "k8s-agent-F8EADCCF-3", "k8s-agent-F8EADCCF-2", "k8s-agent-F8EADCCF-4")
+		errs := ScaleDownVMs(&mockClient, log.NewEntry(log.New()), "sid", "rg", "k8s-agent-F8EADCCF-0", "k8s-agent-F8EADCCF-3", "k8s-agent-F8EADCCF-2", "k8s-agent-F8EADCCF-4")
 		Expect(errs).To(BeNil())
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Have a look at #2916 for the detailed error description.

In short: Role assignments do not get deleted when deleting a VM. If we use managed identities, this leads to an error during the rollout of a new node. With this PR we delete all role assignments that are associated with the VM to be deleted.

**Implementation note**:

I decided to pass the subscription ID to where I needed it for the scope calculation. If you should dislike this approach, I think we could also work without it. Then the listing of all role assignments would only be based on the principal ID of the VM

**Which issue this PR fixes**:

fixes #2916 

**Special notes for your reviewer**:

Current tests were adjusted to work with these changes, but no new tests created.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)
