### PR TITLE
Output empty virtualNetworkResourceGroupName in default kubenet case.

### DIFF
--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -298,7 +298,7 @@
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "vnetSubnetID": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
     "virtualNetworkName": "[concat(variables('orchestratorName'), '-vnet-', variables('nameSuffix'))]",
-    "virtualNetworkResourceGroupName": "''",
+    "virtualNetworkResourceGroupName": "",
   {{end}}
 {{end}}
     "vnetCidr": "[parameters('vnetCidr')]",


### PR DESCRIPTION
Output empty virtualNetworkResourceGroupName in default kubenet case.