### PR TITLE
Update Windows images to 1803

### DIFF
--- a/docs/kubernetes/windows.md
+++ b/docs/kubernetes/windows.md
@@ -132,7 +132,7 @@ After completing this walkthrough you will know how to:
       spec:
         containers:
         - name: windowswebserver
-          image: microsoft/windowsservercore:1709
+          image: microsoft/windowsservercore:1803
           command:
           - powershell.exe
           - -command
@@ -253,7 +253,7 @@ spec:
       containers:
 
         - name: iis-container
-          image: microsoft/iis:windowsservercore-1709
+          image: microsoft/iis:windowsservercore-1803
           volumeMounts:
           - name: shared-data
             mountPath: /wwwcache
@@ -263,7 +263,7 @@ spec:
           - "while ($true) { Start-Sleep -Seconds 10; Copy-Item -Path C:\\wwwcache\\iisstart.htm -Destination C:\\inetpub\\wwwroot\\iisstart.htm; }"            
 
         - name: servercore-container
-          image: microsoft/windowsservercore:1709
+          image: microsoft/windowsservercore:1803
           volumeMounts:
           - name: shared-data
             mountPath: /poddata

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -456,7 +456,7 @@
     "windowsTelemetryGUID": "[parameters('windowsTelemetryGUID')]",
     "agentWindowsPublisher": "MicrosoftWindowsServer",
     "agentWindowsOffer": "WindowsServerSemiAnnual",
-    "agentWindowsSku": "Datacenter-Core-1709-with-Containers-smalldisk",
+    "agentWindowsSku": "Datacenter-Core-1803-with-Containers-smalldisk",
     "agentWindowsVersion": "[parameters('agentWindowsVersion')]",
     "windowsCustomScriptSuffix": " $inputFile = '%SYSTEMDRIVE%\\AzureData\\CustomData.bin' ; $outputFile = '%SYSTEMDRIVE%\\AzureData\\CustomDataSetupScript.ps1' ; Copy-Item $inputFile $outputFile ; Invoke-Expression('{0} {1}' -f $outputFile, $arguments) ; "
 {{end}}

--- a/parts/windowsparams.t
+++ b/parts/windowsparams.t
@@ -39,7 +39,7 @@
       "type": "string"
     },
     "agentWindowsSku": {
-      "defaultValue": "Datacenter-Core-1709-with-Containers-smalldisk",
+      "defaultValue": "Datacenter-Core-1803-with-Containers-smalldisk",
       "metadata": {
         "description": "The SKU of windows image for the agent virtual machines."
       },

--- a/test/cluster-tests/kubernetes/simpleweb-windows.yaml
+++ b/test/cluster-tests/kubernetes/simpleweb-windows.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: windowswebserver
-        image: microsoft/windowsservercore:1709
+        image: microsoft/windowsservercore:1803
         command:
         - powershell.exe
         - -command

--- a/test/e2e/kubernetes/workloads/iis-azurefile.yaml
+++ b/test/e2e/kubernetes/workloads/iis-azurefile.yaml
@@ -7,7 +7,7 @@ metadata:
     name: storage
 spec:
   containers:
-  - image: microsoft/iis:windowsservercore-1709
+  - image: microsoft/iis:windowsservercore-1803
     name: iis-azurefile
     volumeMounts:
     - name: azurefilevol

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -1,3 +1,3 @@
-FROM microsoft/nanoserver:1709
+FROM microsoft/nanoserver:1803
 
 CMD cmd /c ping -t localhost


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Updates the windows images to 1803 version.  1803 has improved networking to improve DNS issues on #2027 as described [here](https://github.com/Microsoft/SDN/blob/master/Diagnostics/ContainerDiagnostics.md)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
hopefully resolves DNS issues referenced in #2027

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
up windows images to version 1803
```
