### PR TITLE
Enhance e2e debuggability

### DIFF
--- a/test/e2e/openshift/openshift_test.go
+++ b/test/e2e/openshift/openshift_test.go
@@ -1,6 +1,7 @@
 package openshift
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,6 +42,26 @@ var _ = BeforeSuite(func() {
 		ClusterDefinition:  csInput,
 		ExpandedDefinition: csGenerated,
 	}
+})
+
+var failed = false
+var _ = AfterEach(func() {
+	// Recommended way to optionally act on failures after
+	// tests finish - see https://github.com/onsi/ginkgo/issues/361
+	failed = failed || CurrentGinkgoTestDescription().Failed
+})
+
+var _ = AfterSuite(func() {
+	if !failed {
+		return
+	}
+
+	nodeOut, _ := util.DumpNodes()
+	fmt.Println(nodeOut)
+	podOut, _ := util.DumpPods()
+	fmt.Println(podOut)
+	diagnosticsOut, _ := util.RunDiagnostics()
+	fmt.Println(diagnosticsOut)
 })
 
 var _ = Describe("Azure Container Cluster using the OpenShift Orchestrator", func() {

--- a/test/e2e/openshift/util/util.go
+++ b/test/e2e/openshift/util/util.go
@@ -99,3 +99,39 @@ func TestHost(host string, maxRetries int, retryDelay time.Duration) error {
 	}
 	return fmt.Errorf("unexpected response status: %v", resp.Status)
 }
+
+// DumpNodes dumps information about nodes.
+func DumpNodes() (string, error) {
+	cmd := exec.Command("oc", "get", "nodes", "-o", "wide")
+	printCmd(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Error trying to list nodes: %s", string(out))
+		return "", err
+	}
+	return string(out), nil
+}
+
+// DumpPods dumps the pods from all namespaces.
+func DumpPods() (string, error) {
+	cmd := exec.Command("oc", "get", "pods", "--all-namespaces", "-o", "wide")
+	printCmd(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Error trying to list pods from all namespaces: %s", string(out))
+		return "", err
+	}
+	return string(out), nil
+}
+
+// RunDiagnostics runs the openshift diagnostics command.
+func RunDiagnostics() (string, error) {
+	cmd := exec.Command("oc", "adm", "diagnostics")
+	printCmd(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Error trying to run diagnostics: %s", string(out))
+		return "", err
+	}
+	return string(out), nil
+}

--- a/test/e2e/openshift/util/util.go
+++ b/test/e2e/openshift/util/util.go
@@ -135,3 +135,14 @@ func RunDiagnostics() (string, error) {
 	}
 	return string(out), nil
 }
+
+// FetchLogs returns logs for the provided kind/name in namespace.
+func FetchLogs(kind, namespace, name string) string {
+	cmd := exec.Command("oc", "logs", fmt.Sprintf("%s/%s", kind, name), "-n", namespace)
+	printCmd(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Sprintf("Error trying to fetch logs from %s/%s in %s: %s", kind, name, namespace, string(out))
+	}
+	return string(out)
+}

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -187,11 +187,23 @@ func teardown() {
 		logsPath := filepath.Join(cfg.CurrentWorkingDir, "_logs", hostname)
 		err := os.MkdirAll(logsPath, 0755)
 		if err != nil {
-			log.Printf("cliProvisioner.FetchProvisioningMetrics error: %s\n", err)
+			log.Printf("cannot create directory for logs: %s", err)
 		}
 		err = cliProvisioner.FetchProvisioningMetrics(logsPath, cfg, acct)
 		if err != nil {
 			log.Printf("cliProvisioner.FetchProvisioningMetrics error: %s\n", err)
+		}
+	}
+	if cliProvisioner.Config.IsOpenShift() {
+		hostname := fmt.Sprintf("%s.%s.cloudapp.azure.com", cfg.Name, cfg.Location)
+		logsPath := filepath.Join(cfg.CurrentWorkingDir, "_logs", hostname)
+		err := os.MkdirAll(logsPath, 0755)
+		if err != nil {
+			log.Printf("cannot create directory for logs: %s", err)
+		}
+		err = cliProvisioner.FetchOpenShiftInfraLogs(logsPath)
+		if err != nil {
+			log.Printf("cliProvisioner.FetchOpenShiftInfraLogs error: %s", err)
 		}
 	}
 	if !cfg.RetainSSH {


### PR DESCRIPTION
Every time a test fails or an interrupt is received (^C), tests dump info about pods, nodes, and a run of diagnostics.

@jim-minter @pweil- 