### PR TITLE
add Kubernetes v1.8.13 support

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -38,6 +38,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.8.10":         true,
 	"1.8.11":         true,
 	"1.8.12":         true,
+	"1.8.13":         true,
 	"1.9.0":          true,
 	"1.9.1":          true,
 	"1.9.2":          true,

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -206,6 +206,7 @@ func getAllKubernetesWindowsSupportedVersionsMap() map[string]bool {
 		"1.6.13",
 		"1.7.0",
 		"1.7.1",
+		"1.8.13",
 		"1.10.0-beta.2",
 		"1.10.0-beta.4",
 		"1.10.0-rc.1",

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -157,6 +157,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should be running the expected version", func() {
+			hasWindows := eng.HasWindowsAgents()
 			version, err := node.Version()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -167,13 +168,13 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					common.Kubernetes,
 					eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorRelease,
 					eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorVersion,
-					false)
+					hasWindows)
 			} else {
 				expectedVersion = common.RationalizeReleaseAndVersion(
 					common.Kubernetes,
 					eng.Config.OrchestratorRelease,
 					eng.Config.OrchestratorVersion,
-					false)
+					hasWindows)
 			}
 			expectedVersionRationalized := strings.Split(expectedVersion, "-")[0] // to account for -alpha and -beta suffixes
 			Expect(version).To(Equal("v" + expectedVersionRationalized))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Adds support for k8s v1.8.13 for Linux only:

https://github.com/kubernetes/kubernetes/releases/tag/v1.8.13

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
add Kubernetes v1.8.13 support
```