### PR TITLE
Build kubletwin/pause to match the node's OS version

### DIFF
--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -216,6 +216,19 @@ function
 New-InfraContainer()
 {
     cd $global:KubeDir
+    $computerInfo = Get-ComputerInfo
+    $windowsBase = if ($computerInfo.WindowsVersion -eq "1709") {
+        "microsoft/nanoserver:1709"
+    } elseif ( ($computerInfo.WindowsVersion -eq "1803") -and ($computerInfo.WindowsBuildLabEx.StartsWith("17134")) ) { 
+        "microsoft/nanoserver:1803"
+    } else { 
+        # This is a temporary workaround. As of May 2018, Windows Server Insider builds still report 1803 which is wrong.
+        # Once that is fixed, add another elseif ( -eq "nnnn") instead and remove the StartsWith("17134") above
+        "microsoft/nanoserver-insider"
+    }
+    
+    "FROM $($windowsBase)" | Out-File -encoding ascii -FilePath Dockerfile
+    "CMD cmd /c ping -t localhost" | Out-File -encoding ascii -FilePath Dockerfile -Append
     docker build -t kubletwin/pause .
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This container is built before each windows agent is added to the cluster. The OS of the container needs to match that of the windows agent. Without this change, it's hardcoded. With this change, it will match the host OS version (Windows Server 2016, Windows Server version 1709, Windows Server version 1803, or Windows Server Insider Preview)

**Which issue this PR fixes** 

#2965 
**Special notes for your reviewer**:
I could use some guidance testing this. Can I just build acs-engine as-is, or do I need to do some other steps to ensure this change is picked up?

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

Will need to test on both Windows Server version 1709, and 1803 to make sure the `kubletwin/pause` image is build correctly and that pods can start successfully.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note

```
