### PR TITLE
Support for Low-priority VMs on Virtual Machine Scale Sets (VMSS) for Kubernetes

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -442,6 +442,8 @@ A cluster can have 0 to 12 agent pool profiles. Agent Pool Profiles are used for
 |---|---|---|
 |availabilityProfile|no|Supported values are `VirtualMachineScaleSets` (default) and `AvailabilitySet`.  For Kubernetes clusters before version 1.10, use `AvailabilitySet`. Otherwise, you should use `VirtualMachineScaleSets`|
 |count|yes|Describes the node count|
+|scaleSetPriority|no|Supported values are `Regular` (default) and `Low`. Only applies to clusters with availabilityProfile `VirtualMachineScaleSets`. Enables the usage of [Low-priority VMs on Scale Sets](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-low-priority).|
+|scaleSetEvictionPolicy|no|Supported values are `Delete` (default) and `Deallocate`. Only applies to clusters with availabilityProfile of `VirtualMachineScaleSets` and scaleSetPriority of `Low`.|
 |diskSizesGB|no|Describes an array of up to 4 attached disk sizes.  Valid disk size values are between 1 and 1024|
 |dnsPrefix|Required if agents are to be exposed publically with a load balancer|The dns prefix that forms the FQDN to access the loadbalancer for this agent pool. This must be a unique name among all agent pools. Not supported for Kubernetes clusters|
 |name|yes|This is the unique name for the agent pool profile. The resources of the agent pool profile are derived from this name|

--- a/examples/kubernetes-vmss-low-priority/kubernetes.json
+++ b/examples/kubernetes-vmss-low-priority/kubernetes.json
@@ -1,0 +1,38 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "1.10",
+      "kubernetesConfig": {
+        "useManagedIdentity": true
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 1,
+        "vmSize": "Standard_D2_v2",
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "scaleSetPriority": "Low",
+        "scaleSetEvictionPolicy": "Delete",
+        "storageProfile": "ManagedDisks"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    }
+  }
+}

--- a/parts/agentparams.t
+++ b/parts/agentparams.t
@@ -16,6 +16,32 @@
       "type": "int"
     },
 {{end}}
+    {{if .IsLowPriorityScaleSet}}
+    "{{.Name}}ScaleSetPriority": {
+      "allowedValues":[
+        "Low",
+        "Regular",
+        ""
+      ],
+      "defaultValue": "{{.ScaleSetPriority}}",
+      "metadata": {
+        "description": "The priority for the VM Scale Set. This value can be Low or Regular."
+      },
+      "type": "string"
+    },
+    "{{.Name}}ScaleSetEvictionPolicy": {
+      "allowedValues":[
+        "Delete",
+        "Deallocate",
+        ""
+      ],
+      "defaultValue": "{{.ScaleSetEvictionPolicy}}",
+      "metadata": {
+        "description": "The Eviction Policy for a Low Priority VM Scale Set."
+      },
+      "type": "string"
+    },
+    {{end}}
     "{{.Name}}VMSize": {
       {{GetAgentAllowedSizes}}
       "defaultValue": "{{.VMSize}}",

--- a/parts/agentparams.t
+++ b/parts/agentparams.t
@@ -37,7 +37,7 @@
       ],
       "defaultValue": "{{.ScaleSetEvictionPolicy}}",
       "metadata": {
-        "description": "The Eviction Policy for a Low Priority VM Scale Set."
+        "description": "The Eviction Policy for a Low-priority VM Scale Set."
       },
       "type": "string"
     },

--- a/parts/k8s/kubernetesagentresourcesvmss.t
+++ b/parts/k8s/kubernetesagentresourcesvmss.t
@@ -43,6 +43,10 @@
         "mode": "Manual"
       },
       "virtualMachineProfile": {
+        {{if .IsLowPriorityScaleSet}}
+        "priority": "[variables('{{.Name}}ScaleSetPriority')]",
+        "evictionPolicy": "[variables('{{.Name}}ScaleSetEvictionPolicy')]",
+        {{end}}
         "networkProfile": {
           "networkInterfaceConfigurations": [
             {

--- a/parts/k8s/kubernetesagentvars.t
+++ b/parts/k8s/kubernetesagentvars.t
@@ -15,6 +15,10 @@
     "{{.Name}}VMNamePrefix": "[concat(variables('orchestratorName'), '-{{.Name}}-', variables('nameSuffix'), '-')]",
 {{else}}
     "{{.Name}}VMNamePrefix": "[concat(variables('orchestratorName'), '-{{.Name}}-', variables('nameSuffix'), '-vmss')]",
+    {{if .IsLowPriorityScaleSet}}
+    "{{.Name}}ScaleSetPriority": "[parameters('{{.Name}}ScaleSetPriority')]",
+    "{{.Name}}ScaleSetEvictionPolicy": "[parameters('{{.Name}}ScaleSetEvictionPolicy')]",
+    {{end}}
 {{end}}
 {{end}}
     "{{.Name}}VMSize": "[parameters('{{.Name}}VMSize')]",

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -764,6 +764,9 @@ func setStorageDefaults(a *api.Properties) {
 		if len(profile.AvailabilityProfile) == 0 {
 			profile.AvailabilityProfile = api.VirtualMachineScaleSets
 		}
+		if len(profile.ScaleSetEvictionPolicy) == 0 && profile.ScaleSetPriority == api.ScaleSetPriorityLow {
+			profile.ScaleSetEvictionPolicy = api.ScaleSetEvictionPolicyDelete
+		}
 	}
 }
 

--- a/pkg/acsengine/defaults_test.go
+++ b/pkg/acsengine/defaults_test.go
@@ -491,6 +491,28 @@ func TestStorageProfile(t *testing.T) {
 	}
 }
 
+func TestAgentPoolProfile(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.10")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = "Kubernetes"
+	properties.MasterProfile.Count = 1
+	SetPropertiesDefaults(&mockCS, false)
+	if properties.AgentPoolProfiles[0].ScaleSetPriority != "" {
+		t.Fatalf("AgentPoolProfiles[0].ScaleSetPriority did not have the expected configuration, got %s, expected %s",
+			properties.AgentPoolProfiles[0].ScaleSetPriority, "")
+	}
+	if properties.AgentPoolProfiles[0].ScaleSetEvictionPolicy != "" {
+		t.Fatalf("AgentPoolProfiles[0].ScaleSetEvictionPolicy did not have the expected configuration, got %s, expected %s",
+			properties.AgentPoolProfiles[0].ScaleSetEvictionPolicy, "")
+	}
+	properties.AgentPoolProfiles[0].ScaleSetPriority = api.ScaleSetPriorityLow
+	SetPropertiesDefaults(&mockCS, false)
+	if properties.AgentPoolProfiles[0].ScaleSetEvictionPolicy != api.ScaleSetEvictionPolicyDelete {
+		t.Fatalf("AgentPoolProfile[0].ScaleSetEvictionPolicy did not have the expected configuration, got %s, expected %s",
+			properties.AgentPoolProfiles[0].ScaleSetEvictionPolicy, api.ScaleSetEvictionPolicyDelete)
+	}
+}
+
 func getMockAddon(name string) api.KubernetesAddon {
 	return api.KubernetesAddon{
 		Name:    name,
@@ -521,6 +543,7 @@ func getMockBaseContainerService(orchestratorVersion string) api.ContainerServic
 		},
 	}
 }
+
 func getKubernetesConfigWithFeatureGates(featureGates string) *api.KubernetesConfig {
 	return &api.KubernetesConfig{
 		KubeletConfig: map[string]string{"--feature-gates": featureGates},

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -69,7 +69,7 @@ const (
 	ScaleSetPriorityLow = "Low"
 	// ScaleSetEvictionPolicyDelete is the default Eviction Policy for Low-priority VM ScaleSets
 	ScaleSetEvictionPolicyDelete = "Delete"
-	// ScaleSetEvictionPolicyDeallocate means a Low-priority VM ScaleSet will deallocated rather than delete VMs.
+	// ScaleSetEvictionPolicyDeallocate means a Low-priority VM ScaleSet will deallocate, rather than delete, VMs.
 	ScaleSetEvictionPolicyDeallocate = "Deallocate"
 )
 

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -63,6 +63,14 @@ const (
 	AvailabilitySet = "AvailabilitySet"
 	// VirtualMachineScaleSets means that the vms are in a virtual machine scaleset
 	VirtualMachineScaleSets = "VirtualMachineScaleSets"
+	// ScaleSetPriorityRegular is the default ScaleSet Priority
+	ScaleSetPriorityRegular = "Regular"
+	// ScaleSetPriorityLow means the ScaleSet will use Low-priority VMs
+	ScaleSetPriorityLow = "Low"
+	// ScaleSetEvictionPolicyDelete is the default Eviction Policy for Low-priority VM ScaleSets
+	ScaleSetEvictionPolicyDelete = "Delete"
+	// ScaleSetEvictionPolicyDeallocate means a Low-priority VM ScaleSet will deallocated rather than delete VMs.
+	ScaleSetEvictionPolicyDeallocate = "Deallocate"
 )
 
 // storage profiles

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -960,6 +960,8 @@ func convertAgentPoolProfileToVLabs(api *AgentPoolProfile, p *vlabs.AgentPoolPro
 	p.Ports = []int{}
 	p.Ports = append(p.Ports, api.Ports...)
 	p.AvailabilityProfile = api.AvailabilityProfile
+	p.ScaleSetPriority = api.ScaleSetPriority
+	p.ScaleSetEvictionPolicy = api.ScaleSetEvictionPolicy
 	p.StorageProfile = api.StorageProfile
 	p.DiskSizesGB = []int{}
 	p.DiskSizesGB = append(p.DiskSizesGB, api.DiskSizesGB...)

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -968,6 +968,8 @@ func convertVLabsAgentPoolProfile(vlabs *vlabs.AgentPoolProfile, api *AgentPoolP
 	api.Ports = []int{}
 	api.Ports = append(api.Ports, vlabs.Ports...)
 	api.AvailabilityProfile = vlabs.AvailabilityProfile
+	api.ScaleSetPriority = vlabs.ScaleSetPriority
+	api.ScaleSetEvictionPolicy = vlabs.ScaleSetEvictionPolicy
 	api.StorageProfile = vlabs.StorageProfile
 	api.DiskSizesGB = []int{}
 	api.DiskSizesGB = append(api.DiskSizesGB, vlabs.DiskSizesGB...)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -402,21 +402,23 @@ type Extension struct {
 
 // AgentPoolProfile represents an agent pool definition
 type AgentPoolProfile struct {
-	Name                string               `json:"name"`
-	Count               int                  `json:"count"`
-	VMSize              string               `json:"vmSize"`
-	OSDiskSizeGB        int                  `json:"osDiskSizeGB,omitempty"`
-	DNSPrefix           string               `json:"dnsPrefix,omitempty"`
-	OSType              OSType               `json:"osType,omitempty"`
-	Ports               []int                `json:"ports,omitempty"`
-	AvailabilityProfile string               `json:"availabilityProfile"`
-	StorageProfile      string               `json:"storageProfile,omitempty"`
-	DiskSizesGB         []int                `json:"diskSizesGB,omitempty"`
-	VnetSubnetID        string               `json:"vnetSubnetID,omitempty"`
-	Subnet              string               `json:"subnet"`
-	IPAddressCount      int                  `json:"ipAddressCount,omitempty"`
-	Distro              Distro               `json:"distro,omitempty"`
-	Role                AgentPoolProfileRole `json:"role,omitempty"`
+	Name                   string               `json:"name"`
+	Count                  int                  `json:"count"`
+	VMSize                 string               `json:"vmSize"`
+	OSDiskSizeGB           int                  `json:"osDiskSizeGB,omitempty"`
+	DNSPrefix              string               `json:"dnsPrefix,omitempty"`
+	OSType                 OSType               `json:"osType,omitempty"`
+	Ports                  []int                `json:"ports,omitempty"`
+	AvailabilityProfile    string               `json:"availabilityProfile"`
+	ScaleSetPriority       string               `json:"scaleSetPriority,omitempty"`
+	ScaleSetEvictionPolicy string               `json:"scaleSetEvictionPolicy,omitempty"`
+	StorageProfile         string               `json:"storageProfile,omitempty"`
+	DiskSizesGB            []int                `json:"diskSizesGB,omitempty"`
+	VnetSubnetID           string               `json:"vnetSubnetID,omitempty"`
+	Subnet                 string               `json:"subnet"`
+	IPAddressCount         int                  `json:"ipAddressCount,omitempty"`
+	Distro                 Distro               `json:"distro,omitempty"`
+	Role                   AgentPoolProfileRole `json:"role,omitempty"`
 
 	FQDN                  string            `json:"fqdn,omitempty"`
 	CustomNodeLabels      map[string]string `json:"customNodeLabels,omitempty"`
@@ -648,6 +650,16 @@ func (p *Properties) HasVirtualMachineScaleSets() bool {
 	return false
 }
 
+// HasLowPriorityScaleSets returns true if the cluster contains Virtual Machine Scale Sets with Low Priority
+func (p *Properties) HasLowPriorityScaleSets() bool {
+	for _, agentPoolProfile := range p.AgentPoolProfiles {
+		if agentPoolProfile.ScaleSetPriority == ScaleSetPriorityLow {
+			return true
+		}
+	}
+	return false
+}
+
 // IsCustomVNET returns true if the customer brought their own VNET
 func (m *MasterProfile) IsCustomVNET() bool {
 	return len(m.VnetSubnetID) > 0
@@ -706,6 +718,11 @@ func (a *AgentPoolProfile) IsAvailabilitySets() bool {
 // IsVirtualMachineScaleSets returns true if the agent pool availability profile is VMSS
 func (a *AgentPoolProfile) IsVirtualMachineScaleSets() bool {
 	return a.AvailabilityProfile == VirtualMachineScaleSets
+}
+
+// IsLowPriorityScaleSet returns true if the VMSS is Low Priority
+func (a *AgentPoolProfile) IsLowPriorityScaleSet() bool {
+	return a.ScaleSetPriority == ScaleSetPriorityLow
 }
 
 // IsManagedDisks returns true if the customer specified disks

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -650,16 +650,6 @@ func (p *Properties) HasVirtualMachineScaleSets() bool {
 	return false
 }
 
-// HasLowPriorityScaleSets returns true if the cluster contains Virtual Machine Scale Sets with Low Priority
-func (p *Properties) HasLowPriorityScaleSets() bool {
-	for _, agentPoolProfile := range p.AgentPoolProfiles {
-		if agentPoolProfile.ScaleSetPriority == ScaleSetPriorityLow {
-			return true
-		}
-	}
-	return false
-}
-
 // IsCustomVNET returns true if the customer brought their own VNET
 func (m *MasterProfile) IsCustomVNET() bool {
 	return len(m.VnetSubnetID) > 0

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -712,7 +712,7 @@ func (a *AgentPoolProfile) IsVirtualMachineScaleSets() bool {
 
 // IsLowPriorityScaleSet returns true if the VMSS is Low Priority
 func (a *AgentPoolProfile) IsLowPriorityScaleSet() bool {
-	return a.ScaleSetPriority == ScaleSetPriorityLow
+	return a.AvailabilityProfile == VirtualMachineScaleSets && a.ScaleSetPriority == ScaleSetPriorityLow
 }
 
 // IsManagedDisks returns true if the customer specified disks

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -401,22 +401,24 @@ type Extension struct {
 
 // AgentPoolProfile represents an agent pool definition
 type AgentPoolProfile struct {
-	Name                string               `json:"name" validate:"required"`
-	Count               int                  `json:"count" validate:"required,min=1,max=100"`
-	VMSize              string               `json:"vmSize" validate:"required"`
-	OSDiskSizeGB        int                  `json:"osDiskSizeGB,omitempty" validate:"min=0,max=1023"`
-	DNSPrefix           string               `json:"dnsPrefix,omitempty"`
-	OSType              OSType               `json:"osType,omitempty"`
-	Ports               []int                `json:"ports,omitempty" validate:"dive,min=1,max=65535"`
-	AvailabilityProfile string               `json:"availabilityProfile"`
-	StorageProfile      string               `json:"storageProfile" validate:"eq=StorageAccount|eq=ManagedDisks|len=0"`
-	DiskSizesGB         []int                `json:"diskSizesGB,omitempty" validate:"max=4,dive,min=1,max=1023"`
-	VnetSubnetID        string               `json:"vnetSubnetID,omitempty"`
-	IPAddressCount      int                  `json:"ipAddressCount,omitempty" validate:"min=0,max=256"`
-	Distro              Distro               `json:"distro,omitempty"`
-	KubernetesConfig    *KubernetesConfig    `json:"kubernetesConfig,omitempty"`
-	ImageRef            *ImageReference      `json:"imageReference,omitempty"`
-	Role                AgentPoolProfileRole `json:"role,omitempty"`
+	Name                   string               `json:"name" validate:"required"`
+	Count                  int                  `json:"count" validate:"required,min=1,max=100"`
+	VMSize                 string               `json:"vmSize" validate:"required"`
+	OSDiskSizeGB           int                  `json:"osDiskSizeGB,omitempty" validate:"min=0,max=1023"`
+	DNSPrefix              string               `json:"dnsPrefix,omitempty"`
+	OSType                 OSType               `json:"osType,omitempty"`
+	Ports                  []int                `json:"ports,omitempty" validate:"dive,min=1,max=65535"`
+	AvailabilityProfile    string               `json:"availabilityProfile"`
+	ScaleSetPriority       string               `json:"scaleSetPriority,omitempty" validate:"eq=Regular|eq=Low|len=0"`
+	ScaleSetEvictionPolicy string               `json:"scaleSetEvictionPolicy,omitempty" validate:"eq=Delete|eq=Deallocate|len=0"`
+	StorageProfile         string               `json:"storageProfile" validate:"eq=StorageAccount|eq=ManagedDisks|len=0"`
+	DiskSizesGB            []int                `json:"diskSizesGB,omitempty" validate:"max=4,dive,min=1,max=1023"`
+	VnetSubnetID           string               `json:"vnetSubnetID,omitempty"`
+	IPAddressCount         int                  `json:"ipAddressCount,omitempty" validate:"min=0,max=256"`
+	Distro                 Distro               `json:"distro,omitempty"`
+	KubernetesConfig       *KubernetesConfig    `json:"kubernetesConfig,omitempty"`
+	ImageRef               *ImageReference      `json:"imageReference,omitempty"`
+	Role                   AgentPoolProfileRole `json:"role,omitempty"`
 
 	// subnet is internal
 	subnet string

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -310,6 +310,9 @@ func (a *AgentPoolProfile) Validate(orchestratorType string) error {
 		if e := validate.Var(a.Ports, "len=0"); e != nil {
 			return fmt.Errorf("AgentPoolProfile.Ports must be empty for Kubernetes")
 		}
+		if validate.Var(a.ScaleSetPriority, "eq=Regular") == nil && validate.Var(a.ScaleSetEvictionPolicy, "len=0") != nil {
+			return fmt.Errorf("property 'AgentPoolProfile.ScaleSetEvictionPolicy' must be empty for AgentPoolProfile.Priority of Regular")
+		}
 	}
 
 	if a.DNSPrefix != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds support for Low-priority VMs on Virtual Machine Scale Sets (VMSS) for Kubernetes v1.10+

**If applicable**:
- [x] documentation
- [ ] tested backward compatibility (n/a)
- [x] unit tests

**Release note**:
```release-note
Add Support for Low-priority VMs on Virtual Machine Scale Sets (VMSS) for Kubernetes v1.10+ agent availability profile
```

cc: @CecileRobertMichon @jackfrancis @sozercan (extends @sozercan's https://github.com/Azure/acs-engine/pull/2620 ).
