### PR TITLE
Allow Windows and Linux to have different default k8s versions

### DIFF
--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -57,6 +57,8 @@ const (
 const (
 	// KubernetesDefaultRelease is the default Kubernetes release
 	KubernetesDefaultRelease string = "1.8"
+	// KubernetesDefaultReleaseWindows is the default Kubernetes release
+	KubernetesDefaultReleaseWindows string = "1.9"
 )
 
 const (

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -60,6 +60,11 @@ func GetDefaultKubernetesVersion() string {
 	return GetLatestPatchVersion(KubernetesDefaultRelease, GetAllSupportedKubernetesVersions())
 }
 
+// GetDefaultKubernetesVersionWindows returns the default Kubernetes version for Windows, that is the latest patch of the default release
+func GetDefaultKubernetesVersionWindows() string {
+	return GetLatestPatchVersion(KubernetesDefaultReleaseWindows, GetAllSupportedKubernetesVersionsWindows())
+}
+
 // GetSupportedKubernetesVersion verifies that a passed-in version string is supported, or returns a default version string if not
 func GetSupportedKubernetesVersion(version string) string {
 	if k8sVersion := version; AllKubernetesSupportedVersions[k8sVersion] {
@@ -225,7 +230,7 @@ func GetSupportedVersions(orchType string, hasWindows bool) (versions []string, 
 	switch orchType {
 	case Kubernetes:
 		if hasWindows {
-			return GetAllSupportedKubernetesVersionsWindows(), GetDefaultKubernetesVersion()
+			return GetAllSupportedKubernetesVersionsWindows(), GetDefaultKubernetesVersionWindows()
 		}
 		return GetAllSupportedKubernetesVersions(), GetDefaultKubernetesVersion()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: With Windows k8s support being more upstream-idiomatic in >= 1.9, let's make 1.9 the default version, which is different compared to Linux.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Windows and Linux use different default k8s versions
```
