### PR TITLE
Clarified that autoscaler addon only supports first agentPool

### DIFF
--- a/examples/addons/cluster-autoscaler/README.md
+++ b/examples/addons/cluster-autoscaler/README.md
@@ -1,15 +1,19 @@
 # Cluster Autoscaler (VMSS) Add-on
 
-Cluster Autoscaler is a tool that automatically adjusts the size of the Kubernetes cluster when:
+[Cluster Autoscaler](https://github.com/kubernetes/autoscaler) is a tool that automatically adjusts the size of the Kubernetes cluster when:
 
 * there are pods that failed to run in the cluster due to insufficient resources.
 * some nodes in the cluster are so underutilized, for an extended period of time, that they can be deleted and their pods will be easily placed on some other, existing nodes.
 
 This is the Kubernetes Cluster Autoscaler add-on for Virtual Machine Scale Sets. Add this add-on to your json file as shown below to automatically enable cluster autoscaler in your new Kubernetes cluster.
 
-To use this add-on, make sure your cluster's Kubernetes version is 1.10 or above, and agent pool `availabilityProfile` is set to `VirtualMachineScaleSets`. This will automatically enable first agent pool to autoscale from 1 to 5 nodes by default. You can override these settings in `config` section of the `cluster-autoscaler` add-on.
+To use this add-on, make sure your cluster's Kubernetes version is 1.10 or above and your agent pool `availabilityProfile` is set to `VirtualMachineScaleSets`. By default, the first agent pool will autoscale the node count between 1 and 5. You can override these settings in `config` section of the `cluster-autoscaler` add-on.
 
-```
+> At this time, only the primaryScaleSet (the first agent pool) is monitored by the autoscaler. To configure autoscale to monitor (and scale) other node pools, you must manually edit the autoscaler YAML at `/etc/kubernetes/addons` on each master node. See the [cluster-autoscaler](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/azure/README.md) docs for guidance.
+
+The following is an example:
+
+```json
 {
   "apiVersion": "vlabs",
   "properties": {
@@ -69,8 +73,8 @@ Follow the README at https://github.com/kubernetes/autoscaler/tree/master/cluste
 
 | Name           | Required | Description                       | Default Value                                              |
 | -------------- | -------- | --------------------------------- | ---------------------------------------------------------- |
-| minNodes       | no       | minimum node count                |                                                            |
-| maxNodes       | no       | maximum node count                |                                                            |
+| minNodes       | no       | minimum node count                | 1                                                          |
+| maxNodes       | no       | maximum node count                | 5                                                          |
 | name           | no       | container name                    | "cluster-autoscaler"                                       |
 | image          | no       | image                             | "gcrio.azureedge.net/google-containers/cluster-autoscaler" |
 | cpuRequests    | no       | cpu requests for the container    | "100m"                                                     |
@@ -80,4 +84,4 @@ Follow the README at https://github.com/kubernetes/autoscaler/tree/master/cluste
 
 ## Supported Orchestrators
 
-Kubernetes
+* Kubernetes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Clarifies the documentation for the cluster-autoscaler addon, that is only supports scaling the first agentPool at this time.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2963 

**Special notes for your reviewer**:

**If applicable**:
- [x] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
