### PR TITLE
Update cluster-autoscaler addon to v1.2.2

### DIFF
--- a/pkg/acsengine/k8s_versions.go
+++ b/pkg/acsengine/k8s_versions.go
@@ -49,7 +49,7 @@ var k8sComponentVersions = map[string]map[string]string{
 		"tiller":             "tiller:v2.8.1",
 		"rescheduler":        "rescheduler:v0.3.1",
 		"aci-connector":      "virtual-kubelet:latest",
-		"cluster-autoscaler": "cluster-autoscaler:v1.2.1",
+		"cluster-autoscaler": "cluster-autoscaler:v1.2.2",
 		"nodestatusfreq":     DefaultKubernetesNodeStatusUpdateFrequency,
 		"nodegraceperiod":    DefaultKubernetesCtrlMgrNodeMonitorGracePeriod,
 		"podeviction":        DefaultKubernetesCtrlMgrPodEvictionTimeout,


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates `cluster-autoscaler` addon to v1.2.2 for k8s v1.10
