### PR TITLE
add default distro for agents.

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -605,9 +605,6 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 			}
 		}
 	case api.OpenShift:
-		if a.MasterProfile.Distro == "" {
-			a.MasterProfile.Distro = api.RHEL
-		}
 		kc := a.OrchestratorProfile.OpenShiftConfig.KubernetesConfig
 		if kc == nil {
 			kc = &api.KubernetesConfig{}
@@ -645,10 +642,18 @@ func setMasterNetworkDefaults(a *api.Properties, isUpgrade bool) {
 	if a.MasterProfile == nil {
 		return
 	}
-
-	// Set default Distro to Ubuntu
-	if a.MasterProfile.Distro == "" {
-		a.MasterProfile.Distro = api.Ubuntu
+	o := a.OrchestratorProfile
+	// set default Distro based on orchestrator
+	switch o.OrchestratorType {
+	case api.OpenShift:
+		if a.MasterProfile.Distro == "" {
+			a.MasterProfile.Distro = api.OpenShiftLatestRHEL
+		}
+	default:
+		// Set default Distro to Ubuntu
+		if a.MasterProfile.Distro == "" {
+			a.MasterProfile.Distro = api.Ubuntu
+		}
 	}
 
 	if !a.MasterProfile.IsCustomVNET() {
@@ -734,14 +739,24 @@ func setAgentNetworkDefaults(a *api.Properties) {
 		}
 	}
 
+	o := a.OrchestratorProfile
 	for _, profile := range a.AgentPoolProfiles {
 		// set default OSType to Linux
 		if profile.OSType == "" {
 			profile.OSType = api.Linux
 		}
-		// set default Distro to Ubuntu
-		if profile.Distro == "" {
-			profile.Distro = api.Ubuntu
+
+		// set default Distro based on orchestrator
+		switch o.OrchestratorType {
+		case api.OpenShift:
+			if profile.Distro == "" {
+				profile.Distro = api.OpenShiftLatestRHEL
+			}
+		default:
+			// Set default Distro to Ubuntu
+			if profile.Distro == "" {
+				profile.Distro = api.Ubuntu
+			}
 		}
 
 		// Set the default number of IP addresses allocated for agents.

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -642,14 +642,8 @@ func setMasterNetworkDefaults(a *api.Properties, isUpgrade bool) {
 	if a.MasterProfile == nil {
 		return
 	}
-	o := a.OrchestratorProfile
-	// set default Distro based on orchestrator
-	switch o.OrchestratorType {
-	case api.OpenShift:
-		if a.MasterProfile.Distro == "" {
-			a.MasterProfile.Distro = api.OpenShiftLatestRHEL
-		}
-	default:
+	// don't default Distro for OpenShift
+	if !a.OrchestratorProfile.IsOpenShift() {
 		// Set default Distro to Ubuntu
 		if a.MasterProfile.Distro == "" {
 			a.MasterProfile.Distro = api.Ubuntu
@@ -739,20 +733,14 @@ func setAgentNetworkDefaults(a *api.Properties) {
 		}
 	}
 
-	o := a.OrchestratorProfile
 	for _, profile := range a.AgentPoolProfiles {
 		// set default OSType to Linux
 		if profile.OSType == "" {
 			profile.OSType = api.Linux
 		}
 
-		// set default Distro based on orchestrator
-		switch o.OrchestratorType {
-		case api.OpenShift:
-			if profile.Distro == "" {
-				profile.Distro = api.OpenShiftLatestRHEL
-			}
-		default:
+		// don't default Distro for OpenShift
+		if !a.OrchestratorProfile.IsOpenShift() {
 			// Set default Distro to Ubuntu
 			if profile.Distro == "" {
 				profile.Distro = api.Ubuntu

--- a/pkg/acsengine/defaults_test.go
+++ b/pkg/acsengine/defaults_test.go
@@ -527,39 +527,20 @@ func TestSetComponentsNetworkDefaults(t *testing.T) {
 		name                string                  // test case name
 		orchestratorProfile api.OrchestratorProfile // orchestrator to be tested
 		expectedDistro      api.Distro              // expected result default disto to be used
-		result              bool                    // test result expectation for false positives (false - fail, true - success)
 	}{
-		{
-			"rhel_openshift",
-			api.OrchestratorProfile{
-				OrchestratorType: api.OpenShift,
-			},
-			api.OpenShiftLatestRHEL,
-			true,
-		},
 		{
 			"ubuntu_kubernetes",
 			api.OrchestratorProfile{
 				OrchestratorType: api.Kubernetes,
 			},
 			api.Ubuntu,
-			true,
 		},
 		{
-			"ubuntu_kubernetes_fail",
+			"rhel_openshift",
 			api.OrchestratorProfile{
 				OrchestratorType: api.OpenShift,
 			},
-			api.Ubuntu,
-			false,
-		},
-		{
-			"ubuntu_openshift_fail",
-			api.OrchestratorProfile{
-				OrchestratorType: api.Kubernetes,
-			},
-			api.OpenShiftLatestRHEL,
-			false,
+			"",
 		},
 	}
 
@@ -568,12 +549,11 @@ func TestSetComponentsNetworkDefaults(t *testing.T) {
 		mockAPI.OrchestratorProfile = &test.orchestratorProfile
 		setMasterNetworkDefaults(&mockAPI, false)
 		setAgentNetworkDefaults(&mockAPI)
-
-		if test.result == !reflect.DeepEqual(mockAPI.MasterProfile.Distro, test.expectedDistro) {
+		if mockAPI.MasterProfile.Distro != test.expectedDistro {
 			t.Fatalf("setMasterNetworkDefaults() test case %v did not return right Distro configurations %v != %v", test.name, mockAPI.MasterProfile.Distro, test.expectedDistro)
 		}
 		for _, agent := range mockAPI.AgentPoolProfiles {
-			if test.result == !reflect.DeepEqual(agent.Distro, test.expectedDistro) {
+			if agent.Distro != test.expectedDistro {
 				t.Fatalf("setAgentNetworkDefaults() test case %v did not return right Distro configurations %v != %v", test.name, agent.Distro, test.expectedDistro)
 			}
 		}
@@ -610,17 +590,8 @@ func getMockAPIProperties(orchestratorVersion string) api.Properties {
 		OrchestratorProfile: &api.OrchestratorProfile{
 			OrchestratorVersion: orchestratorVersion,
 			KubernetesConfig:    &api.KubernetesConfig{},
-			OpenShiftConfig:     &api.OpenShiftConfig{},
-			DcosConfig:          &api.DcosConfig{},
 		},
-		MasterProfile: &api.MasterProfile{
-			Count:        1,
-			DNSPrefix:    "apps.example.com",
-			VMSize:       "Standard_D4s_v3",
-			OSDiskSizeGB: 0,
-			Distro:       "",
-			ImageRef:     &api.ImageReference{},
-		},
+		MasterProfile: &api.MasterProfile{},
 		AgentPoolProfiles: []*api.AgentPoolProfile{
 			{},
 		}}

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -28,8 +28,9 @@ const (
 	RHEL   Distro = "rhel"
 	CoreOS Distro = "coreos"
 	// Supported distros by OpenShift
-	OpenShift39RHEL Distro = "openshift39_rhel"
-	OpenShiftCentOS Distro = "openshift39_centos"
+	OpenShift39RHEL     Distro = "openshift39_rhel"
+	OpenShiftCentOS     Distro = "openshift39_centos"
+	OpenShiftLatestRHEL Distro = OpenShift39RHEL
 )
 
 const (

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -28,9 +28,8 @@ const (
 	RHEL   Distro = "rhel"
 	CoreOS Distro = "coreos"
 	// Supported distros by OpenShift
-	OpenShift39RHEL     Distro = "openshift39_rhel"
-	OpenShiftCentOS     Distro = "openshift39_centos"
-	OpenShiftLatestRHEL Distro = OpenShift39RHEL
+	OpenShift39RHEL Distro = "openshift39_rhel"
+	OpenShiftCentOS Distro = "openshift39_centos"
 )
 
 const (


### PR DESCRIPTION
If you generate template for Openshift now without distro specified (as per docs section in https://github.com/Azure/acs-engine/blob/master/docs/openshift/deploy.md), you will get agent distro as Ubuntu and masters as RHEL. 