### PR TITLE
Added orchestratorRelease to cluster-autoscaler example

### DIFF
--- a/examples/addons/cluster-autoscaler/README.md
+++ b/examples/addons/cluster-autoscaler/README.md
@@ -19,6 +19,7 @@ The following is an example:
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "1.10",
       "kubernetesConfig": {
         "useManagedIdentity": true,
         "addons": [

--- a/examples/addons/cluster-autoscaler/kubernetes-cluster-autoscaler.json
+++ b/examples/addons/cluster-autoscaler/kubernetes-cluster-autoscaler.json
@@ -3,6 +3,7 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "1.10",
       "kubernetesConfig": {
         "useManagedIdentity": true,
         "addons": [


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Added `orchestratorRelease` to cluster-autoscaler example, which requires k8s v1.10 and later.