### PR TITLE
Custom images e2e

### DIFF
--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -35,6 +35,8 @@ type Config struct {
 	Distro                string `envconfig:"DISTRO"`
 	SubscriptionID        string `envconfig:"SUBSCRIPTION_ID"`
 	TenantID              string `envconfig:"TENANT_ID"`
+	ImageName             string `envconfig:"IMAGE_NAME"`
+	ImageResourceGroup    string `envconfig:"IMAGE_RESOURCE_GROUP"`
 
 	ClusterDefinitionPath     string // The original template we want to use to build the cluster from.
 	ClusterDefinitionTemplate string // This is the template after we splice in the environment variables
@@ -110,9 +112,21 @@ func Build(cfg *config.Config, subnetID string) (*Engine, error) {
 		// master and agent config
 		cs.ContainerService.Properties.MasterProfile.Distro = vlabs.Distro(config.Distro)
 		cs.ContainerService.Properties.MasterProfile.ImageRef = nil
+		if config.ImageName != "" && config.ImageResourceGroup != "" {
+			cs.ContainerService.Properties.MasterProfile.ImageRef = &vlabs.ImageReference{
+				Name:          config.ImageName,
+				ResourceGroup: config.ImageResourceGroup,
+			}
+		}
 		for i := range cs.ContainerService.Properties.AgentPoolProfiles {
 			cs.ContainerService.Properties.AgentPoolProfiles[i].Distro = vlabs.Distro(config.Distro)
 			cs.ContainerService.Properties.AgentPoolProfiles[i].ImageRef = nil
+			if config.ImageName != "" && config.ImageResourceGroup != "" {
+				cs.ContainerService.Properties.AgentPoolProfiles[i].ImageRef = &vlabs.ImageReference{
+					Name:          config.ImageName,
+					ResourceGroup: config.ImageResourceGroup,
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
@pschiffe this should enable you to run custom images with openshift e2es.

I was able to run @kwoodson's 3.10 image with
```
docker run --rm -v ${PWD}:/go/src/github.com/Azure/acs-engine:z -w /go/src/github.com/Azure/acs-engine -e ORCHESTRATOR_VERSION=unstable -e CLUSTER_DEFINITION=examples/openshift.json -e CLIENT_ID=${CLIENT_ID} -e CLIENT_SECRET=${CLIENT_SECRET} -e TENANT_ID=${TENANT_ID} -e SUBSCRIPTION_ID=${SUBSCRIPTION_ID} -e ORCHESTRATOR=openshift -e TIMEOUT=30m -e CLEANUP_ON_EXIT=false -e IMAGE_NAME=centos-3.10-201805181451 -e IMAGE_RESOURCE_GROUP=kwoodsontest -e REGIONS=eastus  registry.svc.ci.openshift.org/ci/acs-engine-tests:v3.9 make test-openshift
```

@jim-minter ptal