### PR TITLE
Rationalize AvailabilityProfile default

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -440,7 +440,7 @@ A cluster can have 0 to 12 agent pool profiles. Agent Pool Profiles are used for
 
 |Name|Required|Description|
 |---|---|---|
-|availabilityProfile|no|Supported values are `VirtualMachineScaleSets` (default) and `AvailabilitySet`.  For Kubernetes clusters before version 1.10, use `AvailabilitySet`. Otherwise, you should use `VirtualMachineScaleSets`|
+|availabilityProfile|no|Supported values are `VirtualMachineScaleSets` (default, except for Kubernetes cluster before version 1.10) and `AvailabilitySet`.|
 |count|yes|Describes the node count|
 |scaleSetPriority|no|Supported values are `Regular` (default) and `Low`. Only applies to clusters with availabilityProfile `VirtualMachineScaleSets`. Enables the usage of [Low-priority VMs on Scale Sets](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-low-priority).|
 |scaleSetEvictionPolicy|no|Supported values are `Delete` (default) and `Deallocate`. Only applies to clusters with availabilityProfile of `VirtualMachineScaleSets` and scaleSetPriority of `Low`.|

--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -440,7 +440,7 @@ A cluster can have 0 to 12 agent pool profiles. Agent Pool Profiles are used for
 
 |Name|Required|Description|
 |---|---|---|
-|availabilityProfile|no|Supported values are `VirtualMachineScaleSets` (default, except for Kubernetes cluster before version 1.10) and `AvailabilitySet`.|
+|availabilityProfile|no|Supported values are `VirtualMachineScaleSets` (default, except for Kubernetes clusters before version 1.10) and `AvailabilitySet`.|
 |count|yes|Describes the node count|
 |scaleSetPriority|no|Supported values are `Regular` (default) and `Low`. Only applies to clusters with availabilityProfile `VirtualMachineScaleSets`. Enables the usage of [Low-priority VMs on Scale Sets](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-low-priority).|
 |scaleSetEvictionPolicy|no|Supported values are `Delete` (default) and `Deallocate`. Only applies to clusters with availabilityProfile of `VirtualMachineScaleSets` and scaleSetPriority of `Low`.|

--- a/examples/kubernetes.json
+++ b/examples/kubernetes.json
@@ -13,8 +13,7 @@
       {
         "name": "agentpool1",
         "count": 2,
-        "vmSize": "Standard_D2_v2",
-        "availabilityProfile": "AvailabilitySet"
+        "vmSize": "Standard_D2_v2"
       }
     ],
     "linuxProfile": {

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -756,7 +756,7 @@ func setStorageDefaults(a *api.Properties) {
 		}
 		if len(profile.AvailabilityProfile) == 0 {
 			profile.AvailabilityProfile = api.VirtualMachineScaleSets
-			if a.OrchestratorProfile.OrchestratorType == api.Kubernetes && common.IsKubernetesVersionGe(a.OrchestratorProfile.OrchestratorVersion, "1.10.0") {
+			if a.OrchestratorProfile.OrchestratorType == api.Kubernetes && !common.IsKubernetesVersionGe(a.OrchestratorProfile.OrchestratorVersion, "1.10.0") {
 				profile.AvailabilityProfile = api.AvailabilitySet
 			}
 		}

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -756,6 +756,9 @@ func setStorageDefaults(a *api.Properties) {
 		}
 		if len(profile.AvailabilityProfile) == 0 {
 			profile.AvailabilityProfile = api.VirtualMachineScaleSets
+			if a.OrchestratorProfile.OrchestratorType == api.Kubernetes && common.IsKubernetesVersionGe(a.OrchestratorProfile.OrchestratorVersion, "1.10.0") {
+				profile.AvailabilityProfile = api.AvailabilitySet
+			}
 		}
 		if len(profile.ScaleSetEvictionPolicy) == 0 && profile.ScaleSetPriority == api.ScaleSetPriorityLow {
 			profile.ScaleSetEvictionPolicy = api.ScaleSetEvictionPolicyDelete

--- a/pkg/acsengine/defaults_test.go
+++ b/pkg/acsengine/defaults_test.go
@@ -487,6 +487,7 @@ func TestStorageProfile(t *testing.T) {
 	mockCS = getMockBaseContainerService("1.10.0")
 	properties = mockCS.Properties
 	properties.OrchestratorProfile.OrchestratorType = "Kubernetes"
+	SetPropertiesDefaults(&mockCS, false)
 	if !properties.AgentPoolProfiles[0].IsVirtualMachineScaleSets() {
 		t.Fatalf("AgentPoolProfile[0].AvailabilityProfile did not have the expected configuration, got %s, expected %s",
 			properties.AgentPoolProfiles[0].AvailabilityProfile, api.VirtualMachineScaleSets)

--- a/pkg/acsengine/defaults_test.go
+++ b/pkg/acsengine/defaults_test.go
@@ -479,6 +479,19 @@ func TestStorageProfile(t *testing.T) {
 		t.Fatalf("MasterProfile.StorageProfile did not have the expected configuration, got %s, expected %s",
 			properties.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.StorageProfile, api.ManagedDisks)
 	}
+	if !properties.AgentPoolProfiles[0].IsAvailabilitySets() {
+		t.Fatalf("AgentPoolProfile[0].AvailabilityProfile did not have the expected configuration, got %s, expected %s",
+			properties.AgentPoolProfiles[0].AvailabilityProfile, api.AvailabilitySet)
+	}
+
+	mockCS = getMockBaseContainerService("1.10.0")
+	properties = mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = "Kubernetes"
+	if !properties.AgentPoolProfiles[0].IsVirtualMachineScaleSets() {
+		t.Fatalf("AgentPoolProfile[0].AvailabilityProfile did not have the expected configuration, got %s, expected %s",
+			properties.AgentPoolProfiles[0].AvailabilityProfile, api.VirtualMachineScaleSets)
+	}
+
 }
 
 func TestAgentPoolProfile(t *testing.T) {

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -587,7 +587,7 @@ func (a *Properties) Validate(isUpdate bool) error {
 			}
 		}
 
-		// validation for VMSS for Kubernetes
+		// validation for VMSS with Kubernetes
 		if a.OrchestratorProfile.OrchestratorType == Kubernetes && agentPoolProfile.AvailabilityProfile == VirtualMachineScaleSets {
 			version := common.RationalizeReleaseAndVersion(
 				a.OrchestratorProfile.OrchestratorType,
@@ -611,25 +611,9 @@ func (a *Properties) Validate(isUpdate bool) error {
 				return fmt.Errorf("VirtualMachineScaleSets are only available in Kubernetes version %s or greater; unable to validate for Kubernetes version %s",
 					minVersion, version)
 			}
-		}
-
-		// validation for instanceMetadata using VMSS on Kubernetes
-		if a.OrchestratorProfile.OrchestratorType == Kubernetes && (agentPoolProfile.AvailabilityProfile == VirtualMachineScaleSets || len(agentPoolProfile.AvailabilityProfile) == 0) {
-			version := common.RationalizeReleaseAndVersion(
-				a.OrchestratorProfile.OrchestratorType,
-				a.OrchestratorProfile.OrchestratorRelease,
-				a.OrchestratorProfile.OrchestratorVersion,
-				false)
-			if version == "" {
-				return fmt.Errorf("the following user supplied OrchestratorProfile configuration is not supported: OrchestratorType: %s, OrchestratorRelease: %s, OrchestratorVersion: %s. Please check supported Release or Version for this build of acs-engine", a.OrchestratorProfile.OrchestratorType, a.OrchestratorProfile.OrchestratorRelease, a.OrchestratorProfile.OrchestratorVersion)
-			}
-
-			sv, err := semver.NewVersion(version)
-			if err != nil {
-				return fmt.Errorf("could not validate version %s", version)
-			}
-			minVersion := "1.10.2"
-			cons, err := semver.NewConstraint("<" + minVersion)
+			// validation for instanceMetadata using VMSS with Kubernetes
+			minVersion = "1.10.2"
+			cons, err = semver.NewConstraint("<" + minVersion)
 			if err != nil {
 				return fmt.Errorf("could not apply semver constraint < %s against version %s", minVersion, version)
 			}

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -608,8 +608,7 @@ func (a *Properties) Validate(isUpdate bool) error {
 				return fmt.Errorf("could not apply semver constraint < %s against version %s", minVersion, version)
 			}
 			if cons.Check(sv) {
-				return fmt.Errorf("VirtualMachineScaleSets are only available in Kubernetes version %s or greater; unable to validate for Kubernetes version %s",
-					minVersion, version)
+				return fmt.Errorf("VirtualMachineScaleSets are only available in Kubernetes version %s or greater. Please set \"orchestratorVersion\" to %s or above", minVersion, minVersion)
 			}
 			// validation for instanceMetadata using VMSS with Kubernetes
 			minVersion = "1.10.2"
@@ -619,11 +618,11 @@ func (a *Properties) Validate(isUpdate bool) error {
 			}
 			if a.OrchestratorProfile.KubernetesConfig != nil && a.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata != nil {
 				if *a.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata && cons.Check(sv) {
-					return fmt.Errorf("VirtualMachineScaleSets with instance metadata is supported for Kubernetes version %s or greater. Please set \"useInstanceMetadata\": false in \"kubernetesConfig\"", minVersion)
+					return fmt.Errorf("VirtualMachineScaleSets with instance metadata is supported for Kubernetes version %s or greater. Please set \"useInstanceMetadata\": false in \"kubernetesConfig\" or set \"orchestratorVersion\" to %s or above", minVersion, minVersion)
 				}
 			} else {
 				if cons.Check(sv) {
-					return fmt.Errorf("VirtualMachineScaleSets with instance metadata is supported for Kubernetes version %s or greater. Please set \"useInstanceMetadata\": false in \"kubernetesConfig\"", minVersion)
+					return fmt.Errorf("VirtualMachineScaleSets with instance metadata is supported for Kubernetes version %s or greater. Please set \"useInstanceMetadata\": false in \"kubernetesConfig\" or set \"orchestratorVersion\" to %s or above", minVersion, minVersion)
 				}
 			}
 		}

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -588,7 +588,7 @@ func (a *Properties) Validate(isUpdate bool) error {
 		}
 
 		// validation for VMSS for Kubernetes
-		if a.OrchestratorProfile.OrchestratorType == Kubernetes && (agentPoolProfile.AvailabilityProfile == VirtualMachineScaleSets || len(agentPoolProfile.AvailabilityProfile) == 0) {
+		if a.OrchestratorProfile.OrchestratorType == Kubernetes && agentPoolProfile.AvailabilityProfile == VirtualMachineScaleSets {
 			version := common.RationalizeReleaseAndVersion(
 				a.OrchestratorProfile.OrchestratorType,
 				a.OrchestratorProfile.OrchestratorRelease,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: We were setting AvailabilityProfile to VMSS by default. However, VMSS is not supported for K8s < 1.10. This PR ensures that we set AvailabilityProfile to AvailabilitySet if using K8s < 1.10.

Backwards compatibility should not be affected because we were validating before to make sure that VMSS was not set with k8s < 1.10. This change just makes it easier for the user by setting a default that works with validation instead of requiring an override.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [x] documentation
- [x] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
