### PR TITLE
Create kubernetes1.10.json

### DIFF
--- a/examples/kubernetes-releases/kubernetes1.10.json
+++ b/examples/kubernetes-releases/kubernetes1.10.json
@@ -1,0 +1,36 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "1.10"
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    }
+  }
+}


### PR DESCRIPTION
Deploy Orchestrator Kubernetes Cluster with Release 1.10.*

Improvements

Node
- Kubelet configuration can now be configured via a versioned config file;
- Ability to configure whether containers in a pod should share a single process namespace;
- CRI has been upgraded to v1alpha2;
- Support for Windows Container Configuration;
- Beta release of the CRI validation test suite;
- CPU Manager, which allows users to request exclusive CPU cores;
- Huge Pages, which allows pods to consume either 2Mi or 1Gi Huge Pages;
- Device Plugin feature, which provides a framework for vendors to advertise their resources to the Kubelet without changing Kubernetes core code;

Storage
- Additional power to both local storage and Persistent Volumes;

Windows
- Features on Windows, including container CPU resources, image filesystem stats, and flexvolumes, adding Windows service control manager support and experimental support for Hyper-V isolation of single-container pods

OpenStack
- SIG-OpenStack updated the OpenStack provider to use newer APIs;

API-machinery
- API Aggregation has been upgraded to “stable” in Kubernetes 1.10;
- Webhooks have seen numerous improvements, including alpha Support for self-hosting authorizer webhooks;

Auth
- New authentication methods, including the alpha release of External client-go credential providers and the TokenRequest API;
- Pod Security Policy now lets administrators decide what contexts pods can run in, and gives administrators the ability to limit node access to the API;

Azure
- Kubernetes 1.10 includes alpha Azure support for cluster-autoscaler, as well as support for Azure Virtual Machine Scale Sets;

CLI
- This release includes a change to kubectl get and describe to work better with extensions, as the server, rather than the client, returns this information for a smoother user experience;

Network
- In terms of networking, Kubernetes 1.10 is about control. Users now have beta support for the ability to configure a pod’s resolv.conf, rather than relying on the cluster DNS, as well as configuring the NodePort IP address. You can also switch the default DNS plugin to CoreDNS (beta).
