### PR TITLE
Use collaborators again now that we have an openshift team

### DIFF
--- a/.prowci/plugins.yaml
+++ b/.prowci/plugins.yaml
@@ -17,9 +17,6 @@ label:
   - orchestrator/swarm
   - DO-NOT-MERGE
 
-owners:
-  skip_collaborators:
-  - Azure/acs-engine
 
 plugins:
   Azure/acs-engine:


### PR DESCRIPTION
@CecileRobertMichon now that we have an openshift team in github, we should be good to go back to use collaborators in conjuction with OWNERS - this should also fix the issue we are seeing with `/lgtm` w/o the need to redeploy with https://github.com/kubernetes/test-infra/pull/8159 (although  https://github.com/kubernetes/test-infra/pull/8159 fixes a legitimate bug and needs to be merged regardless)

/assign CecileRobertMichon