### PR TITLE
ensure --admission-control is removed for 1.10

### DIFF
--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -138,6 +138,14 @@ func setAPIServerConfig(cs *api.ContainerService) {
 			delete(o.KubernetesConfig.APIServerConfig, key)
 		}
 	}
+
+	// Enforce flags removal that don't work with specific versions, to accommodate upgrade
+	// Remove flags that are not compatible with 1.10
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.10.0") {
+		for _, key := range []string{"--admission-control"} {
+			delete(o.KubernetesConfig.APIServerConfig, key)
+		}
+	}
 }
 
 func getDefaultAdmissionControls(cs *api.ContainerService) (string, string) {

--- a/pkg/acsengine/defaults-apiserver_test.go
+++ b/pkg/acsengine/defaults-apiserver_test.go
@@ -294,12 +294,13 @@ func TestAPIServerConfigEnableSecureKubelet(t *testing.T) {
 func TestAPIServerConfigDefaultAdmissionControls(t *testing.T) {
 	// Test --enable-admission-plugins for v1.10 and above
 	version := "1.10.0"
-	cs := createContainerService("testcluster", version, 3, 2)
-	setAPIServerConfig(cs)
-	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
-
 	enableAdmissionPluginsKey := "--enable-admission-plugins"
 	admissonControlKey := "--admission-control"
+	cs := createContainerService("testcluster", version, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = map[string]string{}
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig[admissonControlKey] = "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,DenyEscalatingExec,AlwaysPullImages"
+	setAPIServerConfig(cs)
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
 
 	// --enable-admission-plugins should be set for v1.10 and above
 	if _, found := a[enableAdmissionPluginsKey]; !found {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Restores Kubernetes 1.10 upgrade

https://github.com/Azure/acs-engine/pull/3090 introduced a replacement runtime configuration flag for apiserver in 1.10 clusters, we need to be able to deal with this in upgrade situations.

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
ensure --admission-control is removed for 1.10
```