### PR TITLE
remove pre-fill validation in deploy

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -162,7 +162,7 @@ func (dc *deployCmd) load(cmd *cobra.Command, args []string) error {
 	// autofillApimodel calls log.Fatal() directly and does not return errors
 	autofillApimodel(dc)
 
-	_, _, err = revalidateApimodel(apiloader, dc.containerService, dc.apiVersion)
+	_, _, err = validateApimodel(apiloader, dc.containerService, dc.apiVersion)
 	if err != nil {
 		return fmt.Errorf(fmt.Sprintf("Failed to validate the apimodel after populating values: %s", err))
 	}
@@ -291,7 +291,7 @@ func autofillApimodel(dc *deployCmd) {
 	}
 }
 
-func revalidateApimodel(apiloader *api.Apiloader, containerService *api.ContainerService, apiVersion string) (*api.ContainerService, string, error) {
+func validateApimodel(apiloader *api.Apiloader, containerService *api.ContainerService, apiVersion string) (*api.ContainerService, string, error) {
 	// This isn't terribly elegant, but it's the easiest way to go for now w/o duplicating a bunch of code
 	rawVersionedAPIModel, err := apiloader.SerializeContainerService(containerService, apiVersion)
 	if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -138,7 +138,8 @@ func (dc *deployCmd) load(cmd *cobra.Command, args []string) error {
 		},
 	}
 
-	dc.containerService, dc.apiVersion, err = apiloader.LoadContainerServiceFromFile(dc.apimodelPath, true, false, nil)
+	// do not validate when initially loading the apimodel, validation is done later after autofilling values
+	dc.containerService, dc.apiVersion, err = apiloader.LoadContainerServiceFromFile(dc.apimodelPath, false, false, nil)
 	if err != nil {
 		return fmt.Errorf(fmt.Sprintf("error parsing the api model: %s", err.Error()))
 	}

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -428,7 +428,7 @@ func testAutodeployCredentialHandling(t *testing.T, useManagedIdentity bool, cli
 	// cleanup, since auto-populations creates dirs and saves the SSH private key that it might create
 	defer os.RemoveAll(deployCmd.outputDirectory)
 
-	cs, _, err = revalidateApimodel(apiloader, cs, ver)
+	cs, _, err = validateApimodel(apiloader, cs, ver)
 	if err != nil {
 		log.Fatalf("unexpected error validating apimodel after populating defaults: %s", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Reverting pre-autofill validation in deploy command that was introduced in PR #2771. The validation prevents usage of flags for properties such as `--dns-prefix` since it requires the properties to exist in the apimodel. The model will be validated after so there is no need to validate beforehand.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3051 #2933 

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
