### PR TITLE
Replace log.Fatal by return errors in deploy.go

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -159,8 +159,9 @@ func (dc *deployCmd) load(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get client: %s", err.Error())
 	}
 
-	// autofillApimodel calls log.Fatal() directly and does not return errors
-	autofillApimodel(dc)
+	if err = autofillApimodel(dc); err != nil {
+		return err
+	}
 
 	_, _, err = validateApimodel(apiloader, dc.containerService, dc.apiVersion)
 	if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -212,7 +212,7 @@ func autofillApimodel(dc *deployCmd) error {
 		log.Warnf("--resource-group was not specified. Using the DNS prefix from the apimodel as the resource group name: %s", dnsPrefix)
 		dc.resourceGroup = dnsPrefix
 		if dc.location == "" {
-			return fmt.Errorf("--resource-group was not specified. --location must be specified in case the resource group needs creation.")
+			return fmt.Errorf("--resource-group was not specified. --location must be specified in case the resource group needs creation")
 		}
 	}
 

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -223,7 +223,7 @@ func TestAutoSufixWithDnsPrefixInApiModel(t *testing.T) {
 		client: &armhelpers.MockACSEngineClient{},
 	}
 
-	err := autofillApimodel(deployCmd)
+	err = autofillApimodel(deployCmd)
 	if err != nil {
 		t.Fatalf("unexpected error autofilling the example apimodel: %s", err)
 	}
@@ -266,7 +266,7 @@ func TestAPIModelWithoutServicePrincipalProfileAndClientIdAndSecretInCmd(t *test
 	deployCmd.ClientID = TestClientIDInCmd
 	deployCmd.ClientSecret = TestClientSecretInCmd
 
-	err := autofillApimodel(deployCmd)
+	err = autofillApimodel(deployCmd)
 	if err != nil {
 		t.Fatalf("unexpected error autofilling the example apimodel: %s", err)
 	}
@@ -315,7 +315,7 @@ func TestAPIModelWithEmptyServicePrincipalProfileAndClientIdAndSecretInCmd(t *te
 	}
 	deployCmd.ClientID = TestClientIDInCmd
 	deployCmd.ClientSecret = TestClientSecretInCmd
-	err := autofillApimodel(deployCmd)
+	err = autofillApimodel(deployCmd)
 	if err != nil {
 		t.Fatalf("unexpected error autofilling the example apimodel: %s", err)
 	}
@@ -356,7 +356,7 @@ func TestAPIModelWithoutServicePrincipalProfileAndWithoutClientIdAndSecretInCmd(
 
 		client: &armhelpers.MockACSEngineClient{},
 	}
-	err := autofillApimodel(deployCmd)
+	err = autofillApimodel(deployCmd)
 	if err != nil {
 		t.Fatalf("unexpected error autofilling the example apimodel: %s", err)
 	}
@@ -390,7 +390,7 @@ func TestAPIModelWithEmptyServicePrincipalProfileAndWithoutClientIdAndSecretInCm
 
 		client: &armhelpers.MockACSEngineClient{},
 	}
-	err := autofillApimodel(deployCmd)
+	err = autofillApimodel(deployCmd)
 	if err != nil {
 		t.Fatalf("unexpected error autofilling the example apimodel: %s", err)
 	}
@@ -440,7 +440,7 @@ func testAutodeployCredentialHandling(t *testing.T, useManagedIdentity bool, cli
 		client: &armhelpers.MockACSEngineClient{},
 	}
 
-	err := autofillApimodel(deployCmd)
+	err = autofillApimodel(deployCmd)
 	if err != nil {
 		t.Fatalf("unexpected error autofilling the example apimodel: %s", err)
 	}

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -222,7 +222,11 @@ func TestAutoSufixWithDnsPrefixInApiModel(t *testing.T) {
 
 		client: &armhelpers.MockACSEngineClient{},
 	}
-	autofillApimodel(deployCmd)
+
+	err := autofillApimodel(deployCmd)
+	if err != nil {
+		t.Fatalf("unexpected error autofilling the example apimodel: %s", err)
+	}
 
 	defer os.RemoveAll(deployCmd.outputDirectory)
 
@@ -260,8 +264,12 @@ func TestAPIModelWithoutServicePrincipalProfileAndClientIdAndSecretInCmd(t *test
 		client: &armhelpers.MockACSEngineClient{},
 	}
 	deployCmd.ClientID = TestClientIDInCmd
-	deployCmd.ClientSecret = TestClientSecretInCmd
-	autofillApimodel(deployCmd)
+	deployCmd.ClientSecret = TestCerr := autofillApimodel(deployCmd)
+
+	err := autofillApimodel(deployCmd)
+	if err != nil {
+		t.Fatalf("unexpected error autofilling the example apimodel: %s", err)
+	}
 
 	defer os.RemoveAll(deployCmd.outputDirectory)
 
@@ -307,7 +315,10 @@ func TestAPIModelWithEmptyServicePrincipalProfileAndClientIdAndSecretInCmd(t *te
 	}
 	deployCmd.ClientID = TestClientIDInCmd
 	deployCmd.ClientSecret = TestClientSecretInCmd
-	autofillApimodel(deployCmd)
+	err := autofillApimodel(deployCmd)
+	if err != nil {
+		t.Fatalf("unexpected error autofilling the example apimodel: %s", err)
+	}
 
 	defer os.RemoveAll(deployCmd.outputDirectory)
 
@@ -345,7 +356,10 @@ func TestAPIModelWithoutServicePrincipalProfileAndWithoutClientIdAndSecretInCmd(
 
 		client: &armhelpers.MockACSEngineClient{},
 	}
-	autofillApimodel(deployCmd)
+	err := autofillApimodel(deployCmd)
+	if err != nil {
+		t.Fatalf("unexpected error autofilling the example apimodel: %s", err)
+	}
 
 	defer os.RemoveAll(deployCmd.outputDirectory)
 
@@ -376,7 +390,10 @@ func TestAPIModelWithEmptyServicePrincipalProfileAndWithoutClientIdAndSecretInCm
 
 		client: &armhelpers.MockACSEngineClient{},
 	}
-	autofillApimodel(deployCmd)
+	err := autofillApimodel(deployCmd)
+	if err != nil {
+		t.Fatalf("unexpected error autofilling the example apimodel: %s", err)
+	}
 
 	defer os.RemoveAll(deployCmd.outputDirectory)
 
@@ -423,7 +440,10 @@ func testAutodeployCredentialHandling(t *testing.T, useManagedIdentity bool, cli
 		client: &armhelpers.MockACSEngineClient{},
 	}
 
-	autofillApimodel(deployCmd)
+	err := autofillApimodel(deployCmd)
+	if err != nil {
+		t.Fatalf("unexpected error autofilling the example apimodel: %s", err)
+	}
 
 	// cleanup, since auto-populations creates dirs and saves the SSH private key that it might create
 	defer os.RemoveAll(deployCmd.outputDirectory)

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -264,7 +264,7 @@ func TestAPIModelWithoutServicePrincipalProfileAndClientIdAndSecretInCmd(t *test
 		client: &armhelpers.MockACSEngineClient{},
 	}
 	deployCmd.ClientID = TestClientIDInCmd
-	deployCmd.ClientSecret = TestCerr := autofillApimodel(deployCmd)
+	deployCmd.ClientSecret = TestClientSecretInCmd
 
 	err := autofillApimodel(deployCmd)
 	if err != nil {

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/acs-engine/pkg/api"
 	"github.com/Azure/acs-engine/pkg/armhelpers"
 	"github.com/satori/go.uuid"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -450,18 +449,18 @@ func testAutodeployCredentialHandling(t *testing.T, useManagedIdentity bool, cli
 
 	cs, _, err = validateApimodel(apiloader, cs, ver)
 	if err != nil {
-		log.Fatalf("unexpected error validating apimodel after populating defaults: %s", err)
+		t.Fatalf("unexpected error validating apimodel after populating defaults: %s", err)
 	}
 
 	if useManagedIdentity {
 		if cs.Properties.ServicePrincipalProfile != nil &&
 			(cs.Properties.ServicePrincipalProfile.ClientID != "" || cs.Properties.ServicePrincipalProfile.Secret != "") {
-			log.Fatalf("Unexpected credentials were populated even though MSI was active.")
+			t.Fatalf("Unexpected credentials were populated even though MSI was active.")
 		}
 	} else {
 		if cs.Properties.ServicePrincipalProfile == nil ||
 			cs.Properties.ServicePrincipalProfile.ClientID == "" || cs.Properties.ServicePrincipalProfile.Secret == "" {
-			log.Fatalf("Credentials were missing even though MSI was not active.")
+			t.Fatalf("Credentials were missing even though MSI was not active.")
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Return errors instead of doing `log.Fatal` inside functions

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
