### PR TITLE
Fix k8s 1.11.0-alpha.2+ cluster bootstrap issue

### DIFF
--- a/parts/k8s/artifacts/kuberneteskubelet.service
+++ b/parts/k8s/artifacts/kuberneteskubelet.service
@@ -23,7 +23,7 @@ ExecStart=/usr/local/bin/kubelet \
         --v=2 \
         --volume-plugin-dir=/etc/kubernetes/volumeplugins \
         $KUBELET_CONFIG $KUBELET_OPTS \
-        ${KUBELET_REGISTER_NODE} ${KUBELET_REGISTER_WITH_TAINTS}
+        $KUBELET_REGISTER_NODE $KUBELET_REGISTER_WITH_TAINTS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fix systemd service quote issue.

New validation was introduced in kubelet that does not allow empty argument, but using empty variable ${} in systemd will interpret as empty argument. This is to address the issue.

Reference:
https://github.com/kubernetes/kubernetes/pull/61833
https://unix.stackexchange.com/questions/175461/how-to-use-quote-and-dollarsign-with-systemd

Fixes https://github.com/Azure/acs-engine/issues/3098
Related https://github.com/Azure/acs-engine/pull/2838

cc @jackfrancis @CecileRobertMichon 