### PR TITLE
acs-engine orchestrators should throw an error when an invalid/unsup…

### DIFF
--- a/pkg/api/common/const.go
+++ b/pkg/api/common/const.go
@@ -97,7 +97,29 @@ const (
 	OpenShiftDefaultVersion string = OpenShiftVersion3Dot9Dot0
 )
 
+const (
+	// SwarmVersion is the Swarm orchestrator version
+	SwarmVersion = "swarm:1.1.0"
+	// DockerCEVersion is the DockerCE orchestrator version
+	DockerCEVersion = "17.03.*"
+)
+
+// GetAllSupportedDCOSVersions returns a slice of all supported DCOS versions.
+func GetAllSupportedDCOSVersions() []string {
+	return AllDCOSSupportedVersions
+}
+
 // GetAllSupportedOpenShiftVersions returns a slice of all supported OpenShift versions.
 func GetAllSupportedOpenShiftVersions() []string {
 	return []string{OpenShiftVersion3Dot9Dot0, OpenShiftVersionUnstable}
+}
+
+// GetAllSupportedSwarmVersions returns a slice of all supported Swarm versions.
+func GetAllSupportedSwarmVersions() []string {
+	return []string{SwarmVersion}
+}
+
+// GetAllSupportedDockerCEVersions returns a slice of all supported Docker CE versions.
+func GetAllSupportedDockerCEVersions() []string {
+	return []string{DockerCEVersion}
 }

--- a/pkg/api/orchestrators.go
+++ b/pkg/api/orchestrators.go
@@ -13,6 +13,7 @@ import (
 type orchestratorsFunc func(*OrchestratorProfile) ([]*OrchestratorVersionProfile, error)
 
 var funcmap map[string]orchestratorsFunc
+var versionsMap map[string][]string
 
 func init() {
 	funcmap = map[string]orchestratorsFunc{
@@ -21,6 +22,13 @@ func init() {
 		Swarm:      swarmInfo,
 		SwarmMode:  dockerceInfo,
 		OpenShift:  openShiftInfo,
+	}
+	versionsMap = map[string][]string{
+		Kubernetes: common.GetAllSupportedKubernetesVersions(),
+		DCOS:       common.GetAllSupportedDCOSVersions(),
+		Swarm:      common.GetAllSupportedSwarmVersions(),
+		SwarmMode:  common.GetAllSupportedDockerCEVersions(),
+		OpenShift:  common.GetAllSupportedOpenShiftVersions(),
 	}
 }
 
@@ -44,6 +52,18 @@ func validate(orchestrator, version string) (string, error) {
 		return "", fmt.Errorf("Unsupported orchestrator '%s'", orchestrator)
 	}
 	return "", nil
+}
+
+func isVersionSupported(csOrch *OrchestratorProfile) bool {
+	supported := false
+	for _, version := range versionsMap[csOrch.OrchestratorType] {
+
+		if version == csOrch.OrchestratorVersion {
+			supported = true
+			break
+		}
+	}
+	return supported
 }
 
 // GetOrchestratorVersionProfileListVLabs returns vlabs OrchestratorVersionProfileList object per (optionally) specified orchestrator and version
@@ -89,7 +109,7 @@ func getOrchestratorVersionProfileList(orchestrator, version string) ([]*Orchest
 			orchs = append(orchs, arr...)
 		}
 	} else {
-		if orchs, err = funcmap[orchestrator](&OrchestratorProfile{OrchestratorVersion: version}); err != nil {
+		if orchs, err = funcmap[orchestrator](&OrchestratorProfile{OrchestratorType: orchestrator, OrchestratorVersion: version}); err != nil {
 			return nil, err
 		}
 	}
@@ -137,15 +157,7 @@ func kubernetesInfo(csOrch *OrchestratorProfile) ([]*OrchestratorVersionProfile,
 				})
 		}
 	} else {
-		ver, err := semver.NewVersion(csOrch.OrchestratorVersion)
-		if err != nil {
-			return nil, err
-		}
-		cons, err := semver.NewConstraint("<1.6.0")
-		if err != nil {
-			return nil, err
-		}
-		if cons.Check(ver) {
+		if !isVersionSupported(csOrch) {
 			return nil, fmt.Errorf("Kubernetes version %s is not supported", csOrch.OrchestratorVersion)
 		}
 
@@ -204,6 +216,10 @@ func dcosInfo(csOrch *OrchestratorProfile) ([]*OrchestratorVersionProfile, error
 				})
 		}
 	} else {
+		if !isVersionSupported(csOrch) {
+			return nil, fmt.Errorf("DCOS version %s is not supported", csOrch.OrchestratorVersion)
+		}
+
 		// get info for the specified version
 		upgrades, err := dcosUpgrades(csOrch)
 		if err != nil {
@@ -236,22 +252,51 @@ func dcosUpgrades(csOrch *OrchestratorProfile) ([]*OrchestratorProfile, error) {
 }
 
 func swarmInfo(csOrch *OrchestratorProfile) ([]*OrchestratorVersionProfile, error) {
+	if csOrch.OrchestratorVersion == "" {
+		return []*OrchestratorVersionProfile{
+			{
+				OrchestratorProfile: OrchestratorProfile{
+					OrchestratorType:    Swarm,
+					OrchestratorVersion: SwarmVersion,
+				},
+			},
+		}, nil
+	}
+
+	if !isVersionSupported(csOrch) {
+		return nil, fmt.Errorf("Swarm version %s is not supported", csOrch.OrchestratorVersion)
+	}
 	return []*OrchestratorVersionProfile{
 		{
 			OrchestratorProfile: OrchestratorProfile{
 				OrchestratorType:    Swarm,
-				OrchestratorVersion: SwarmVersion,
+				OrchestratorVersion: csOrch.OrchestratorVersion,
 			},
 		},
 	}, nil
 }
 
 func dockerceInfo(csOrch *OrchestratorProfile) ([]*OrchestratorVersionProfile, error) {
+
+	if csOrch.OrchestratorVersion == "" {
+		return []*OrchestratorVersionProfile{
+			{
+				OrchestratorProfile: OrchestratorProfile{
+					OrchestratorType:    SwarmMode,
+					OrchestratorVersion: DockerCEVersion,
+				},
+			},
+		}, nil
+	}
+
+	if !isVersionSupported(csOrch) {
+		return nil, fmt.Errorf("Docker CE version %s is not supported", csOrch.OrchestratorVersion)
+	}
 	return []*OrchestratorVersionProfile{
 		{
 			OrchestratorProfile: OrchestratorProfile{
 				OrchestratorType:    SwarmMode,
-				OrchestratorVersion: DockerCEVersion,
+				OrchestratorVersion: csOrch.OrchestratorVersion,
 			},
 		},
 	}, nil
@@ -276,15 +321,7 @@ func openShiftInfo(csOrch *OrchestratorProfile) ([]*OrchestratorVersionProfile, 
 				})
 		}
 	} else {
-		ver, err := semver.NewVersion(csOrch.OrchestratorVersion)
-		if err != nil {
-			return nil, err
-		}
-		cons, err := semver.NewConstraint("<3.9.0")
-		if err != nil {
-			return nil, err
-		}
-		if cons.Check(ver) {
+		if !isVersionSupported(csOrch) {
 			return nil, fmt.Errorf("OpenShift version %s is not supported", csOrch.OrchestratorVersion)
 		}
 

--- a/pkg/api/orchestrators_test.go
+++ b/pkg/api/orchestrators_test.go
@@ -50,8 +50,8 @@ func TestVersionCompare(t *testing.T) {
 
 func TestOrchestratorUpgradeInfo(t *testing.T) {
 	RegisterTestingT(t)
-	// 1.6.8 is upgradable to 1.6.x and 1.7.x
-	deployedVersion := "1.6.8"
+	// 1.6.9 is upgradable to 1.6.x and 1.7.x
+	deployedVersion := "1.6.9"
 	nextNextMinorVersion := "1.8.0"
 	csOrch := &OrchestratorProfile{
 		OrchestratorType:    Kubernetes,
@@ -164,7 +164,9 @@ func TestKubernetesInfo(t *testing.T) {
 		"31.29.",
 		".17.02",
 		"43.156.89.",
-		"1.2.a"}
+		"1.2.a",
+		"1.5.9",
+		"1.6.8"}
 
 	for _, v := range invalid {
 		csOrch := &OrchestratorProfile{
@@ -188,7 +190,9 @@ func TestOpenshiftInfo(t *testing.T) {
 		"31.29.",
 		".17.02",
 		"43.156.89.",
-		"1.2.a"}
+		"1.2.a",
+		"3.8.9",
+		"3.9.2"}
 
 	for _, v := range invalid {
 		csOrch := &OrchestratorProfile{
@@ -207,5 +211,90 @@ func TestOpenshiftInfo(t *testing.T) {
 	}
 
 	_, e := openShiftInfo(csOrch)
+	Expect(e).To(BeNil())
+}
+
+func TestDcosInfo(t *testing.T) {
+	RegisterTestingT(t)
+	invalid := []string{
+		"invalid number",
+		"invalid.number",
+		"a4.b7.c3",
+		"31.29.",
+		".17.02",
+		"43.156.89.",
+		"1.2.a"}
+
+	for _, v := range invalid {
+		csOrch := &OrchestratorProfile{
+			OrchestratorType:    DCOS,
+			OrchestratorVersion: v,
+		}
+
+		_, e := dcosInfo(csOrch)
+		Expect(e).NotTo(BeNil())
+	}
+
+	// test good value
+	csOrch := &OrchestratorProfile{
+		OrchestratorType:    DCOS,
+		OrchestratorVersion: common.DCOSDefaultVersion,
+	}
+
+	_, e := dcosInfo(csOrch)
+	Expect(e).To(BeNil())
+}
+
+func TestSwarmInfo(t *testing.T) {
+	RegisterTestingT(t)
+	invalid := []string{
+		"swarm:1.1.1",
+		"swarm:1.1.2",
+	}
+
+	for _, v := range invalid {
+		csOrch := &OrchestratorProfile{
+			OrchestratorType:    Swarm,
+			OrchestratorVersion: v,
+		}
+
+		_, e := swarmInfo(csOrch)
+		Expect(e).NotTo(BeNil())
+	}
+
+	// test good value
+	csOrch := &OrchestratorProfile{
+		OrchestratorType:    Swarm,
+		OrchestratorVersion: common.SwarmVersion,
+	}
+
+	_, e := swarmInfo(csOrch)
+	Expect(e).To(BeNil())
+}
+
+func TestDockerceInfoInfo(t *testing.T) {
+	RegisterTestingT(t)
+	invalid := []string{
+		"17.02.1",
+		"43.156.89",
+	}
+
+	for _, v := range invalid {
+		csOrch := &OrchestratorProfile{
+			OrchestratorType:    SwarmMode,
+			OrchestratorVersion: v,
+		}
+
+		_, e := dockerceInfo(csOrch)
+		Expect(e).NotTo(BeNil())
+	}
+
+	// test good value
+	csOrch := &OrchestratorProfile{
+		OrchestratorType:    SwarmMode,
+		OrchestratorVersion: common.DockerCEVersion,
+	}
+
+	_, e := dockerceInfo(csOrch)
 	Expect(e).To(BeNil())
 }

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -212,7 +212,7 @@ func (mc *MockACSEngineClient) ListVirtualMachines(resourceGroup string) (comput
 	poolnameString := "poolName"
 
 	creationSource := "acsengine-k8s-agentpool1-12345678-0"
-	orchestrator := "Kubernetes:1.6.8"
+	orchestrator := "Kubernetes:1.6.9"
 	resourceNameSuffix := "12345678"
 	poolname := "agentpool1"
 
@@ -272,7 +272,7 @@ func (mc *MockACSEngineClient) GetVirtualMachine(resourceGroup, name string) (co
 	poolnameString := "poolName"
 
 	creationSource := "acsengine-k8s-agentpool1-12345678-0"
-	orchestrator := "Kubernetes:1.6.8"
+	orchestrator := "Kubernetes:1.6.9"
 	resourceNameSuffix := "12345678"
 	poolname := "agentpool1"
 

--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 
 		err := uc.UpgradeCluster(subID, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
 		Expect(err).NotTo(BeNil())
-		Expect(err.Error()).To(Equal("Error while querying ARM for resources: Kubernetes:1.6.8 cannot be upgraded to 1.8.6"))
+		Expect(err.Error()).To(Equal("Error while querying ARM for resources: Kubernetes:1.6.9 cannot be upgraded to 1.8.6"))
 	})
 
 	It("Should return error message when failing to delete role assignment during upgrade operation", func() {


### PR DESCRIPTION
…ported version is provided

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: The orchestrators command should error out when an invalid orchestrator version is provided as input.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2852

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [x] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
