### PR TITLE
calico needs kubelet config —network-config=cni

### DIFF
--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -61,7 +61,9 @@ func setKubeletConfig(cs *api.ContainerService) {
 
 	// Override default --network-plugin?
 	if o.KubernetesConfig.NetworkPlugin == NetworkPluginKubenet {
-		o.KubernetesConfig.KubeletConfig["--network-plugin"] = NetworkPluginKubenet
+		if o.KubernetesConfig.NetworkPolicy != NetworkPolicyCalico {
+			o.KubernetesConfig.KubeletConfig["--network-plugin"] = NetworkPluginKubenet
+		}
 		o.KubernetesConfig.KubeletConfig["--max-pods"] = strconv.Itoa(DefaultKubernetesMaxPods)
 	}
 

--- a/pkg/acsengine/defaults-kubelet_test.go
+++ b/pkg/acsengine/defaults-kubelet_test.go
@@ -173,3 +173,14 @@ func TestKubeletMaxPods(t *testing.T) {
 			NetworkPluginKubenet, k["--max-pods"])
 	}
 }
+
+func TestKubeletCalico(t *testing.T) {
+	cs := createContainerService("testcluster", defaultTestClusterVer, 3, 2)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy = NetworkPolicyCalico
+	setKubeletConfig(cs)
+	k := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	if k["--network-plugin"] != "cni" {
+		t.Fatalf("got unexpected '--network-plugin' kubelet config value for NetworkPolicy=%s: %s",
+			NetworkPolicyCalico, k["--network-plugin"])
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: With recent evolutions to `NetworkPolicy` `KubernetesConfig` config interface, calico clusters are now bootstrapping w/ `--network-plugin=kubenet` kubelet runtime config, which is incorrect.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3044

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
calico needs kubelet config —network-config=cni
```