### PR TITLE
Feat/custom dns

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -475,6 +475,7 @@ A cluster can have 0 to 12 agent pool profiles. Agent Pool Profiles are used for
 |customSearchDomain.name|no|describes the search domain to be used on all linux clusters|
 |customSearchDomain.realmUser|no|describes the realm user with permissions to update dns registries on Windows Server DNS|
 |customSearchDomain.realmPassword|no|describes the realm user password to update dns registries on Windows Server DNS|
+|customNodesDNS.dnsServer|no|describes the IP address of the DNS Server|
 
 #### secrets
 `secrets` details which certificates to install on the masters and nodes in the cluster.

--- a/examples/vnet/kubernetesvnet-customnodesdns.json
+++ b/examples/vnet/kubernetesvnet-customnodesdns.json
@@ -1,0 +1,51 @@
+{
+    "apiVersion": "vlabs",
+    "properties": {
+      "orchestratorProfile": {
+        "orchestratorType": "Kubernetes",
+        "kubernetesConfig": {
+          "networkPolicy": "calico"
+        }
+      },
+      "masterProfile": {
+        "count": 1,
+        "dnsPrefix": "test",
+        "vmSize": "Standard_D2_v2",
+        "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
+        "firstConsecutiveStaticIP": "10.239.255.239" 
+      },
+      "agentPoolProfiles": [
+        {
+          "name": "agentpri",
+          "count": 2,
+          "vmSize": "Standard_D2_v2",
+          "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
+          "availabilityProfile": "AvailabilitySet"
+        },
+        {
+          "name": "agentpri2",
+          "count": 2,
+          "vmSize": "Standard_D2_v2",
+          "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
+          "availabilityProfile": "AvailabilitySet"
+        }
+      ],
+      "linuxProfile": {
+        "customNodesDNS": {
+            "dnsServer": "10.239.255.255"
+        },
+        "adminUsername": "azureuser",
+        "ssh": {
+          "publicKeys": [
+            {
+              "keyData": ""
+            }
+          ]
+        }
+      },
+      "servicePrincipalProfile": {
+        "clientId": "",
+        "secret": ""
+      }
+    }
+  }

--- a/parts/k8s/kubernetesagentresourcesvmss.t
+++ b/parts/k8s/kubernetesagentresourcesvmss.t
@@ -73,7 +73,12 @@
                   }
                   {{if lt $seq $.IPAddressCount}},{{end}}
                   {{end}}
-                ]
+                ],
+                 "dnsSettings": {
+                    "dnsServers": [
+                        "[variables('dnsServer')]"
+                    ]
+                }
                 {{if not IsAzureCNI}}
                 ,"enableIPForwarding": true
                 {{end}}

--- a/parts/k8s/kubernetesagentresourcesvmss.t
+++ b/parts/k8s/kubernetesagentresourcesvmss.t
@@ -73,12 +73,14 @@
                   }
                   {{if lt $seq $.IPAddressCount}},{{end}}
                   {{end}}
-                ],
-                 "dnsSettings": {
+                ]
+{{if HasCustomNodesDNS}}
+                 ,"dnsSettings": {
                     "dnsServers": [
                         "[variables('dnsServer')]"
                     ]
                 }
+{{end}}
                 {{if not IsAzureCNI}}
                 ,"enableIPForwarding": true
                 {{end}}

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -467,11 +467,13 @@
         ,
         "enableIPForwarding": true
 {{end}}
+{{if HasCustomNodesDNS}}
  ,"dnsSettings": {
           "dnsServers": [
               "[variables('dnsServer')]"
           ]
       }
+{{end}}
 {{if or .MasterProfile.IsCustomVNET IsOpenShift}}
         ,"networkSecurityGroup": {
           "id": "[variables('nsgID')]"
@@ -548,11 +550,13 @@
           ,
           "enableIPForwarding": true
   {{end}}
+  {{if HasCustomNodesDNS}}
    ,"dnsSettings": {
           "dnsServers": [
               "[variables('dnsServer')]"
           ]
       }
+  {{end}}
   {{if or .MasterProfile.IsCustomVNET IsOpenShift}}
           ,"networkSecurityGroup": {
             "id": "[variables('nsgID')]"

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -467,6 +467,11 @@
         ,
         "enableIPForwarding": true
 {{end}}
+ ,"dnsSettings": {
+          "dnsServers": [
+              "[variables('dnsServer')]"
+          ]
+      }
 {{if or .MasterProfile.IsCustomVNET IsOpenShift}}
         ,"networkSecurityGroup": {
           "id": "[variables('nsgID')]"
@@ -543,6 +548,11 @@
           ,
           "enableIPForwarding": true
   {{end}}
+   ,"dnsSettings": {
+          "dnsServers": [
+              "[variables('dnsServer')]"
+          ]
+      }
   {{if or .MasterProfile.IsCustomVNET IsOpenShift}}
           ,"networkSecurityGroup": {
             "id": "[variables('nsgID')]"

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -276,6 +276,9 @@
     "searchDomainRealmUser": "[parameters('searchDomainRealmUser')]",
     "searchDomainRealmPassword": "[parameters('searchDomainRealmPassword')]",
 {{end}}
+{{if HasCustomNodesDNS}}
+    "dnsServer": "[parameters('dnsServer')]",
+{{end}}
 {{if not IsHostedMaster}}
   {{if .MasterProfile.IsCustomVNET}}
     "vnetSubnetID": "[parameters('masterVnetSubnetID')]",

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -819,6 +819,16 @@
       "type": "securestring"
     }
 {{end}}
+{{if HasCustomNodesDNS}}
+    ,"dnsServer": {
+      "defaultValue": "",
+      "metadata": {
+        "description": "DNS Server IP"
+      },
+      "type": "string"
+    }
+{{end}}
+
 {{if EnableEncryptionWithExternalKms}}
    ,
    {{if not UseManagedIdentity}}

--- a/pkg/acsengine/params.go
+++ b/pkg/acsengine/params.go
@@ -42,6 +42,9 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 		addValue(parametersMap, "searchDomainRealmUser", properties.LinuxProfile.CustomSearchDomain.RealmUser)
 		addValue(parametersMap, "searchDomainRealmPassword", properties.LinuxProfile.CustomSearchDomain.RealmPassword)
 	}
+	if properties.LinuxProfile.CustomNodesDNS != nil {
+		addValue(parametersMap, "dnsServer", properties.LinuxProfile.CustomNodesDNS.DNSServer)
+	}
 	// masterEndpointDNSNamePrefix is the basis for storage account creation across dcos, swarm, and k8s
 	if properties.MasterProfile != nil {
 		// MasterProfile exists, uses master DNS prefix

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -665,6 +665,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"HasCustomSearchDomain": func() bool {
 			return cs.Properties.LinuxProfile.HasSearchDomain()
 		},
+		"HasCustomNodesDNS": func() bool {
+			return cs.Properties.LinuxProfile.HasCustomNodesDNS()
+		},
 		"HasWindowsSecrets": func() bool {
 			return cs.Properties.WindowsProfile.HasSecrets()
 		},

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -561,6 +561,11 @@ func convertLinuxProfileToVLabs(obj *LinuxProfile, vlabsProfile *vlabs.LinuxProf
 		vlabsProfile.CustomSearchDomain.RealmUser = obj.CustomSearchDomain.RealmUser
 		vlabsProfile.CustomSearchDomain.RealmPassword = obj.CustomSearchDomain.RealmPassword
 	}
+
+	if obj.CustomNodesDNS != nil {
+		vlabsProfile.CustomNodesDNS = &vlabs.CustomNodesDNS{}
+		vlabsProfile.CustomNodesDNS.DNSServer = obj.CustomNodesDNS.DNSServer
+	}
 }
 
 func convertWindowsProfileToV20160930(api *WindowsProfile, v20160930 *v20160930.WindowsProfile) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -485,6 +485,11 @@ func convertVLabsLinuxProfile(vlabs *vlabs.LinuxProfile, api *LinuxProfile) {
 		api.CustomSearchDomain.RealmUser = vlabs.CustomSearchDomain.RealmUser
 		api.CustomSearchDomain.RealmPassword = vlabs.CustomSearchDomain.RealmPassword
 	}
+
+	if vlabs.CustomNodesDNS != nil {
+		api.CustomNodesDNS = &CustomNodesDNS{}
+		api.CustomNodesDNS.DNSServer = vlabs.CustomNodesDNS.DNSServer
+	}
 }
 
 func convertV20160930WindowsProfile(v20160930 *v20160930.WindowsProfile, api *WindowsProfile) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -150,6 +150,7 @@ type CustomSearchDomain struct {
 	RealmPassword string `json:"realmPassword,omitempty"`
 }
 
+// CustomNodesDNS represents the Search Domain when the custom vnet for a custom DNS as a nameserver.
 type CustomNodesDNS struct {
 	DNSServer string `json:"dnsServer,omitempty"`
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -135,6 +135,7 @@ type LinuxProfile struct {
 	Distro             Distro              `json:"distro,omitempty"`
 	ScriptRootURL      string              `json:"scriptroot,omitempty"`
 	CustomSearchDomain *CustomSearchDomain `json:"customSearchDomain,omitempty"`
+	CustomNodesDNS     *CustomNodesDNS     `json:"CustomNodesDNS,omitempty"`
 }
 
 // PublicKey represents an SSH key for LinuxProfile
@@ -147,6 +148,10 @@ type CustomSearchDomain struct {
 	Name          string `json:"name,omitempty"`
 	RealmUser     string `json:"realmUser,omitempty"`
 	RealmPassword string `json:"realmPassword,omitempty"`
+}
+
+type CustomNodesDNS struct {
+	DNSServer string `json:"dnsServer,omitempty"`
 }
 
 // WindowsProfile represents the windows parameters passed to the cluster
@@ -772,6 +777,16 @@ func (l *LinuxProfile) HasSecrets() bool {
 func (l *LinuxProfile) HasSearchDomain() bool {
 	if l.CustomSearchDomain != nil {
 		if l.CustomSearchDomain.Name != "" && l.CustomSearchDomain.RealmPassword != "" && l.CustomSearchDomain.RealmUser != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// HasCustomNodesDNS returns true if the customer specified a dns server
+func (l *LinuxProfile) HasCustomNodesDNS() bool {
+	if l.CustomNodesDNS != nil {
+		if l.CustomNodesDNS.DNSServer != "" {
 			return true
 		}
 	}

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -610,7 +610,7 @@ func (l *LinuxProfile) HasSearchDomain() bool {
 	return false
 }
 
-// HasSearchDomain returns true if the customer specified secrets to install
+// HasCustomNodesDNS returns true if the customer specified secrets to install
 func (l *LinuxProfile) HasCustomNodesDNS() bool {
 	if l.CustomNodesDNS != nil {
 		if l.CustomNodesDNS.DNSServer != "" {

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -127,6 +127,7 @@ type LinuxProfile struct {
 	Secrets            []KeyVaultSecrets   `json:"secrets,omitempty"`
 	ScriptRootURL      string              `json:"scriptroot,omitempty"`
 	CustomSearchDomain *CustomSearchDomain `json:"customSearchDomain,omitempty"`
+	CustomNodesDNS     *CustomNodesDNS     `json:"customNodesDNS,omitempty"`
 }
 
 // PublicKey represents an SSH key for LinuxProfile
@@ -139,6 +140,11 @@ type CustomSearchDomain struct {
 	Name          string `json:"name,omitempty"`
 	RealmUser     string `json:"realmUser,omitempty"`
 	RealmPassword string `json:"realmPassword,omitempty"`
+}
+
+// CustomNodesDNS represents the Search Domain
+type CustomNodesDNS struct {
+	DNSServer string `json:"dnsServer,omitempty"`
 }
 
 // WindowsProfile represents the windows parameters passed to the cluster
@@ -598,6 +604,16 @@ func (a *AgentPoolProfile) SetSubnet(subnet string) {
 func (l *LinuxProfile) HasSearchDomain() bool {
 	if l.CustomSearchDomain != nil {
 		if l.CustomSearchDomain.Name != "" && l.CustomSearchDomain.RealmPassword != "" && l.CustomSearchDomain.RealmUser != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// HasSearchDomain returns true if the customer specified secrets to install
+func (l *LinuxProfile) HasCustomNodesDNS() bool {
+	if l.CustomNodesDNS != nil {
+		if l.CustomNodesDNS.DNSServer != "" {
 			return true
 		}
 	}


### PR DESCRIPTION
When using custom VNET, I had to update manually /etc/hosts files on whole nodes to add nodes IP and hostname entries. This is makes autoscaling unusable.
Thanks to this PR, I can choose a custom DNS server I created (Ubuntu/Bind9) and I'm able by adding an extension to update the DNS entry of my nodes on their creation.