### PR TITLE
add support for k8s 1.11.0-beta.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,6 +356,30 @@ jobs:
           path: /go/src/github.com/Azure/acs-engine/_logs
       - store_artifacts:
           path: /go/src/github.com/Azure/acs-engine/_output
+  k8s-windows-1.11-release-e2e:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: |
+          echo 'export TIMEOUT=30m' >> $BASH_ENV
+          echo 'export ORCHESTRATOR_RELEASE=1.11' >> $BASH_ENV
+          echo 'export CLUSTER_DEFINITION=examples/e2e-tests/kubernetes/windows/definition.json' >> $BASH_ENV
+          echo 'export CLEANUP_ON_EXIT=${CLEANUP_ON_EXIT}' >> $BASH_ENV
+          echo 'export RETAIN_SSH=false' >> $BASH_ENV
+          echo 'export SUBSCRIPTION_ID=${SUBSCRIPTION_ID_E2E_KUBERNETES}' >> $BASH_ENV
+          echo 'export CLIENT_ID=${SERVICE_PRINCIPAL_CLIENT_ID_E2E_KUBERNETES}' >> $BASH_ENV
+          echo 'export CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET_E2E_KUBERNETES}' >> $BASH_ENV
+      - run:
+          name: compile
+          command: make build-binary
+      - run:
+          name: ginkgo k8s windows e2e tests
+          command: make test-kubernetes
+          no_output_timeout: "30m"
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_logs
+      - store_artifacts:
+          path: /go/src/github.com/Azure/acs-engine/_output
   openshift-3.9-rhel-e2e:
     working_directory: /go/src/github.com/Azure/acs-engine
     docker:
@@ -440,6 +464,12 @@ workflows:
             branches:
               ignore: master
       - k8s-windows-1.10-release-e2e:
+          requires:
+            - pr-e2e-hold
+          filters:
+            branches:
+              ignore: master
+      - k8s-windows-1.11-release-e2e:
           requires:
             - pr-e2e-hold
           filters:

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -57,6 +57,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.10.3":         true,
 	"1.11.0-alpha.1": true,
 	"1.11.0-alpha.2": true,
+	"1.11.0-beta.1":  true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: https://github.com/kubernetes/kubernetes/releases/tag/v1.11.0-beta.1!

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
This is the first 1.11 minor k8s version for Windows
```
