### PR TITLE
Merge AADProfile during update

### DIFF
--- a/pkg/api/agentPoolOnlyApi/v20180331/merge.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/merge.go
@@ -37,5 +37,9 @@ func (mc *ManagedCluster) Merge(emc *ManagedCluster) error {
 		// For update scenario, the default behavior is to use existing behavior
 		mc.Properties.NetworkProfile = emc.Properties.NetworkProfile
 	}
+	if mc.Properties.AADProfile == nil {
+		// For update scenario, the default behavior is to use existing behavior
+		mc.Properties.AADProfile = emc.Properties.AADProfile
+	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR merges old and new AADProfile API models for the update case as all properties are not required during update and ACS Engine merge API models for the caller.