### PR TITLE
Move artifacts gathering around

### DIFF
--- a/test/e2e/openshift/openshift_test.go
+++ b/test/e2e/openshift/openshift_test.go
@@ -1,9 +1,7 @@
 package openshift
 
 import (
-	"fmt"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"strings"
 	"time"
@@ -46,33 +44,6 @@ var _ = BeforeSuite(func() {
 		ClusterDefinition:  csInput,
 		ExpandedDefinition: csGenerated,
 	}
-	signal.Notify(ch, os.Interrupt)
-})
-
-var _ = AfterEach(func() {
-	// Recommended way to optionally act on failures after
-	// tests finish - see https://github.com/onsi/ginkgo/issues/361
-	failed = failed || CurrentGinkgoTestDescription().Failed
-})
-
-var _ = AfterSuite(func() {
-	select {
-	case <-ch:
-		// interrupt
-		interrupted = true
-	default:
-	}
-
-	if !failed && !interrupted {
-		return
-	}
-
-	nodeOut, _ := util.DumpNodes()
-	fmt.Println(nodeOut)
-	podOut, _ := util.DumpPods()
-	fmt.Println(podOut)
-	diagnosticsOut, _ := util.RunDiagnostics()
-	fmt.Println(diagnosticsOut)
 })
 
 var _ = Describe("Azure Container Cluster using the OpenShift Orchestrator", func() {

--- a/test/e2e/openshift/util/util.go
+++ b/test/e2e/openshift/util/util.go
@@ -166,13 +166,14 @@ func FetchClusterInfo(logPath string) error {
 
 // FetchOpenShiftLogs returns logs for all OpenShift components
 // (control plane and infra).
-func FetchOpenShiftLogs(distro, version, sshKeyPath, adminName, name, location, logPath string) {
+func FetchOpenShiftLogs(distro, version, sshKeyPath, adminName, name, location, logPath string) error {
 	if err := fetchControlPlaneLogs(distro, version, sshKeyPath, adminName, name, location, logPath); err != nil {
-		log.Printf("Cannot fetch logs for control plane components: %v", err)
+		return fmt.Errorf("cannot fetch logs for control plane components: %v", err)
 	}
 	if err := fetchInfraLogs(logPath); err != nil {
-		log.Printf("Cannot fetch logs for infra components: %v", err)
+		return fmt.Errorf("cannot fetch logs for infra components: %v", err)
 	}
+	return nil
 }
 
 // fetchControlPlaneLogs returns logs for Openshift control plane components.
@@ -185,8 +186,7 @@ func fetchControlPlaneLogs(distro, version, sshKeyPath, adminName, name, locatio
 	case common.OpenShiftVersionUnstable:
 		return fetchUnstableControlPlaneLogs(distro, sshKeyPath, sshAddress, name, logPath)
 	default:
-		log.Printf("Invalid OpenShift version %q - won't gather logs from the control plane", version)
-		return nil
+		return fmt.Errorf("invalid OpenShift version %q - won't gather logs from the control plane", version)
 	}
 }
 

--- a/test/e2e/openshift/util/util.go
+++ b/test/e2e/openshift/util/util.go
@@ -181,7 +181,8 @@ func fetchControlPlaneLogs(distro, version, sshKeyPath, adminName, name, locatio
 	case common.OpenShiftVersionUnstable:
 		return fetchUnstableControlPlaneLogs(distro, sshKeyPath, sshAddress, name, logPath)
 	default:
-		panic(fmt.Sprintf("BUG: invalid OpenShift version %s", version))
+		log.Printf("Invalid OpenShift version %q - won't gather logs from the control plane", version)
+		return nil
 	}
 }
 

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -203,6 +203,7 @@ func teardown() {
 		version := eng.Config.OrchestratorVersion
 		distro := eng.Config.Distro
 		outil.FetchOpenShiftLogs(distro, version, sshKeyPath, adminName, cfg.Name, cfg.Location, logsPath)
+		outil.FetchClusterInfo(logsPath)
 	}
 	if err := cliProvisioner.FetchActivityLog(acct, logsPath); err != nil {
 		log.Printf("cannot fetch the activity log: %v", err)

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -203,7 +203,9 @@ func teardown() {
 		version := eng.Config.OrchestratorVersion
 		distro := eng.Config.Distro
 		outil.FetchOpenShiftLogs(distro, version, sshKeyPath, adminName, cfg.Name, cfg.Location, logsPath)
-		outil.FetchClusterInfo(logsPath)
+		if err := outil.FetchClusterInfo(logsPath); err != nil {
+			log.Printf("cannot get pod and node info: %v", err)
+		}
 	}
 	if err := cliProvisioner.FetchActivityLog(acct, logsPath); err != nil {
 		log.Printf("cannot fetch the activity log: %v", err)

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -202,7 +202,9 @@ func teardown() {
 		adminName := eng.ClusterDefinition.Properties.LinuxProfile.AdminUsername
 		version := eng.Config.OrchestratorVersion
 		distro := eng.Config.Distro
-		outil.FetchOpenShiftLogs(distro, version, sshKeyPath, adminName, cfg.Name, cfg.Location, logsPath)
+		if err := outil.FetchOpenShiftLogs(distro, version, sshKeyPath, adminName, cfg.Name, cfg.Location, logsPath); err != nil {
+			log.Printf("cannot get openshift logs: %v", err)
+		}
 		if err := outil.FetchClusterInfo(logsPath); err != nil {
 			log.Printf("cannot get pod and node info: %v", err)
 		}


### PR DESCRIPTION
* moves logging of node and pod info into artifact gathering in `teardown`
* removes running diagnostics at least for now
* avoid version check panic

Depends on https://github.com/Azure/acs-engine/pull/3152