### PR TITLE
Fix test-style broken since bcf7d3b

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -623,7 +623,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				}
 
 				By("Cleaning up after ourselves")
-				err = networkpolicy.DeleteNetworkPolicy(networkPolicyName, namespace)
+				networkpolicy.DeleteNetworkPolicy(networkPolicyName, namespace)
 				// TODO delete networkpolicy
 				// Expect(err).NotTo(HaveOccurred())
 				err = nginxDeploy.Delete()


### PR DESCRIPTION
After bcf7d3b err var is directly re-assigned without being
used and this breaks the static validation.
