### PR TITLE
Drop redundant prowjob namespace

### DIFF
--- a/.prowci/config.yaml
+++ b/.prowci/config.yaml
@@ -1,4 +1,3 @@
-prowjob_namespace: default
 log_level: debug
 
 tide:


### PR DESCRIPTION
/assign CecileRobertMichon 

The namespace is already defaulted to "default" but we don't use prowjobs so we don't really care about this config option.