### PR TITLE
Add more debug log in the router test

### DIFF
--- a/test/e2e/openshift/util/util.go
+++ b/test/e2e/openshift/util/util.go
@@ -86,7 +86,7 @@ func TestHost(host string, maxRetries int, retryDelay time.Duration) error {
 		log.Printf("error while trying to access %s: %v", host, err)
 	}
 	for retries := 1; retries <= maxRetries; retries++ {
-		log.Printf("Retry #%d to access %s", retries, host)
+		log.Printf("%v: Retry #%d to access %s", time.Now(), retries, host)
 		resp, err = http.Get(url)
 		if err != nil {
 			log.Printf("error while trying to access %s: %v", host, err)
@@ -97,6 +97,7 @@ func TestHost(host string, maxRetries int, retryDelay time.Duration) error {
 			return nil
 		}
 		log.Printf("got status %q while trying to access %s", resp.Status, host)
+		log.Printf("sleeping for %fs", backoff.Seconds())
 		time.Sleep(backoff)
 		backoff *= 2
 	}


### PR DESCRIPTION
`log`s timestamps are very annoying:
```
2018/06/05 09:02:41 got status "503 Service Unavailable" while trying to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 Retry #1 to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 got status "503 Service Unavailable" while trying to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 Retry #2 to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 got status "503 Service Unavailable" while trying to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 Retry #3 to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 got status "503 Service Unavailable" while trying to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 Retry #4 to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 got status "503 Service Unavailable" while trying to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 Retry #5 to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 got status "503 Service Unavailable" while trying to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 Retry #6 to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 got status "503 Service Unavailable" while trying to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 Retry #7 to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 got status "503 Service Unavailable" while trying to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 Retry #8 to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 got status "503 Service Unavailable" while trying to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 Retry #9 to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 got status "503 Service Unavailable" while trying to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 Retry #10 to access nginx-example-default.40.117.142.30.nip.io
2018/06/05 09:02:41 got status "503 Service Unavailable" while trying to access nginx-example-default.40.117.142.30.nip.io
```

@mjudeikis ptal