### PR TITLE
Support --set flag in deploy command

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -170,7 +170,7 @@ func (dc *deployCmd) loadAPIModel(cmd *cobra.Command, args []string) error {
 	}
 
 	// do not validate when initially loading the apimodel, validation is done later after autofilling values
-	dc.containerService, dc.apiVersion, err = apiloader.LoadContainerServiceFromFile(dc.apimodelPath, true, false, nil)
+	dc.containerService, dc.apiVersion, err = apiloader.LoadContainerServiceFromFile(dc.apimodelPath, false, false, nil)
 	if err != nil {
 		return fmt.Errorf(fmt.Sprintf("error parsing the api model: %s", err.Error()))
 	}

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -464,3 +464,51 @@ func testAutodeployCredentialHandling(t *testing.T, useManagedIdentity bool, cli
 		}
 	}
 }
+
+func TestDeployCmdMergeAPIModel(t *testing.T) {
+	d := &deployCmd{}
+	d.apimodelPath = "../pkg/acsengine/testdata/simple/kubernetes.json"
+	err := d.mergeAPIModel()
+	if err != nil {
+		t.Fatalf("unexpected error calling mergeAPIModel with no --set flag defined: %s", err.Error())
+	}
+
+	d = &deployCmd{}
+	d.apimodelPath = "../pkg/acsengine/testdata/simple/kubernetes.json"
+	d.set = []string{"masterProfile.count=3,linuxProfile.adminUsername=testuser"}
+	err = d.mergeAPIModel()
+	if err != nil {
+		t.Fatalf("unexpected error calling mergeAPIModel with one --set flag: %s", err.Error())
+	}
+
+	d = &deployCmd{}
+	d.apimodelPath = "../pkg/acsengine/testdata/simple/kubernetes.json"
+	d.set = []string{"masterProfile.count=3", "linuxProfile.adminUsername=testuser"}
+	err = d.mergeAPIModel()
+	if err != nil {
+		t.Fatalf("unexpected error calling mergeAPIModel with multiple --set flags: %s", err.Error())
+	}
+
+	d = &deployCmd{}
+	d.apimodelPath = "../pkg/acsengine/testdata/simple/kubernetes.json"
+	d.set = []string{"agentPoolProfiles[0].count=1"}
+	err = d.mergeAPIModel()
+	if err != nil {
+		t.Fatalf("unexpected error calling mergeAPIModel with one --set flag to override an array property: %s", err.Error())
+	}
+}
+
+func TestDeployCmdMLoadAPIModel(t *testing.T) {
+	d := &deployCmd{}
+	r := &cobra.Command{}
+
+	d.apimodelPath = "../pkg/acsengine/testdata/simple/kubernetes.json"
+	d.set = []string{"agentPoolProfiles[0].count=1"}
+
+	d.validate(r, []string{"../pkg/acsengine/testdata/simple/kubernetes.json"})
+	d.mergeAPIModel()
+	err := d.loadAPIModel(r, []string{"../pkg/acsengine/testdata/simple/kubernetes.json"})
+	if err != nil {
+		t.Fatalf("unexpected error loading api model: %s", err.Error())
+	}
+}

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -173,7 +173,7 @@ func TestValidate(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		err = c.dc.validate(r, c.args)
+		err = c.dc.validateArgs(r, c.args)
 		if err != nil && c.expectedErr != nil {
 			if err.Error() != c.expectedErr.Error() {
 				t.Fatalf("expected validate deploy command to return error %s, but instead got %s", c.expectedErr.Error(), err.Error())
@@ -447,7 +447,7 @@ func testAutodeployCredentialHandling(t *testing.T, useManagedIdentity bool, cli
 	// cleanup, since auto-populations creates dirs and saves the SSH private key that it might create
 	defer os.RemoveAll(deployCmd.outputDirectory)
 
-	cs, _, err = validateApimodel(apiloader, cs, ver)
+	cs, _, err = deployCmd.validateApimodel()
 	if err != nil {
 		t.Fatalf("unexpected error validating apimodel after populating defaults: %s", err)
 	}
@@ -465,7 +465,7 @@ func testAutodeployCredentialHandling(t *testing.T, useManagedIdentity bool, cli
 	}
 }
 
-func TestDeployCmdMergeAPIModel(t *testing.T) {
+func testDeployCmdMergeAPIModel(t *testing.T) {
 	d := &deployCmd{}
 	d.apimodelPath = "../pkg/acsengine/testdata/simple/kubernetes.json"
 	err := d.mergeAPIModel()
@@ -498,16 +498,27 @@ func TestDeployCmdMergeAPIModel(t *testing.T) {
 	}
 }
 
-func TestDeployCmdMLoadAPIModel(t *testing.T) {
+func testDeployCmdMLoadAPIModel(t *testing.T) {
 	d := &deployCmd{}
 	r := &cobra.Command{}
+	f := r.Flags()
+
+	addAuthFlags(&d.authArgs, f)
+
+	fakeRawSubscriptionID := "6dc93fae-9a76-421f-bbe5-cc6460ea81cb"
+	fakeSubscriptionID, err := uuid.FromString(fakeRawSubscriptionID)
+	if err != nil {
+		t.Fatalf("Invalid SubscriptionId in Test: %s", err)
+	}
 
 	d.apimodelPath = "../pkg/acsengine/testdata/simple/kubernetes.json"
 	d.set = []string{"agentPoolProfiles[0].count=1"}
+	d.SubscriptionID = fakeSubscriptionID
+	d.rawSubscriptionID = fakeRawSubscriptionID
 
-	d.validate(r, []string{"../pkg/acsengine/testdata/simple/kubernetes.json"})
+	d.validateArgs(r, []string{"../pkg/acsengine/testdata/simple/kubernetes.json"})
 	d.mergeAPIModel()
-	err := d.loadAPIModel(r, []string{"../pkg/acsengine/testdata/simple/kubernetes.json"})
+	err = d.loadAPIModel(r, []string{"../pkg/acsengine/testdata/simple/kubernetes.json"})
 	if err != nil {
 		t.Fatalf("unexpected error loading api model: %s", err.Error())
 	}

--- a/docs/kubernetes/deploy.md
+++ b/docs/kubernetes/deploy.md
@@ -71,6 +71,22 @@ Administrative note: By default, the directory where acs-engine stores cluster c
 
 **Note**: If the cluster is using an existing VNET please see the [Custom VNET](features.md#feat-custom-vnet) feature documentation for additional steps that must be completed after cluster provisioning.
 
+The deploy command lets you override any values under the properties tag (even in arrays) from the cluster definition file without having to update the file. You can use the `--set` flag to do that. For example:
+
+```bash
+acs-engine deploy --resource-group "your-resource-group" \
+  --location "westeurope" \
+  --subscription-id "your-subscription-id" \
+  --api-model "./apimodel.json" \
+  --set masterProfile.dnsPrefix="your-dns-prefix-override" \
+  --set agentPoolProfiles[0].name="your-agentpool-0-name-override" \
+  --set agentPoolProfiles[0].count=1 \
+  --set linuxProfile.ssh.publicKeys[0].keyData="ssh-rsa PUBLICKEY azureuser@linuxvm" \
+  --set servicePrincipalProfile.clientId="spn-client-id" \
+  --set servicePrincipalProfile.secret="spn-client-secret"
+```
+
+
 <a href="#the-long-way"></a>
 
 ## ACS Engine the Long Way


### PR DESCRIPTION
**What this PR does / why we need it**:
Brings support for using --set flag to override values from the api model JSON file directly from acs-engine deploy command

Ex:

```bash
acs-engine deploy --resource-group "your-resource-group" \
  --location "westeurope" \
  --subscription-id "your-subscription-id" \
  --api-model "./apimodel.json" \
  --set masterProfile.dnsPrefix="your-dns-prefix-override" \
  --set agentPoolProfiles[0].name="your-agentpool-0-name-override" \
  --set agentPoolProfiles[0].count=1 \
  --set linuxProfile.ssh.publicKeys[0].keyData="ssh-rsa PUBLICKEY azureuser@linuxvm" \
  --set servicePrincipalProfile.clientId="spn-client-id" \
  --set servicePrincipalProfile.secret="spn-client-secret"
```

**Which issue this PR fixes**: fixes #2796 

**Special notes for your reviewer**:
I've done some refactoring in the deploy.go file to be able to extract the api model validation from the api model loading. That means that there is now 5 steps:
- validate the command line args
- merge the api model with eventual --set overrides into a new file
- load the merge api model
- validate the api model
- run the command

I think some code could be refactored more and shared between generate and deploy command, but it may be better to handle this in another issue/PR.
 
**If applicable**:
- [x] documentation
- [x] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Support for using --set flag to override api model JSON file directly in the acs-engine deploy command
```
