### PR TITLE
Prow updates

### DIFF
--- a/.prowci/hook.yaml
+++ b/.prowci/hook.yaml
@@ -39,7 +39,7 @@ items:
       spec:
         containers:
         - name: hook
-          image: registry.svc.ci.openshift.org/ci/hook:latest
+          image: quay.io/kargakis/hook:workaround
           imagePullPolicy: IfNotPresent
           args:
           - --dry-run=false

--- a/.prowci/plugins.yaml
+++ b/.prowci/plugins.yaml
@@ -1,6 +1,8 @@
 approve:
 - repos:
   - Azure/acs-engine
+  implicit_self_approve: true
+  lgtm_acts_as_approve: true
 
 config_updater:
   maps:

--- a/.prowci/tide.yaml
+++ b/.prowci/tide.yaml
@@ -38,7 +38,7 @@ items:
         serviceAccountName: tide
         containers:
         - name: tide
-          image: registry.svc.ci.openshift.org/ci/tide:latest
+          image: quay.io/kargakis/tide:workaround
           imagePullPolicy: IfNotPresent
           args:
           - --dry-run=false


### PR DESCRIPTION
First commit adds two options in the prow config:
`implicit_self_approve: true` means every PR opened is implicitly self-approved by the author. So if I open a PR against a directory I am an owner of, I don't need to explicitly `/approve` it.
`lgtm_acts_as_approve: true` means every PR I am `/lgtm`ing is also approved by me. So if I `/lgtm` a PR which I can also `/approve`, I don't need to do `/approve` manually.

Second commit syncs the manifests in acs-engine with what's deployed in-cluster.

/assign CecileRobertMichon