### PR TITLE
fix #3190 only use nvidia-container-runtime on gpu nodes

### DIFF
--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -34,7 +34,7 @@ write_files:
       "log-opts":  {
          "max-size": "50m",
          "max-file": "5"
-      }{{if IsNVIDIADevicePluginEnabled}}
+      }{{if and (IsNSeriesSKU .) (IsNVIDIADevicePluginEnabled)}}
       ,"default-runtime": "nvidia",
       "runtimes": {
          "nvidia": {


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows deployment of a cluster with cpu and gpu agent pools with the nvidia-device-plugin enabled. Without this the docker daemon on the cpu nodes fails to start.

**Which issue this PR fixes** *
This fixes #3190 by only making the changes to `/etc/docker/daemon.json` on gpu enabled nodes using the same template switch which enables/disables the installation of the GPU drivers.