### PR TITLE
When UseMasterCustomImage or UseAgentCustomImage is set, ensure that …

### DIFF
--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -232,8 +232,13 @@
             {{end}}
           },
           "osDisk": {
-            "createOption": "FromImage"
-            ,"caching": "ReadWrite"
+            "createOption": "FromImage",
+            "caching": "ReadWrite"
+            {{if UseAgentCustomImage .}}
+            ,"managedDisk": {
+              "storageAccountType": "Premium_LRS"
+            }
+            {{end}}
           {{if .IsStorageAccount}}
             ,"name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')),'-osdisk')]"
             ,"vhd": {

--- a/parts/k8s/kubernetesagentresourcesvmss.t
+++ b/parts/k8s/kubernetesagentresourcesvmss.t
@@ -125,6 +125,11 @@
           "osDisk": {
             "createOption": "FromImage",
             "caching": "ReadWrite"
+            {{if UseAgentCustomImage .}}
+            ,"managedDisk": {
+              "storageAccountType": "Premium_LRS"
+            }
+            {{end}}
           {{if ne .OSDiskSizeGB 0}}
             ,"diskSizeGB": {{.OSDiskSizeGB}}
           {{end}}

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -787,7 +787,7 @@
        "apiVersion": "[variables('apiVersionKeyVault')]",
        "location": "[variables('location')]",
        {{ if UseManagedIdentity}}
-       "dependsOn": 
+       "dependsOn":
        [
           {{$max := .MasterProfile.Count}}
           {{$c := subtract $max 1}}
@@ -820,7 +820,7 @@
            }
          ],
  {{else}}
-         "accessPolicies": 
+         "accessPolicies":
          [
           {{$max := .MasterProfile.Count}}
           {{$c := subtract $max 1}}
@@ -968,8 +968,13 @@
             {{end}}
           },
           "osDisk": {
-            "caching": "ReadWrite"
-            ,"createOption": "FromImage"
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+            {{if UseMasterCustomImage}}
+            ,"managedDisk": {
+              "storageAccountType": "Premium_LRS"
+            }
+            {{end}}
 {{if .MasterProfile.IsStorageAccount}}
             ,"name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-osdisk')]"
             ,"vhd": {


### PR DESCRIPTION
…the OS

disk is Premium_LRS (SSD-backed).

It is much easier to ensure this in the acs-engine template rather than in the
image itself, because the `az` command-line tooling does not allow the image
disk SLA to be specified (even though it can be done in the API).
