### PR TITLE
Document required manual calico 2.6.3 -> calico 3.1.1 upgrade when upgrading from < 0.17.0-provisioned clusters

### DIFF
--- a/examples/networkpolicy/README.md
+++ b/examples/networkpolicy/README.md
@@ -31,3 +31,22 @@ To understand how to deploy this template, please read the baseline [Kubernetes]
 Once the template has been successfully deployed, following the [simple policy tutorial](https://docs.projectcalico.org/v3.0/getting-started/kubernetes/tutorials/simple-policy) or the [advanced policy tutorial](https://docs.projectcalico.org/v3.0/getting-started/kubernetes/tutorials/advanced-policy) will help to understand calico networking.
 
 > Note: `ping` (ICMP) traffic is blocked on the cluster by default.  Wherever `ping` is used in any tutorial substitute testing access with something like `wget -q --timeout=5 google.com -O -` instead.
+
+### Update guidance for clusters deployed by acs-engine releases prior to 0.17.0
+Clusters deployed with calico networkPolicy enabled prior to `0.17.0` had calico `2.6.3` deployed, and a daemonset with an `updateStrategy` of `Ondelete`.
+
+acs-engine releases starting with 0.17.0 now produce an addon manifest for calico in `/etc/kubernetes/addons/calico-daemonset.yaml` contaning calico 3.1.x, and an `updateStrategy` of `RollingUpdate`.
+
+To get up and running with the new version of calico, follow these steps:
+
+1) Edit `/etc/kubernetes/addons/calico-daemonset.yaml` on a master node, replacing `calico/node:v3.1.1` with `calico/node:v2.6.10` and `calico/cni:v3.1.1` with `calico/cni:v2.0.6`. Run `kubectl apply -f /etc/kubernetes/addons/calico-daemonset.yaml`.
+
+   We're performing this step because calico does not support migrating its datastore from v2 to v3 when coming from releases prior to `2.6.5`. `2.6.10` is chosen as a migration stepping stone because it is the most recent 2.6.x patch available.
+
+2) Confirm that all the pods in the daemonset get rotated and come up healthy, reporting ready status in logs.
+
+3) Edit `/etc/kubernetes/addons/calico-daemonset.yaml` on the master node again, replacing `calico/node:v2.6.10` with `calico/node:v3.1.1` and `calico/cni:v2.0.6` with `calico/cni:v3.1.1`. Run `kubectl apply -f /etc/kubernetes/addons/calico-daemonset.yaml`.
+
+    Propagate this updated manifest to any other master nodes in the cluster.
+
+4) Confirm that all the pods in the daemonset get rotated and come up healthy after finishing tasks logged by migrate.go


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Upgrading from clusters deployed by acs-engine < 0.17.0 and calico enabled had calico 2.6.3. When upgrading such a cluster with 0.17.0 and later, calico addon manifest is 3.1.x, and a migration is not supported for releases prior to 2.6.5, so we need to perform some manual steps to get up and running on 3.1.x. See Issue #3191 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #3191 

**Special notes for your reviewer**:
I'm not entirely certain where this belongs (whether in examples/networkpolicy or examples/k8s-upgrade.

**If applicable**:
- [x] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
