### PR TITLE
DCOS: validate integrity of downloaded packages

### DIFF
--- a/parts/dcos/bstrap/bootstrapcustomdata.yml
+++ b/parts/dcos/bstrap/bootstrapcustomdata.yml
@@ -66,9 +66,10 @@ MASTER_IP_LIST
 - content: |
     #!/bin/bash
 
+    source /opt/azure/containers/provision_source.sh
     cd /opt/azure/dcos
-    curl -O {{{dcosBootstrapURL}}}
-
+    retrycmd_if_failure 10 10 120 curl -fsSL -o dcos_generate_config.sh.sha1sum {{{dcosBootstrapURL}}}.sha1sum
+    retry_download 1 1 120 {{{dcosBootstrapURL}}} dcos_generate_config.sh $(cat dcos_generate_config.sh.sha1sum)
     bash dcos_generate_config.sh
     docker run -d -p 8086:80 -v $PWD/genconf/serve:/usr/share/nginx/html:ro nginx
   owner: root

--- a/parts/dcos/bstrap/bootstrapprovision.sh
+++ b/parts/dcos/bstrap/bootstrapprovision.sh
@@ -4,20 +4,31 @@ source /opt/azure/containers/provision_source.sh
 source /opt/azure/dcos/environment
 
 # default dc/os component download address (Azure CDN)
-LIBLTDL_DOWNLOAD_URL=https://dcos-mirror.azureedge.net/pkg/libltdl7_2.4.6-0.1_amd64.deb
-DOCKER_CE_DOWNLOAD_URL=https://dcos-mirror.azureedge.net/pkg/docker-ce_17.09.0~ce-0~ubuntu_amd64.deb
+packages=(
+  https://dcos-mirror.azureedge.net/pkg/libltdl7_2.4.6-0.1_amd64.deb
+  https://dcos-mirror.azureedge.net/pkg/docker-ce_17.09.0~ce-0~ubuntu_amd64.deb
+)
+
+# sha1sum checksums for @packages
+sha1sums=(
+  9a0f9f2769d3dc834737aa7df50aaaea369af98d
+  94f6e89be6d45d9988269a237eb27c7d6a844d7f
+)
 
 case $DCOS_ENVIRONMENT in
-    # because of Chinese GreatWall Firewall, the default packages on Azure CDN is blocked. So the following Chinese local mirror url should be used instead.
-    AzureChinaCloud)
-        LIBLTDL_DOWNLOAD_URL=http://acsengine.blob.core.chinacloudapi.cn/dcos/libltdl7_2.4.6-0.1_amd64.deb
-        DOCKER_CE_DOWNLOAD_URL=http://mirror.kaiyuanshe.cn/docker-ce/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_17.09.0~ce-0~ubuntu_amd64.deb
+  # because of Chinese GreatWall Firewall, the default packages on Azure CDN is blocked. So the following Chinese local mirror url should be used instead.
+  AzureChinaCloud)
+    packages=(
+      http://acsengine.blob.core.chinacloudapi.cn/dcos/libltdl7_2.4.6-0.1_amd64.deb
+      http://mirror.kaiyuanshe.cn/docker-ce/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_17.09.0~ce-0~ubuntu_amd64.deb
+    )
     ;;
 esac
 
-for url in $LIBLTDL_DOWNLOAD_URL $DOCKER_CE_DOWNLOAD_URL; do
-  retry_get_install_deb 10 10 120 $url
-  if [ $? -ne 0  ]; then
+len=$((${#packages[@]}-1))
+for i in $(seq 0 $len); do
+  retry_get_install_deb 10 10 120 ${packages[$i]} ${sha1sums[$i]}
+    if [ $? -ne 0  ]; then
     exit 1
   fi
 done

--- a/parts/dcos/bstrap/bootstrapresources.t
+++ b/parts/dcos/bstrap/bootstrapresources.t
@@ -1,3 +1,14 @@
+{{if HasBootstrapPublicIP}}
+    {
+      "apiVersion": "[variables('apiVersionDefault')]",
+      "location": "[variables('location')]",
+      "name": "bootstrapPublicIP",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      },
+      "type": "Microsoft.Network/publicIPAddresses"
+    },
+{{end}}
     {
       "apiVersion": "[variables('apiVersionDefault')]",
       "location": "[variables('location')]",
@@ -42,6 +53,9 @@
 {{if not .MasterProfile.IsCustomVNET}}
         "[variables('vnetID')]",
 {{end}}
+{{if HasBootstrapPublicIP}}
+        "bootstrapPublicIP",
+{{end}}
         "[variables('bootstrapNSGID')]"
       ],
       "location": "[variables('location')]",
@@ -53,6 +67,11 @@
             "properties": {
               "privateIPAddress": "[variables('bootstrapStaticIP')]",
               "privateIPAllocationMethod": "Static",
+{{if HasBootstrapPublicIP}}
+              "publicIpAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIpAddresses', 'bootstrapPublicIP')]"
+              },
+{{end}}
               "subnet": {
                 "id": "[variables('masterVnetSubnetID')]"
               }

--- a/parts/dcos/bstrap/dcosprovision.sh
+++ b/parts/dcos/bstrap/dcosprovision.sh
@@ -7,28 +7,43 @@ TMPDIR="/tmp/dcos"
 mkdir -p $TMPDIR
 
 # default dc/os component download address (Azure CDN)
-LIBIPSET_DOWNLOAD_URL=https://dcos-mirror.azureedge.net/pkg/libipset3_6.29-1_amd64.deb
-IPSET_DOWNLOAD_URL=https://dcos-mirror.azureedge.net/pkg/ipset_6.29-1_amd64.deb
-UNZIP_DOWNLOAD_URL=https://dcos-mirror.azureedge.net/pkg/unzip_6.0-20ubuntu1_amd64.deb
-LIBLTDL_DOWNLOAD_URL=https://dcos-mirror.azureedge.net/pkg/libltdl7_2.4.6-0.1_amd64.deb
-DOCKER_CE_DOWNLOAD_URL=https://dcos-mirror.azureedge.net/pkg/docker-ce_17.09.0~ce-0~ubuntu_amd64.deb
-SELINUX_DOWNLOAD_URL=https://dcos-mirror.azureedge.net/pkg/selinux-utils_2.4-3build2_amd64.deb
+packages=(
+  https://dcos-mirror.azureedge.net/pkg/libipset3_6.29-1_amd64.deb
+  https://dcos-mirror.azureedge.net/pkg/ipset_6.29-1_amd64.deb
+  https://dcos-mirror.azureedge.net/pkg/unzip_6.0-20ubuntu1_amd64.deb
+  https://dcos-mirror.azureedge.net/pkg/libltdl7_2.4.6-0.1_amd64.deb
+  https://dcos-mirror.azureedge.net/pkg/docker-ce_17.09.0~ce-0~ubuntu_amd64.deb
+  https://dcos-mirror.azureedge.net/pkg/selinux-utils_2.4-3build2_amd64.deb
+)
+
+# sha1sum checksums for @packages
+sha1sums=(
+  f88d09688291917c8bb65682fea9f5d571ec8d6a
+  807dc11f5bfa39bb4b0dc9024fc51bb309905a21
+  57ae2bb6ded1fdf91b6d518294134df1ff13fcca
+  9a0f9f2769d3dc834737aa7df50aaaea369af98d
+  94f6e89be6d45d9988269a237eb27c7d6a844d7f
+  77bdb5847060845c0a158f567b1ddd7fa34b7236
+)
 
 case $DCOS_ENVIRONMENT in
-    # because of Chinese GreatWall Firewall, the default packages on Azure CDN is blocked. So the following Chinese local mirror url should be used instead.
-    AzureChinaCloud)
-        LIBIPSET_DOWNLOAD_URL=http://acsengine.blob.core.chinacloudapi.cn/dcos/libipset3_6.29-1_amd64.deb
-        IPSET_DOWNLOAD_URL=http://acsengine.blob.core.chinacloudapi.cn/dcos/ipset_6.29-1_amd64.deb
-        UNZIP_DOWNLOAD_URL=http://acsengine.blob.core.chinacloudapi.cn/dcos/unzip_6.0-20ubuntu1_amd64.deb
-        LIBLTDL_DOWNLOAD_URL=http://acsengine.blob.core.chinacloudapi.cn/dcos/libltdl7_2.4.6-0.1_amd64.deb
-        DOCKER_CE_DOWNLOAD_URL=http://mirror.kaiyuanshe.cn/docker-ce/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_17.09.0~ce-0~ubuntu_amd64.deb
-        SELINUX_DOWNLOAD_URL=http://acsengine.blob.core.chinacloudapi.cn/dcos/selinux-utils_2.4-3build2_amd64.deb
-    ;;
+  # because of Chinese GreatWall Firewall, the default packages on Azure CDN is blocked. So the following Chinese local mirror url should be used instead.
+  AzureChinaCloud)
+    packages=(
+      http://acsengine.blob.core.chinacloudapi.cn/dcos/libipset3_6.29-1_amd64.deb
+      http://acsengine.blob.core.chinacloudapi.cn/dcos/ipset_6.29-1_amd64.deb
+      http://acsengine.blob.core.chinacloudapi.cn/dcos/unzip_6.0-20ubuntu1_amd64.deb
+      http://acsengine.blob.core.chinacloudapi.cn/dcos/libltdl7_2.4.6-0.1_amd64.deb
+      http://mirror.kaiyuanshe.cn/docker-ce/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_17.09.0~ce-0~ubuntu_amd64.deb
+      http://acsengine.blob.core.chinacloudapi.cn/dcos/selinux-utils_2.4-3build2_amd64.deb
+    )
+  ;;
 esac
 
-for url in $LIBIPSET_DOWNLOAD_URL $IPSET_DOWNLOAD_URL $UNZIP_DOWNLOAD_URL $LIBLTDL_DOWNLOAD_URL $DOCKER_CE_DOWNLOAD_URL $SELINUX_DOWNLOAD_URL; do
-  retry_get_install_deb 10 10 120 $url
-  if [ $? -ne 0  ]; then
+len=$((${#packages[@]}-1))
+for i in $(seq 0 $len); do
+  retry_get_install_deb 10 10 120 ${packages[$i]} ${sha1sums[$i]}
+    if [ $? -ne 0  ]; then
     exit 1
   fi
 done

--- a/parts/dcos/dcosprovisionsource.sh
+++ b/parts/dcos/dcosprovisionsource.sh
@@ -1,10 +1,36 @@
-#!/bin/sh
+function retry_download() {
+  retries=$1; wait_sleep=$2; timeout=$3; url=$4; path=$5 checksum=$6
+  for i in $(seq 1 $retries); do
+    rm -f $path
+    timeout $timeout curl -fsSL $url -o $path
+    if [ $? -ne 0 ]; then
+      echo "retry_download[$i] Error: Failed to execute curl -fsSL $url -o $path"
+      sleep $wait_sleep
+      continue
+    fi
+    if [ ! -z "${checksum:-}" ]; then
+      actual=$(sha1sum -b $path | cut -f 1 -d " ")
+      if [ $? -ne 0 ]; then
+        echo "retry_download[$i] Error: Failed to execute sha1sum -b $path (per $url)"
+        sleep $wait_sleep
+        continue
+      fi
+      if [ "$checksum" != "$actual" ]; then
+        echo "retry_download[$i] Error: sha1sum mismatch for $url"
+        sleep $wait_sleep
+        continue
+      fi
+    fi
+    return 0
+  done
+  return 1
+}
 
-retrycmd_if_failure() {
+function retrycmd_if_failure() {
     retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
     for i in $(seq 1 $retries); do
         timeout $timeout ${@}
-        [ $? -eq 0  ] && break || \
+        [ $? -eq 0 ] && break || \
         if [ $i -eq $retries ]; then
             echo "Error: Failed to execute \"$@\" after $i attempts"
             return 1
@@ -14,17 +40,18 @@ retrycmd_if_failure() {
     done
     echo Executed \"$@\" $i times;
 }
-retry_get_install_deb() {
-  retries=$1; wait_sleep=$2; timeout=$3; url=$4;
+
+function retry_get_install_deb() {
+  retries=$1; wait_sleep=$2; timeout=$3; url=$4; checksum=$5
   deb=$(mktemp)
   trap "rm -f $deb" RETURN
-  retrycmd_if_failure $retries $wait_sleep $timeout curl -fsSL $url -o $deb
-  if [ $? -ne 0  ]; then
+  retry_download $retries $wait_sleep $timeout $url $deb $checksum
+  if [ $? -ne 0 ]; then
     echo "Error: Failed to download $url"
     return 1
   fi
   retrycmd_if_failure $retries $wait_sleep $timeout dpkg -i $deb
-  if [ $? -ne 0  ]; then
+  if [ $? -ne 0 ]; then
     echo "Error: Failed to install $url"
     return 1
   fi

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -321,6 +321,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"HasBootstrap": func() bool {
 			return cs.Properties.OrchestratorProfile.DcosConfig != nil && cs.Properties.OrchestratorProfile.DcosConfig.BootstrapProfile != nil
 		},
+		"HasBootstrapPublicIP": func() bool {
+			return false
+		},
 		"IsHostedBootstrap": func() bool {
 			return false
 		},


### PR DESCRIPTION
Validating the integrity of downloaded packages by comparing their checksums
Adding option to provision bootstrap public IP for debugging purposes

