### PR TITLE
Support upgrading a Kubernetes cluster that contains Virtual Machine Scale Sets

### DIFF
--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -46,17 +46,18 @@ type AzureClient struct {
 	environment     azure.Environment
 	subscriptionID  string
 
-	authorizationClient           authorization.RoleAssignmentsClient
-	deploymentsClient             resources.DeploymentsClient
-	deploymentOperationsClient    resources.DeploymentOperationsClient
-	resourcesClient               resources.GroupClient
-	storageAccountsClient         storage.AccountsClient
-	interfacesClient              network.InterfacesClient
-	groupsClient                  resources.GroupsClient
-	providersClient               resources.ProvidersClient
-	virtualMachinesClient         compute.VirtualMachinesClient
-	virtualMachineScaleSetsClient compute.VirtualMachineScaleSetsClient
-	disksClient                   disk.DisksClient
+	authorizationClient             authorization.RoleAssignmentsClient
+	deploymentsClient               resources.DeploymentsClient
+	deploymentOperationsClient      resources.DeploymentOperationsClient
+	resourcesClient                 resources.GroupClient
+	storageAccountsClient           storage.AccountsClient
+	interfacesClient                network.InterfacesClient
+	groupsClient                    resources.GroupsClient
+	providersClient                 resources.ProvidersClient
+	virtualMachinesClient           compute.VirtualMachinesClient
+	virtualMachineScaleSetsClient   compute.VirtualMachineScaleSetsClient
+	virtualMachineScaleSetVMsClient compute.VirtualMachineScaleSetVMsClient
+	disksClient                     disk.DisksClient
 
 	applicationsClient      graphrbac.ApplicationsClient
 	servicePrincipalsClient graphrbac.ServicePrincipalsClient
@@ -264,17 +265,18 @@ func getClient(env azure.Environment, subscriptionID, tenantID string, armSpt *a
 		environment:    env,
 		subscriptionID: subscriptionID,
 
-		authorizationClient:           authorization.NewRoleAssignmentsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
-		deploymentsClient:             resources.NewDeploymentsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
-		deploymentOperationsClient:    resources.NewDeploymentOperationsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
-		resourcesClient:               resources.NewGroupClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
-		storageAccountsClient:         storage.NewAccountsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
-		interfacesClient:              network.NewInterfacesClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
-		groupsClient:                  resources.NewGroupsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
-		providersClient:               resources.NewProvidersClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
-		virtualMachinesClient:         compute.NewVirtualMachinesClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
-		virtualMachineScaleSetsClient: compute.NewVirtualMachineScaleSetsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
-		disksClient:                   disk.NewDisksClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		authorizationClient:             authorization.NewRoleAssignmentsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		deploymentsClient:               resources.NewDeploymentsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		deploymentOperationsClient:      resources.NewDeploymentOperationsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		resourcesClient:                 resources.NewGroupClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		storageAccountsClient:           storage.NewAccountsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		interfacesClient:                network.NewInterfacesClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		groupsClient:                    resources.NewGroupsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		providersClient:                 resources.NewProvidersClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		virtualMachinesClient:           compute.NewVirtualMachinesClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		virtualMachineScaleSetsClient:   compute.NewVirtualMachineScaleSetsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		virtualMachineScaleSetVMsClient: compute.NewVirtualMachineScaleSetVMsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		disksClient:                     disk.NewDisksClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
 
 		applicationsClient:      graphrbac.NewApplicationsClientWithBaseURI(env.GraphEndpoint, tenantID),
 		servicePrincipalsClient: graphrbac.NewServicePrincipalsClientWithBaseURI(env.GraphEndpoint, tenantID),
@@ -291,6 +293,7 @@ func getClient(env azure.Environment, subscriptionID, tenantID string, armSpt *a
 	c.providersClient.Authorizer = authorizer
 	c.virtualMachinesClient.Authorizer = authorizer
 	c.virtualMachineScaleSetsClient.Authorizer = authorizer
+	c.virtualMachineScaleSetVMsClient.Authorizer = authorizer
 	c.disksClient.Authorizer = authorizer
 
 	c.deploymentsClient.PollingDelay = time.Second * 5

--- a/pkg/armhelpers/compute.go
+++ b/pkg/armhelpers/compute.go
@@ -23,3 +23,26 @@ func (az *AzureClient) DeleteVirtualMachine(resourceGroup, name string, cancel <
 func (az *AzureClient) ListVirtualMachineScaleSets(resourceGroup string) (compute.VirtualMachineScaleSetListResult, error) {
 	return az.virtualMachineScaleSetsClient.List(resourceGroup)
 }
+
+// ListVirtualMachineScaleSetVMs returns the list of VMs per VMSS
+func (az *AzureClient) ListVirtualMachineScaleSetVMs(resourceGroup, virtualMachineScaleSet string) (compute.VirtualMachineScaleSetVMListResult, error) {
+	return az.virtualMachineScaleSetVMsClient.List(resourceGroup, virtualMachineScaleSet, "", "", "")
+}
+
+// DeleteVirtualMachineScaleSetVM deletes a VM in a VMSS
+func (az *AzureClient) DeleteVirtualMachineScaleSetVM(resourceGroup, virtualMachineScaleSet, instanceID string, cancel <-chan struct{}) (<-chan compute.OperationStatusResponse, <-chan error) {
+	return az.virtualMachineScaleSetVMsClient.Delete(resourceGroup, virtualMachineScaleSet, instanceID, cancel)
+}
+
+// SetVirtualMachineScaleSetCapacity sets the VMSS capacity
+func (az *AzureClient) SetVirtualMachineScaleSetCapacity(resourceGroup, virtualMachineScaleSet string, sku compute.Sku, location string, cancel <-chan struct{}) (<-chan compute.VirtualMachineScaleSet, <-chan error) {
+	return az.virtualMachineScaleSetsClient.CreateOrUpdate(
+		resourceGroup,
+		virtualMachineScaleSet,
+		compute.VirtualMachineScaleSet{
+			Location: &location,
+			Sku:      &sku,
+		},
+		cancel,
+	)
+}

--- a/pkg/armhelpers/interfaces.go
+++ b/pkg/armhelpers/interfaces.go
@@ -44,6 +44,15 @@ type ACSEngineClient interface {
 	// ListVirtualMachineScaleSets lists the vmss resources in the resource group
 	ListVirtualMachineScaleSets(resourceGroup string) (compute.VirtualMachineScaleSetListResult, error)
 
+	// ListVirtualMachineScaleSetVMs lists the virtual machines contained in a vmss
+	ListVirtualMachineScaleSetVMs(resourceGroup, virtualMachineScaleSet string) (compute.VirtualMachineScaleSetVMListResult, error)
+
+	// DeleteVirtualMachineScaleSetVM deletes a VM in a VMSS
+	DeleteVirtualMachineScaleSetVM(resourceGroup, virtualMachineScaleSet, instanceID string, cancel <-chan struct{}) (<-chan compute.OperationStatusResponse, <-chan error)
+
+	// SetVirtualMachineScaleSetCapacity sets the VMSS capacity
+	SetVirtualMachineScaleSetCapacity(resourceGroup, virtualMachineScaleSet string, sku compute.Sku, location string, cancel <-chan struct{}) (<-chan compute.VirtualMachineScaleSet, <-chan error)
+
 	//
 	// STORAGE
 

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -20,21 +20,24 @@ import (
 
 //MockACSEngineClient is an implementation of ACSEngineClient where all requests error out
 type MockACSEngineClient struct {
-	FailDeployTemplate              bool
-	FailDeployTemplateQuota         bool
-	FailDeployTemplateConflict      bool
-	FailEnsureResourceGroup         bool
-	FailListVirtualMachines         bool
-	FailListVirtualMachineScaleSets bool
-	FailGetVirtualMachine           bool
-	FailDeleteVirtualMachine        bool
-	FailGetStorageClient            bool
-	FailDeleteNetworkInterface      bool
-	FailGetKubernetesClient         bool
-	FailListProviders               bool
-	ShouldSupportVMIdentity         bool
-	FailDeleteRoleAssignment        bool
-	MockKubernetesClient            *MockKubernetesClient
+	FailDeployTemplate                    bool
+	FailDeployTemplateQuota               bool
+	FailDeployTemplateConflict            bool
+	FailEnsureResourceGroup               bool
+	FailListVirtualMachines               bool
+	FailListVirtualMachineScaleSets       bool
+	FailGetVirtualMachine                 bool
+	FailDeleteVirtualMachine              bool
+	FailDeleteVirtualMachineScaleSetVM    bool
+	FailSetVirtualMachineScaleSetCapacity bool
+	FailListVirtualMachineScaleSetVMs     bool
+	FailGetStorageClient                  bool
+	FailDeleteNetworkInterface            bool
+	FailGetKubernetesClient               bool
+	FailListProviders                     bool
+	ShouldSupportVMIdentity               bool
+	FailDeleteRoleAssignment              bool
+	MockKubernetesClient                  *MockKubernetesClient
 }
 
 //MockStorageClient mock implementation of StorageClient
@@ -342,6 +345,79 @@ func (mc *MockACSEngineClient) DeleteVirtualMachine(resourceGroup, name string, 
 		respChan <- compute.OperationStatusResponse{}
 	}()
 	return respChan, errChan
+}
+
+//DeleteVirtualMachineScaleSetVM mock
+func (mc *MockACSEngineClient) DeleteVirtualMachineScaleSetVM(resourceGroup, virtualMachineScaleSet, instanceID string, cancel <-chan struct{}) (<-chan compute.OperationStatusResponse, <-chan error) {
+	if mc.FailDeleteVirtualMachineScaleSetVM {
+		errChan := make(chan error)
+		respChan := make(chan compute.OperationStatusResponse)
+		go func() {
+			defer func() {
+				close(errChan)
+			}()
+			defer func() {
+				close(respChan)
+			}()
+			errChan <- fmt.Errorf("DeleteVirtualMachineScaleSetVM failed")
+		}()
+		return respChan, errChan
+	}
+
+	errChan := make(chan error)
+	respChan := make(chan compute.OperationStatusResponse)
+	go func() {
+		defer func() {
+			close(errChan)
+		}()
+		defer func() {
+			close(respChan)
+		}()
+		errChan <- nil
+		respChan <- compute.OperationStatusResponse{}
+	}()
+	return respChan, errChan
+}
+
+//SetVirtualMachineScaleSetCapacity mock
+func (mc *MockACSEngineClient) SetVirtualMachineScaleSetCapacity(resourceGroup, virtualMachineScaleSet string, sku compute.Sku, location string, cancel <-chan struct{}) (<-chan compute.VirtualMachineScaleSet, <-chan error) {
+	if mc.FailSetVirtualMachineScaleSetCapacity {
+		errChan := make(chan error)
+		respChan := make(chan compute.VirtualMachineScaleSet)
+		go func() {
+			defer func() {
+				close(errChan)
+			}()
+			defer func() {
+				close(respChan)
+			}()
+			errChan <- fmt.Errorf("SetVirtualMachineScaleSetCapacity failed")
+		}()
+		return respChan, errChan
+	}
+
+	errChan := make(chan error)
+	respChan := make(chan compute.VirtualMachineScaleSet)
+	go func() {
+		defer func() {
+			close(errChan)
+		}()
+		defer func() {
+			close(respChan)
+		}()
+		errChan <- nil
+		respChan <- compute.VirtualMachineScaleSet{}
+	}()
+	return respChan, errChan
+}
+
+//ListVirtualMachineScaleSetVMs mock
+func (mc *MockACSEngineClient) ListVirtualMachineScaleSetVMs(resourceGroup, virtualMachineScaleSet string) (compute.VirtualMachineScaleSetVMListResult, error) {
+	if mc.FailDeleteVirtualMachineScaleSetVM {
+		return compute.VirtualMachineScaleSetVMListResult{}, fmt.Errorf("DeleteVirtualMachineScaleSetVM failed")
+	}
+
+	return compute.VirtualMachineScaleSetVMListResult{}, nil
 }
 
 //GetStorageClient mock

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -144,15 +144,6 @@ func (uc *UpgradeCluster) getClusterNodeStatus(subscriptionID uuid.UUID, resourc
 	targetOrchestratorTypeVersion := fmt.Sprintf("%s:%s", uc.DataModel.Properties.OrchestratorProfile.OrchestratorType,
 		uc.DataModel.Properties.OrchestratorProfile.OrchestratorVersion)
 
-	// Loop through all of the scale sets and see if the VMs in the scale
-	// set are at the current targetOrchestratorTypeVersion
-	//
-	// If they are not, then add them to be "ugpraded"
-	//
-	// Subsequently loop through the VMs to be upgrade and add scale up
-	// the VMSS by one and then remove the old node
-	//
-	// The unique identifier of a scale set vm is VmssName:InstanceId
 	vmScaleSets, err := uc.Client.ListVirtualMachineScaleSets(resourceGroup)
 	if err != nil {
 		return err

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -415,12 +415,6 @@ func (ku *Upgrader) upgradeAgentScaleSets() error {
 				return err
 			}
 
-			ku.logger.Infof(
-				"Deleting VM %s in VMSS %s",
-				vmToUpgrade.Name,
-				vmssToUpgrade.Name,
-			)
-
 			// Before we can delete the node we should safely and responsibly drain it
 			var kubeAPIServerURL string
 			getClientTimeout := 10 * time.Second
@@ -440,6 +434,8 @@ func (ku *Upgrader) upgradeAgentScaleSets() error {
 				ku.logger.Errorf("Error getting Kubernetes client: %v", err)
 				return err
 			}
+
+			ku.logger.Infof("Draining node %s", vmToUpgrade.Name)
 			err = operations.SafelyDrainNodeWithClient(
 				client,
 				ku.logger,
@@ -450,6 +446,12 @@ func (ku *Upgrader) upgradeAgentScaleSets() error {
 				ku.logger.Errorf("Error draining VM in VMSS: %v", err)
 				return err
 			}
+
+			ku.logger.Infof(
+				"Deleting VM %s in VMSS %s",
+				vmToUpgrade.Name,
+				vmssToUpgrade.Name,
+			)
 
 			// At this point we have our buffer node that will replace the node to delete
 			// so we can just remove this current node then

--- a/pkg/operations/kubernetesupgrade/upgrader.go
+++ b/pkg/operations/kubernetesupgrade/upgrader.go
@@ -466,13 +466,13 @@ func (ku *Upgrader) upgradeAgentScaleSets() error {
 			case <-res:
 				ku.logger.Infof(
 					"Successfully deleted VM %s in VMSS %s",
-					vmToUpgrade,
+					vmToUpgrade.Name,
 					vmssToUpgrade.Name,
 				)
 			case err := <-failure:
 				ku.logger.Errorf(
 					"Failed to delete VM %s in VMSS %s",
-					vmToUpgrade,
+					vmToUpgrade.Name,
 					vmssToUpgrade,
 				)
 				return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: this PR will add support for upgrading (`acs-engine upgrade`) a Kubernetes cluster that includes one or more virtual machine scale sets for their agent pools.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3122 

**Special notes for your reviewer**: this is currently a work in progress

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add support to upgrade a Kubernetes cluster that contains one or more virtual machine scale sets for agent pools
```

// cc @sozercan 
