### PR TITLE
Merge fields of AAD profile during update

### DIFF
--- a/pkg/api/agentPoolOnlyApi/v20180331/merge.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/merge.go
@@ -2,6 +2,8 @@ package v20180331
 
 import (
 	"fmt"
+
+	"github.com/imdario/mergo"
 )
 
 // Merge existing ManagedCluster attribute into mc
@@ -37,9 +39,15 @@ func (mc *ManagedCluster) Merge(emc *ManagedCluster) error {
 		// For update scenario, the default behavior is to use existing behavior
 		mc.Properties.NetworkProfile = emc.Properties.NetworkProfile
 	}
-	if mc.Properties.AADProfile == nil {
-		// For update scenario, the default behavior is to use existing behavior
-		mc.Properties.AADProfile = emc.Properties.AADProfile
+
+	if emc.Properties.AADProfile != nil {
+		if mc.Properties.AADProfile == nil {
+			mc.Properties.AADProfile = &AADProfile{}
+		}
+		if err := mergo.Merge(mc.Properties.AADProfile,
+			*emc.Properties.AADProfile); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/api/agentPoolOnlyApi/v20180331/merge_test.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/merge_test.go
@@ -163,3 +163,240 @@ func TestMerge_EnableRBAC(t *testing.T) {
 	}
 
 }
+
+func TestMerge_AAD(t *testing.T) {
+	// Partial AAD profile was passed during update
+	newMC := &ManagedCluster{
+		Properties: &Properties{
+			EnableRBAC: helpers.PointerToBool(true),
+			AADProfile: &AADProfile{
+				ClientAppID: "1234-5",
+				ServerAppID: "1a34-5",
+				TenantID:    "c234-5",
+			},
+		},
+	}
+
+	existingMC := &ManagedCluster{
+		Properties: &Properties{
+			DNSPrefix:  "something",
+			EnableRBAC: helpers.PointerToBool(true),
+			AADProfile: &AADProfile{
+				ClientAppID:     "1234-5",
+				ServerAppID:     "1a34-5",
+				ServerAppSecret: "ba34-5",
+				TenantID:        "c234-5",
+			},
+		},
+	}
+
+	e := newMC.Merge(existingMC)
+	if e != nil {
+		t.Error("expect error to be nil")
+	}
+
+	if newMC.Properties.AADProfile == nil {
+		t.Error("AADProfile should not be nil")
+	}
+
+	if newMC.Properties.AADProfile.ServerAppSecret == "" {
+		t.Error("ServerAppSecret should not be empty")
+	}
+
+	if newMC.Properties.AADProfile.ServerAppID != "1a34-5" {
+		t.Error("ServerAppID should not be empty")
+	}
+
+	if newMC.Properties.AADProfile.ServerAppSecret != "ba34-5" {
+		t.Error("ServerAppSecret should not be empty")
+	}
+
+	if newMC.Properties.AADProfile.ClientAppID != "1234-5" {
+		t.Error("ClientAppID should not be empty")
+	}
+
+	if newMC.Properties.AADProfile.TenantID != "c234-5" {
+		t.Error("TenantID should not be empty")
+	}
+
+	// Nil AAD profile was passed during update but DM had AAD Profile
+	newMC = &ManagedCluster{
+		Properties: &Properties{
+			EnableRBAC: helpers.PointerToBool(true),
+			AADProfile: nil,
+		},
+	}
+
+	existingMC = &ManagedCluster{
+		Properties: &Properties{
+			DNSPrefix:  "something",
+			EnableRBAC: helpers.PointerToBool(true),
+			AADProfile: &AADProfile{
+				ClientAppID:     "1234-5",
+				ServerAppID:     "1a34-5",
+				ServerAppSecret: "ba34-5",
+				TenantID:        "c234-5",
+			},
+		},
+	}
+
+	e = newMC.Merge(existingMC)
+	if e != nil {
+		t.Error("expect error to be nil")
+	}
+
+	if newMC.Properties.AADProfile == nil {
+		t.Error("AADProfile should not be nil")
+	}
+
+	if newMC.Properties.AADProfile.ServerAppSecret == "" {
+		t.Error("ServerAppSecret should not be empty")
+	}
+
+	if newMC.Properties.AADProfile.ServerAppID != "1a34-5" {
+		t.Error("ServerAppID should not be empty")
+	}
+
+	if newMC.Properties.AADProfile.ServerAppSecret != "ba34-5" {
+		t.Error("ServerAppSecret should not be empty")
+	}
+
+	if newMC.Properties.AADProfile.ClientAppID != "1234-5" {
+		t.Error("ClientAppID should not be empty")
+	}
+
+	if newMC.Properties.AADProfile.TenantID != "c234-5" {
+		t.Error("TenantID should not be empty")
+	}
+
+	// No AAD profile set
+	newMC = &ManagedCluster{
+		Properties: &Properties{
+			EnableRBAC: helpers.PointerToBool(true),
+			AADProfile: nil,
+		},
+	}
+
+	existingMC = &ManagedCluster{
+		Properties: &Properties{
+			DNSPrefix:  "something",
+			EnableRBAC: helpers.PointerToBool(true),
+			AADProfile: nil,
+		},
+	}
+
+	e = newMC.Merge(existingMC)
+	if e != nil {
+		t.Error("expect error to be nil")
+	}
+
+	if newMC.Properties.AADProfile != nil {
+		t.Error("AADProfile should be nil")
+	}
+
+	// Empty field in AAD profile was passed during update but DM had AAD Profile
+	newMC = &ManagedCluster{
+		Properties: &Properties{
+			EnableRBAC: helpers.PointerToBool(true),
+			AADProfile: &AADProfile{
+				ClientAppID:     "1234-5",
+				ServerAppID:     "1a34-5",
+				ServerAppSecret: "",
+				TenantID:        "c234-5",
+			},
+		},
+	}
+
+	existingMC = &ManagedCluster{
+		Properties: &Properties{
+			DNSPrefix:  "something",
+			EnableRBAC: helpers.PointerToBool(true),
+			AADProfile: &AADProfile{
+				ClientAppID:     "1234-5",
+				ServerAppID:     "1a34-5",
+				ServerAppSecret: "ba34-5",
+				TenantID:        "c234-5",
+			},
+		},
+	}
+
+	e = newMC.Merge(existingMC)
+	if e != nil {
+		t.Error("expect error to be nil")
+	}
+
+	if newMC.Properties.AADProfile == nil {
+		t.Error("AADProfile should not be nil")
+	}
+
+	if newMC.Properties.AADProfile.ServerAppID != "1a34-5" {
+		t.Error("ServerAppID should not be empty")
+	}
+
+	if newMC.Properties.AADProfile.ServerAppSecret != "ba34-5" {
+		t.Error("ServerAppSecret should not be empty")
+	}
+
+	if newMC.Properties.AADProfile.ClientAppID != "1234-5" {
+		t.Error("ClientAppID should not be empty")
+	}
+
+	if newMC.Properties.AADProfile.TenantID != "c234-5" {
+		t.Error("TenantID should not be empty")
+	}
+
+	// Full AAD profile was passed during update
+	newMC = &ManagedCluster{
+		Properties: &Properties{
+			EnableRBAC: helpers.PointerToBool(true),
+			AADProfile: &AADProfile{
+				ClientAppID:     "1234-5",
+				ServerAppID:     "1a34-5",
+				ServerAppSecret: "ba34-5",
+				TenantID:        "c234-5",
+			},
+		},
+	}
+
+	existingMC = &ManagedCluster{
+		Properties: &Properties{
+			DNSPrefix:  "something",
+			EnableRBAC: helpers.PointerToBool(true),
+			AADProfile: &AADProfile{
+				ClientAppID:     "1234-5",
+				ServerAppID:     "1a34-5",
+				ServerAppSecret: "ba34-5",
+				TenantID:        "c234-5",
+			},
+		},
+	}
+
+	e = newMC.Merge(existingMC)
+	if e != nil {
+		t.Error("expect error to be nil")
+	}
+
+	if newMC.Properties.AADProfile == nil {
+		t.Error("AADProfile should not be nil")
+	}
+
+	if newMC.Properties.AADProfile.ServerAppSecret == "" {
+		t.Error("ServerAppSecret should not be empty")
+	}
+
+	if newMC.Properties.AADProfile.ServerAppID != "1a34-5" {
+		t.Error("ServerAppID should not be empty")
+	}
+
+	if newMC.Properties.AADProfile.ServerAppSecret != "ba34-5" {
+		t.Error("ServerAppSecret should not be empty")
+	}
+
+	if newMC.Properties.AADProfile.ClientAppID != "1234-5" {
+		t.Error("ClientAppID should not be empty")
+	}
+
+	if newMC.Properties.AADProfile.TenantID != "c234-5" {
+		t.Error("TenantID should not be empty")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR is needed because during update (scale/upgrade) customer's might not set all the fields. In that cases merge of existing and new data models needs to happen for further validation

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
