### PR TITLE
Wait for cloud-init to complete before pkg cache is updated

### DIFF
--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -475,6 +475,8 @@ configAddons() {
 
 testOutboundConnection
 
+waitForCloudInit
+
 if [[ $OS == $UBUNTU_OS_NAME ]]; then
     echo `date`,`hostname`, apt-get_update_begin>>/opt/m
     apt_get_update || exit $ERR_APT_INSTALL_TIMEOUT
@@ -483,8 +485,6 @@ if [[ $OS == $UBUNTU_OS_NAME ]]; then
 	retrycmd_if_failure 20 5 30 apt-mark hold walinuxagent || exit $ERR_HOLD_WALINUXAGENT
 
 fi
-
-waitForCloudInit
 
 if [[ ! -z "${MASTER_NODE}" ]]; then
     echo "executing master node provision operations"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This makes the cluster provisioning wait until cloud-init configuration has completed prior to updating the cache. A part of the cloud-init configuration includes adding apt source (templating), and it appears as though there was a race condition causing transient failures (for more information, please see #3204).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3204

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix race condition for pkg cache updating prior to cloud-init completion
```
