### PR TITLE
Kubernetes: Remove Windows-specific foo for control plane config

### DIFF
--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -43,13 +43,8 @@ func setAPIServerConfig(cs *api.ContainerService) {
 		"--audit-log-maxsize":   "100",
 	}
 
-	// Data Encryption at REST configuration
-	if helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableDataEncryptionAtRest) {
-		staticAPIServerConfig["--experimental-encryption-provider-config"] = "/etc/kubernetes/encryption-config.yaml"
-	}
-
-	// Data Encryption at REST with external KMS configuration
-	if helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableEncryptionWithExternalKms) {
+	// Data Encryption at REST configuration conditions
+	if helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableDataEncryptionAtRest) || helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableEncryptionWithExternalKms) {
 		staticAPIServerConfig["--experimental-encryption-provider-config"] = "/etc/kubernetes/encryption-config.yaml"
 	}
 

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -10,7 +10,7 @@ import (
 
 func setAPIServerConfig(cs *api.ContainerService) {
 	o := cs.Properties.OrchestratorProfile
-	staticLinuxAPIServerConfig := map[string]string{
+	staticAPIServerConfig := map[string]string{
 		"--bind-address":               "0.0.0.0",
 		"--advertise-address":          "<kubernetesAPIServerIP>",
 		"--allow-privileged":           "true",
@@ -36,13 +36,6 @@ func setAPIServerConfig(cs *api.ContainerService) {
 		"--v":                          "4",
 	}
 
-	// Windows apiserver config overrides
-	// TODO placeholder for specific config overrides for Windows clusters
-	staticWindowsAPIServerConfig := make(map[string]string)
-	for key, val := range staticLinuxAPIServerConfig {
-		staticWindowsAPIServerConfig[key] = val
-	}
-
 	// Default apiserver config
 	defaultAPIServerConfig := map[string]string{
 		"--audit-log-maxage":    "30",
@@ -52,12 +45,12 @@ func setAPIServerConfig(cs *api.ContainerService) {
 
 	// Data Encryption at REST configuration
 	if helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableDataEncryptionAtRest) {
-		staticLinuxAPIServerConfig["--experimental-encryption-provider-config"] = "/etc/kubernetes/encryption-config.yaml"
+		staticAPIServerConfig["--experimental-encryption-provider-config"] = "/etc/kubernetes/encryption-config.yaml"
 	}
 
 	// Data Encryption at REST with external KMS configuration
 	if helpers.IsTrueBoolPointer(o.KubernetesConfig.EnableEncryptionWithExternalKms) {
-		staticLinuxAPIServerConfig["--experimental-encryption-provider-config"] = "/etc/kubernetes/encryption-config.yaml"
+		staticAPIServerConfig["--experimental-encryption-provider-config"] = "/etc/kubernetes/encryption-config.yaml"
 	}
 
 	// Aggregated API configuration
@@ -73,8 +66,8 @@ func setAPIServerConfig(cs *api.ContainerService) {
 
 	// Enable cloudprovider if we're not using cloud controller manager
 	if !helpers.IsTrueBoolPointer(o.KubernetesConfig.UseCloudControllerManager) {
-		staticLinuxAPIServerConfig["--cloud-provider"] = "azure"
-		staticLinuxAPIServerConfig["--cloud-config"] = "/etc/kubernetes/azure.json"
+		staticAPIServerConfig["--cloud-provider"] = "azure"
+		staticAPIServerConfig["--cloud-config"] = "/etc/kubernetes/azure.json"
 	}
 
 	// AAD configuration
@@ -91,7 +84,7 @@ func setAPIServerConfig(cs *api.ContainerService) {
 
 	// Audit Policy configuration
 	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.8.0") {
-		staticLinuxAPIServerConfig["--audit-policy-file"] = "/etc/kubernetes/manifests/audit-policy.yaml"
+		staticAPIServerConfig["--audit-policy-file"] = "/etc/kubernetes/manifests/audit-policy.yaml"
 	}
 
 	// RBAC configuration
@@ -122,13 +115,7 @@ func setAPIServerConfig(cs *api.ContainerService) {
 
 	// We don't support user-configurable values for the following,
 	// so any of the value assignments below will override user-provided values
-	var overrideAPIServerConfig map[string]string
-	if cs.Properties.HasWindows() {
-		overrideAPIServerConfig = staticWindowsAPIServerConfig
-	} else {
-		overrideAPIServerConfig = staticLinuxAPIServerConfig
-	}
-	for key, val := range overrideAPIServerConfig {
+	for key, val := range staticAPIServerConfig {
 		o.KubernetesConfig.APIServerConfig[key] = val
 	}
 

--- a/pkg/acsengine/defaults-cloud-controller-manager.go
+++ b/pkg/acsengine/defaults-cloud-controller-manager.go
@@ -8,7 +8,7 @@ import (
 
 func setCloudControllerManagerConfig(cs *api.ContainerService) {
 	o := cs.Properties.OrchestratorProfile
-	staticLinuxCloudControllerManagerConfig := map[string]string{
+	staticCloudControllerManagerConfig := map[string]string{
 		"--allocate-node-cidrs":    strconv.FormatBool(!o.IsAzureCNI()),
 		"--configure-cloud-routes": strconv.FormatBool(o.RequireRouteTable()),
 		"--cloud-provider":         "azure",
@@ -21,17 +21,10 @@ func setCloudControllerManagerConfig(cs *api.ContainerService) {
 
 	// Set --cluster-name based on appropriate DNS prefix
 	if cs.Properties.MasterProfile != nil {
-		staticLinuxCloudControllerManagerConfig["--cluster-name"] = cs.Properties.MasterProfile.DNSPrefix
+		staticCloudControllerManagerConfig["--cluster-name"] = cs.Properties.MasterProfile.DNSPrefix
 	} else if cs.Properties.HostedMasterProfile != nil {
-		staticLinuxCloudControllerManagerConfig["--cluster-name"] = cs.Properties.HostedMasterProfile.DNSPrefix
+		staticCloudControllerManagerConfig["--cluster-name"] = cs.Properties.HostedMasterProfile.DNSPrefix
 	}
-
-	staticWindowsCloudControllerManagerConfig := make(map[string]string)
-	for key, val := range staticLinuxCloudControllerManagerConfig {
-		staticWindowsCloudControllerManagerConfig[key] = val
-	}
-	// Windows cloud-controller-manager config overrides
-	// TODO placeholder for specific config overrides for Windows clusters
 
 	// Default cloud-controller-manager config
 	defaultCloudControllerManagerConfig := map[string]string{
@@ -53,13 +46,7 @@ func setCloudControllerManagerConfig(cs *api.ContainerService) {
 
 	// We don't support user-configurable values for the following,
 	// so any of the value assignments below will override user-provided values
-	var overrideCloudControllerManagerConfig map[string]string
-	if cs.Properties.HasWindows() {
-		overrideCloudControllerManagerConfig = staticWindowsCloudControllerManagerConfig
-	} else {
-		overrideCloudControllerManagerConfig = staticLinuxCloudControllerManagerConfig
-	}
-	for key, val := range overrideCloudControllerManagerConfig {
+	for key, val := range staticCloudControllerManagerConfig {
 		o.KubernetesConfig.CloudControllerManagerConfig[key] = val
 	}
 

--- a/pkg/acsengine/defaults-scheduler.go
+++ b/pkg/acsengine/defaults-scheduler.go
@@ -4,8 +4,8 @@ import (
 	"github.com/Azure/acs-engine/pkg/api"
 )
 
-// staticLinuxSchedulerConfig is not user-overridable
-var staticLinuxSchedulerConfig = map[string]string{
+// staticSchedulerConfig is not user-overridable
+var staticSchedulerConfig = map[string]string{
 	"--kubeconfig":   "/var/lib/kubelet/kubeconfig",
 	"--leader-elect": "true",
 	"--profiling":    "false",
@@ -18,12 +18,6 @@ var defaultSchedulerConfig = map[string]string{
 
 func setSchedulerConfig(cs *api.ContainerService) {
 	o := cs.Properties.OrchestratorProfile
-	staticWindowsSchedulerConfig := make(map[string]string)
-	for key, val := range staticLinuxSchedulerConfig {
-		staticWindowsSchedulerConfig[key] = val
-	}
-	// Windows scheduler config overrides
-	// TODO placeholder for specific config overrides for Windows clusters
 
 	// If no user-configurable scheduler config values exists, use the defaults
 	if o.KubernetesConfig.SchedulerConfig == nil {
@@ -40,13 +34,7 @@ func setSchedulerConfig(cs *api.ContainerService) {
 
 	// We don't support user-configurable values for the following,
 	// so any of the value assignments below will override user-provided values
-	var overrideSchedulerConfig map[string]string
-	if cs.Properties.HasWindows() {
-		overrideSchedulerConfig = staticWindowsSchedulerConfig
-	} else {
-		overrideSchedulerConfig = staticLinuxSchedulerConfig
-	}
-	for key, val := range overrideSchedulerConfig {
+	for key, val := range staticSchedulerConfig {
 		o.KubernetesConfig.SchedulerConfig[key] = val
 	}
 }

--- a/pkg/acsengine/defaults-scheduler_test.go
+++ b/pkg/acsengine/defaults-scheduler_test.go
@@ -8,7 +8,7 @@ func TestSchedulerDefaultConfig(t *testing.T) {
 	cs := createContainerService("testcluster", "1.9.6", 3, 2)
 	setSchedulerConfig(cs)
 	s := cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig
-	for key, val := range staticLinuxSchedulerConfig {
+	for key, val := range staticSchedulerConfig {
 		if val != s[key] {
 			t.Fatalf("got unexpected kube-scheduler static config value for %s. Expected %s, got %s",
 				key, val, s[key])
@@ -46,7 +46,7 @@ func TestSchedulerStaticConfig(t *testing.T) {
 		"--profiling":    "user-override",
 	}
 	setSchedulerConfig(cs)
-	for key, val := range staticLinuxSchedulerConfig {
+	for key, val := range staticSchedulerConfig {
 		if val != cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig[key] {
 			t.Fatalf("kube-scheduler static config did not override user values for %s. Expected %s, got %s",
 				key, val, cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Since we don't have any support for Windows-backed control plane components, and we don't have any need to discretely configure the control plane if the cluster has Windows nodes, all of the Windows-specific code paths in the following componentry are bogon:

- apiserver
- controller-manager
- kube-scheduler
- cloud-controller-manager

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3219

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Kubernetes: Remove Windows-specific foo for control plane config
```