### PR TITLE
Fixing panic issue in Validate when properties are nil

### DIFF
--- a/pkg/api/apiloader.go
+++ b/pkg/api/apiloader.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"reflect"
 
+	"fmt"
+
 	"github.com/Azure/acs-engine/pkg/api/agentPoolOnlyApi/v20170831"
 	"github.com/Azure/acs-engine/pkg/api/agentPoolOnlyApi/v20180331"
 	apvlabs "github.com/Azure/acs-engine/pkg/api/agentPoolOnlyApi/vlabs"
@@ -82,6 +84,9 @@ func (a *Apiloader) LoadContainerService(
 			}
 		}
 		setContainerServiceDefaultsv20160930(containerService)
+		if containerService.Properties == nil {
+			return nil, fmt.Errorf("missing ContainerService Properties")
+		}
 		if e := containerService.Properties.Validate(); validate && e != nil {
 			return nil, e
 		}
@@ -102,6 +107,9 @@ func (a *Apiloader) LoadContainerService(
 			}
 		}
 		setContainerServiceDefaultsv20160330(containerService)
+		if containerService.Properties == nil {
+			return nil, fmt.Errorf("missing ContainerService Properties")
+		}
 		if e := containerService.Properties.Validate(); validate && e != nil {
 			return nil, e
 		}
@@ -123,6 +131,9 @@ func (a *Apiloader) LoadContainerService(
 			}
 		}
 		setContainerServiceDefaultsv20170131(containerService)
+		if containerService.Properties == nil {
+			return nil, fmt.Errorf("missing ContainerService Properties")
+		}
 		if e := containerService.Properties.Validate(); validate && e != nil {
 			return nil, e
 		}
@@ -142,6 +153,9 @@ func (a *Apiloader) LoadContainerService(
 			if e := containerService.Merge(vecs); e != nil {
 				return nil, e
 			}
+		}
+		if containerService.Properties == nil {
+			return nil, fmt.Errorf("missing ContainerService Properties")
 		}
 		if e := containerService.Properties.Validate(isUpdate); validate && e != nil {
 			return nil, e
@@ -167,6 +181,9 @@ func (a *Apiloader) LoadContainerService(
 			if e := containerService.Merge(vecs); e != nil {
 				return nil, e
 			}
+		}
+		if containerService.Properties == nil {
+			return nil, fmt.Errorf("missing ContainerService Properties")
 		}
 		if e := containerService.Properties.Validate(isUpdate); validate && e != nil {
 			return nil, e

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -96,6 +96,9 @@ func init() {
 
 // Validate implements APIObject
 func (a *Properties) Validate(isUpdate bool) error {
+	if a == nil {
+		return fmt.Errorf("missing ContainerService Properties")
+	}
 	if e := validate.Struct(a); e != nil {
 		return handleValidationErrors(e.(validator.ValidationErrors))
 	}

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -852,6 +852,15 @@ func Test_Properties_ValidateAddons(t *testing.T) {
 	}
 }
 
+func TestPropertiesValidationNil(t *testing.T) {
+	containerService := &ContainerService{}
+	err := containerService.Properties.Validate(true)
+	expected := "missing ContainerService Properties"
+	if err == nil || err.Error() != expected {
+		t.Errorf("Expected error with message %s", expected)
+	}
+}
+
 func TestWindowsVersions(t *testing.T) {
 	for _, version := range common.GetAllSupportedKubernetesVersionsWindows() {
 		p := getK8sDefaultProperties(true)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Avoiding panics during validation

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2586 fixes #1820

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [x] unit tests
- [x] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
