### PR TITLE
Add cluster-autoscaler addon documentation

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -103,7 +103,7 @@ As you can see above, `addons` is an array child property of `kubernetesConfig`.
 }
 ```
 
-More usefully, let's add some custom configuration to both of the above addons:
+More usefully, let's add some custom configuration to the above addons:
 
 ```
 "kubernetesConfig": {

--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -69,6 +69,7 @@ Here are the valid values for the orchestrator types:
 |tiller|true|1|Delivers the Helm server-side component: tiller. See https://github.com/kubernetes/helm for more info|
 |kubernetes-dashboard|true|1|Delivers the kubernetes dashboard component. See https://github.com/kubernetes/dashboard for more info|
 |rescheduler|false|1|Delivers the kubernetes rescheduler component|
+|cluster-autoscaler|false|1|Delivers the kubernetes cluster autoscaler component. See https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/azure for more info|
 
 To give a bit more info on the `addons` property: We've tried to expose the basic bits of data that allow useful configuration of these cluster features. Here are some example usage patterns that will unpack what `addons` provide:
 
@@ -131,6 +132,22 @@ More usefully, let's add some custom configuration to both of the above addons:
                   "memoryLimits": "512Mi"
                 }
               ]
+        },
+        {
+            "name": "cluster-autoscaler",
+            "containers": [
+              {
+                "name": "cluster-autoscaler",
+                "cpuRequests": "100m",
+                "memoryRequests": "300Mi",
+                "cpuLimits": "100m",
+                "memoryLimits": "300Mi"
+              }
+            ],
+            "config": {
+              "maxNodes": "5",
+              "minNodes": "1"
+            }
         }
     ]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
It mentions cluster-autoscaler add-on in cluster definition documentation. The feature is present in acs-engine but it is not documented and because of it users are not able to use it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [x] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
