### PR TITLE
DCOS: use CDN to host Windows bootstrap binaries

### DIFF
--- a/parts/dcos/dcosWindowsProvision.ps1
+++ b/parts/dcos/dcosWindowsProvision.ps1
@@ -124,7 +124,7 @@ Get-BootstrapScript($download_uri, $download_dir)
     # Get Mesos Binaries
     $scriptfile = "DCOSWindowsAgentSetup.ps1"
 
-    Write-Log " get script "+ ($download_uri+"/"+$scriptfile) + "and put it "+ ($download_dir+"\"+$scriptfile)
+    Write-Log "get script $download_uri/$scriptfile and put it $download_dir\$scriptfile"
 
     Invoke-WebRequest -Uri ($download_uri+"/"+$scriptfile) -OutFile ($download_dir+"\"+$scriptfile)
 }
@@ -193,6 +193,7 @@ try
         $run_cmd += ">"+$global:BootstrapInstallDir+"\DCOSWindowsAgentSetup.log 2>&1"
         Write-Log "run setup script $run_cmd"
         Invoke-Expression $run_cmd
+        Write-Log "setup script completed"
     }
     else # We must be deploying a master
     {
@@ -202,9 +203,12 @@ try
     }
 
     PREPROVISION_EXTENSION
+
+    Write-Log "Provisioning script succeeded"
 }
 catch
 {
+    Write-Log "Provisioning script failed"
     Write-Error $_
     exit 1
 }

--- a/parts/dcos/dcosparams.t
+++ b/parts/dcos/dcosparams.t
@@ -6,7 +6,7 @@
       "type": "string"
     },
     "dcosWindowsBootstrapURL": {
-      "defaultValue": "http://dcos-win.westus.cloudapp.azure.com/dcos-windows/stable/",
+      "defaultValue": "https://dcos-mirror.azureedge.net/winagent",
       "metadata": {
         "description": "The default mesosphere bootstrap package location for windows."
       },

--- a/parts/dcos/dcosparams.t
+++ b/parts/dcos/dcosparams.t
@@ -6,7 +6,7 @@
       "type": "string"
     },
     "dcosWindowsBootstrapURL": {
-      "defaultValue": "https://dcos-mirror.azureedge.net/winagent",
+      "defaultValue": "http://dcos-win.westus.cloudapp.azure.com/dcos-windows/stable/",
       "metadata": {
         "description": "The default mesosphere bootstrap package location for windows."
       },

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -50,7 +50,7 @@ var (
 		DCOS198BootstrapDownloadURL:     fmt.Sprintf(AzureEdgeDCOSBootstrapDownloadURL, "stable/1.9.8", "f4ae0d20665fc68ee25282d6f78681b2773c6e10"),
 		DCOS110BootstrapDownloadURL:     fmt.Sprintf(AzureEdgeDCOSBootstrapDownloadURL, "stable/1.10.0", "4d92536e7381176206e71ee15b5ffe454439920c"),
 		DCOS111BootstrapDownloadURL:     fmt.Sprintf(AzureEdgeDCOSBootstrapDownloadURL, "stable/1.11.0", "a0654657903fb68dff60f6e522a7f241c1bfbf0f"),
-		DCOSWindowsBootstrapDownloadURL: "http://dcos-win.westus.cloudapp.azure.com/dcos-windows/stable/",
+		DCOSWindowsBootstrapDownloadURL: "https://dcos-mirror.azureedge.net/winagent/",
 		DcosRepositoryURL:               "https://dcosio.azureedge.net/dcos/stable/1.11.0",
 		DcosClusterPackageListID:        "248a66388bba1adbcb14a52fd3b7b424ab06fa76",
 	}

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -50,7 +50,7 @@ var (
 		DCOS198BootstrapDownloadURL:     fmt.Sprintf(AzureEdgeDCOSBootstrapDownloadURL, "stable/1.9.8", "f4ae0d20665fc68ee25282d6f78681b2773c6e10"),
 		DCOS110BootstrapDownloadURL:     fmt.Sprintf(AzureEdgeDCOSBootstrapDownloadURL, "stable/1.10.0", "4d92536e7381176206e71ee15b5ffe454439920c"),
 		DCOS111BootstrapDownloadURL:     fmt.Sprintf(AzureEdgeDCOSBootstrapDownloadURL, "stable/1.11.0", "a0654657903fb68dff60f6e522a7f241c1bfbf0f"),
-		DCOSWindowsBootstrapDownloadURL: "https://dcos-mirror.azureedge.net/winagent/",
+		DCOSWindowsBootstrapDownloadURL: "http://dcos-win.westus.cloudapp.azure.com/dcos-windows/stable/",
 		DcosRepositoryURL:               "https://dcosio.azureedge.net/dcos/stable/1.11.0",
 		DcosClusterPackageListID:        "248a66388bba1adbcb14a52fd3b7b424ab06fa76",
 	}
@@ -620,9 +620,6 @@ func setOrchestratorDefaults(cs *api.ContainerService) {
 	case api.DCOS:
 		if o.DcosConfig == nil {
 			o.DcosConfig = &api.DcosConfig{}
-		}
-		if o.DcosConfig.DcosWindowsBootstrapURL == "" {
-			o.DcosConfig.DcosWindowsBootstrapURL = DefaultDCOSSpecConfig.DCOSWindowsBootstrapDownloadURL
 		}
 		dcosSemVer, _ := semver.Make(o.OrchestratorVersion)
 		dcosBootstrapSemVer, _ := semver.Make(common.DCOSVersion1Dot11Dot0)

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -368,6 +368,18 @@ func getDCOSDefaultBootstrapInstallerURL(profile *api.OrchestratorProfile) strin
 	return ""
 }
 
+func getDCOSDefaultWindowsBootstrapInstallerURL(profile *api.OrchestratorProfile) string {
+	if profile.OrchestratorType == api.DCOS {
+		switch profile.OrchestratorVersion {
+		case common.DCOSVersion1Dot11Dot2:
+			return "https://dcos-mirror.azureedge.net/dcos-windows/1-11-2"
+		case common.DCOSVersion1Dot11Dot0:
+			return "https://dcos-mirror.azureedge.net/dcos-windows/1-11-0"
+		}
+	}
+	return ""
+}
+
 func getDCOSDefaultProviderPackageGUID(orchestratorType string, orchestratorVersion string, masterCount int) string {
 	if orchestratorType == api.DCOS {
 		switch orchestratorVersion {

--- a/pkg/acsengine/params.go
+++ b/pkg/acsengine/params.go
@@ -122,6 +122,7 @@ func getParameters(cs *api.ContainerService, isClassicMode bool, generatorCode s
 				dcosBootstrapURL = cloudSpecConfig.DCOSSpecConfig.DCOS110BootstrapDownloadURL
 			default:
 				dcosBootstrapURL = getDCOSDefaultBootstrapInstallerURL(properties.OrchestratorProfile)
+				dcosWindowsBootstrapURL = getDCOSDefaultWindowsBootstrapInstallerURL(properties.OrchestratorProfile)
 			}
 		}
 


### PR DESCRIPTION
Using Microsoft CDN to host Windows bootstrap binaries