### PR TITLE
quote base64 strings in the yaml files; use k8s compatible encoding for base64 values

### DIFF
--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -287,7 +287,7 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
 {{end}}
 
 {{if EnableDataEncryptionAtRest }}
-    sed -i "s|<etcdEncryptionSecret>|{{WrapAsVariable "etcdEncryptionKey"}}|g" "/etc/kubernetes/encryption-config.yaml"
+    sed -i "s|<etcdEncryptionSecret>|\"{{WrapAsVariable "etcdEncryptionKey"}}\"|g" "/etc/kubernetes/encryption-config.yaml"
 {{end}}
 
 {{if eq .OrchestratorProfile.KubernetesConfig.NetworkPolicy "calico"}}
@@ -297,9 +297,9 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
 {{if eq .OrchestratorProfile.KubernetesConfig.NetworkPolicy "cilium"}}
     # If Cilium Policy enabled then update the etcd certs and address
     sed -i "s|<ETCD_URL>|{{WrapAsVerbatim "variables('masterEtcdClientURLs')[copyIndex(variables('masterOffset'))]"}}|g" "/etc/kubernetes/addons/cilium-daemonset.yaml"
-    sed -i "s|<ETCD_CA>|$(base64 -w 0 /etc/kubernetes/certs/ca.crt)|g" "/etc/kubernetes/addons/cilium-daemonset.yaml"
-    sed -i "s|<ETCD_CLIENT_KEY>|$(base64 -w 0 /etc/kubernetes/certs/etcdclient.key)|g" "/etc/kubernetes/addons/cilium-daemonset.yaml"
-    sed -i "s|<ETCD_CLIENT_CERT>|$(base64 -w 0 /etc/kubernetes/certs/etcdclient.crt)|g" "/etc/kubernetes/addons/cilium-daemonset.yaml"
+    sed -i "s|<ETCD_CA>|\"$(base64 -w 0 /etc/kubernetes/certs/ca.crt)\"|g" "/etc/kubernetes/addons/cilium-daemonset.yaml"
+    sed -i "s|<ETCD_CLIENT_KEY>|\"$(base64 -w 0 /etc/kubernetes/certs/etcdclient.key)\"|g" "/etc/kubernetes/addons/cilium-daemonset.yaml"
+    sed -i "s|<ETCD_CLIENT_CERT>|\"$(base64 -w 0 /etc/kubernetes/certs/etcdclient.crt)\"|g" "/etc/kubernetes/addons/cilium-daemonset.yaml"
 {{end}}
 {{if UseCloudControllerManager }}
     sed -i "s|<kubernetesCcmImageSpec>|{{WrapAsVariable "kubernetesCcmImageSpec"}}|g" "/etc/kubernetes/manifests/cloud-controller-manager.yaml"

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -1087,5 +1087,5 @@ func k8sVersionMetricsServerAddonEnabled(o *api.OrchestratorProfile) *bool {
 func generateEtcdEncryptionKey() string {
 	b := make([]byte, 32)
 	rand.Read(b)
-	return base64.URLEncoding.EncodeToString(b)
+	return base64.stdencoding.EncodeToString(b)
 }

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -1087,5 +1087,5 @@ func k8sVersionMetricsServerAddonEnabled(o *api.OrchestratorProfile) *bool {
 func generateEtcdEncryptionKey() string {
 	b := make([]byte, 32)
 	rand.Read(b)
-	return base64.stdencoding.EncodeToString(b)
+	return base64.StdEncoding.EncodeToString(b)
 }

--- a/pkg/acsengine/defaults_test.go
+++ b/pkg/acsengine/defaults_test.go
@@ -393,7 +393,7 @@ func TestGenerateEtcdEncryptionKey(t *testing.T) {
 		t.Fatalf("generateEtcdEncryptionKey should return a unique key each time, instead returned identical %s and %s", key1, key2)
 	}
 	for _, val := range []string{key1, key2} {
-		_, err := base64.URLEncoding.DecodeString(val)
+		_, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {
 			t.Fatalf("generateEtcdEncryptionKey should return a base64 encoded key, instead returned %s", val)
 		}

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -209,7 +209,7 @@ func (a *Properties) validateOrchestratorProfile(isUpdate bool) error {
 							minVersion.String(), o.OrchestratorVersion)
 					}
 					if o.KubernetesConfig.EtcdEncryptionKey != "" {
-						_, err = base64.URLEncoding.DecodeString(o.KubernetesConfig.EtcdEncryptionKey)
+						_, err = base64.StdEncoding.DecodeString(o.KubernetesConfig.EtcdEncryptionKey)
 						if err != nil {
 							return fmt.Errorf("etcdEncryptionKey must be base64 encoded. Please provide a valid base64 encoded value or leave the etcdEncryptionKey empty to auto-generate the value")
 						}


### PR DESCRIPTION
**What this PR does / why we need it**:

put double quotes around the base64 strings in the yaml files to protect against base64 strings which contain '-'  (note: not all dialects of base64 have '-' in index 62, some have '+', '_', '~'

this prevents errors in parsing the yaml 

**Which issue this PR fixes**

fixes https://github.com/Azure/acs-engine/issues/3247

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
```release-note
```