### PR TITLE
Adding keyvaultSecretRef usage information to cluster definition docs

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -508,6 +508,13 @@ https://{keyvaultname}.vault.azure.net:443/secrets/{secretName}/{version}
 |clientId|yes, for Kubernetes clusters|describes the Azure client id.  It is recommended to use a separate client ID per cluster|
 |secret|yes, for Kubernetes clusters|describes the Azure client secret.  It is recommended to use a separate client secret per client id|
 |objectId|optional, for Kubernetes clusters|describes the Azure service principal object id.  It is required if enableEncryptionWithExternalKms is true|
+|keyvaultSecretRef.vaultId|no, for Kubernetes clusters|describes the vault id of the keyvault to retrieve the service principal secret from. See below for format.|
+|keyvaultSecretRef.secretName|no, for Kubernetes clusters|describes the name of the service principal secret in keyvault|
+|keyvaultSecretRef.version|no, for Kubernetes clusters|describes the version of the secret to use|
+
+
+format for `keyvaultSecretRef.vaultId`, can be obtained in cli, or found in the portal:
+`/subscriptions/<SUB_ID>/resourceGroups/<RG_NAME>/providers/Microsoft.KeyVault/vaults/<KV_NAME>`. See [keyvault params](../examples/keyvault-params/README.md#service-principal-profile) for an example.
 
 ## Cluster Defintions for apiVersion "2016-03-30"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Adds keyvaultSecretRef usage docs to cluster definition. 

**Which issue this PR fixes**:

None 

**Special notes for your reviewer**:

**If applicable**:
- [x] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
