### PR TITLE
Update Calico to 3.1.3

### DIFF
--- a/examples/networkpolicy/README.md
+++ b/examples/networkpolicy/README.md
@@ -18,7 +18,7 @@ The kubernetes-calico deployment template enables Calico networking and policies
       }
 ```
 
-This template will deploy the [v3.0 release](https://docs.projectcalico.org/v3.0/releases/) of [Kubernetes Datastore Install](https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/) version of calico with the "Calico policy-only with user-supplied networking" which supports kubernetes ingress policies and has some limitations as denoted on the referenced page.
+This template will deploy the [v3.1 release](https://docs.projectcalico.org/v3.1/releases/) of [Kubernetes Datastore Install](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/other) version of calico with the "Calico for policy" with user-supplied networking which supports kubernetes ingress policies.
 
 > Note: The Typha service and deployment is installed on the cluster, but effectively disabled using the default settings of deployment replicas set to 0 and Typha service name not configured.  Typha is recommended to be enabled when scaling to 50+ nodes on the cluster to reduce the load on the Kubernetes API server.  If this functionality is desired to be configurable via the API model, please file an issue on Github requesting this feature be added.  Otherwise, this can be manually changed via modifying and applying changes with the `/etc/kubernetes/addons/calico-daemonset.yaml` file on every master node in the cluster.
 
@@ -28,6 +28,6 @@ To understand how to deploy this template, please read the baseline [Kubernetes]
 
 ### Post installation
 
-Once the template has been successfully deployed, following the [simple policy tutorial](https://docs.projectcalico.org/v3.0/getting-started/kubernetes/tutorials/simple-policy) or the [advanced policy tutorial](https://docs.projectcalico.org/v3.0/getting-started/kubernetes/tutorials/advanced-policy) will help to understand calico networking.
+Once the template has been successfully deployed, following the [simple policy tutorial](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/simple-policy) or the [advanced policy tutorial](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/advanced-policy) will help to understand calico networking.
 
 > Note: `ping` (ICMP) traffic is blocked on the cluster by default.  Wherever `ping` is used in any tutorial substitute testing access with something like `wget -q --timeout=5 google.com -O -` instead.

--- a/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
@@ -1,8 +1,8 @@
-# Calico Version v3.1.1
-# https://docs.projectcalico.org/v3.1/releases#v3.1.1
+# Calico Version v3.1.3
+# https://docs.projectcalico.org/v3.1/releases#v3.1.3
 # This manifest includes the following component versions:
-#   calico/node:v3.1.1
-#   calico/cni:v3.1.1
+#   calico/node:v3.1.3
+#   calico/cni:v3.1.3
 
 apiVersion: v1
 kind: ServiceAccount
@@ -217,7 +217,7 @@ spec:
       # as a host-networked pod.
       serviceAccountName: calico-node
       containers:
-      - image: quay.io/calico/typha:v0.7.2
+      - image: quay.io/calico/typha:v0.7.4
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -314,7 +314,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.1.1
+          image: quay.io/calico/node:v3.1.3
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -393,7 +393,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v3.1.1
+          image: quay.io/calico/cni:v3.1.3
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.


### PR DESCRIPTION
**What this PR does / why we need it**:
A number of fixes and improvements since 3.1.1 as listed [here for 3.1.3](https://github.com/projectcalico/calico/releases/tag/v3.1.3) and [here for 3.1.2](https://github.com/projectcalico/calico/releases/tag/v3.1.2).

```release-note
Update calico to 3.1.3
```
