### PR TITLE
Adding validation for existing ip when using an existing vnet.

### DIFF
--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -311,9 +311,6 @@ func (a *Properties) validateMasterProfile() error {
 		if m.VnetSubnetID != "" && m.FirstConsecutiveStaticIP == "" {
 			return errors.New("when specifying a vnetsubnetid the firstconsecutivestaticip is required")
 		}
-		if m.FirstConsecutiveStaticIP != "" && m.VnetSubnetID == "" {
-			return errors.New("when specifying the firstconsecutivestaticip the vnetsubnetid is required")
-		}
 		if m.StorageProfile != ManagedDisks {
 			return errors.New("OpenShift orchestrator supports only ManagedDisks")
 		}

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -304,12 +304,19 @@ func (a *Properties) validateOrchestratorProfile(isUpdate bool) error {
 
 func (a *Properties) validateMasterProfile() error {
 	m := a.MasterProfile
-	if a.OrchestratorProfile.OrchestratorType == OpenShift && m.Count != 1 {
-		return errors.New("openshift can only deployed with one master")
-	}
-
-	if a.OrchestratorProfile.OrchestratorType == OpenShift && m.StorageProfile != ManagedDisks {
-		return errors.New("OpenShift orchestrator supports only ManagedDisks")
+	if a.OrchestratorProfile.OrchestratorType == OpenShift {
+		if m.Count != 1 {
+			return errors.New("openshift can only deployed with one master")
+		}
+		if m.VnetSubnetID != "" && m.FirstConsecutiveStaticIP == "" {
+			return errors.New("when specifying a vnetsubnetid the firstconsecutivestaticip is required")
+		}
+		if m.FirstConsecutiveStaticIP != "" && m.VnetSubnetID == "" {
+			return errors.New("when specifying the firstconsecutivestaticip the vnetsubnetid is required")
+		}
+		if m.StorageProfile != ManagedDisks {
+			return errors.New("OpenShift orchestrator supports only ManagedDisks")
+		}
 	}
 
 	if m.ImageRef != nil {

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -1008,14 +1008,6 @@ func TestMasterProfileValidate(t *testing.T) {
 			},
 			expectedErr: "when specifying a vnetsubnetid the firstconsecutivestaticip is required",
 		},
-		{ // test existing vnet: run with only specifying firstconsecutivestaticip
-			orchestratorType: OpenShift,
-			masterProfile: MasterProfile{
-				FirstConsecutiveStaticIP: "10.0.0.1",
-				Count: 1,
-			},
-			expectedErr: "when specifying the firstconsecutivestaticip the vnetsubnetid is required",
-		},
 		{ // test existing vnet: run with specifying both vnetsubnetid and firstconsecutivestaticip
 			orchestratorType: OpenShift,
 			masterProfile: MasterProfile{

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -1000,6 +1000,31 @@ func TestMasterProfileValidate(t *testing.T) {
 			},
 			expectedErr: "openshift can only deployed with one master",
 		},
+		{ // test existing vnet: run with only specifying vnetsubnetid
+			orchestratorType: OpenShift,
+			masterProfile: MasterProfile{
+				VnetSubnetID: "testvnetstring",
+				Count:        1,
+			},
+			expectedErr: "when specifying a vnetsubnetid the firstconsecutivestaticip is required",
+		},
+		{ // test existing vnet: run with only specifying firstconsecutivestaticip
+			orchestratorType: OpenShift,
+			masterProfile: MasterProfile{
+				FirstConsecutiveStaticIP: "10.0.0.1",
+				Count: 1,
+			},
+			expectedErr: "when specifying the firstconsecutivestaticip the vnetsubnetid is required",
+		},
+		{ // test existing vnet: run with specifying both vnetsubnetid and firstconsecutivestaticip
+			orchestratorType: OpenShift,
+			masterProfile: MasterProfile{
+				DNSPrefix:                "dummy",
+				VnetSubnetID:             "testvnetstring",
+				FirstConsecutiveStaticIP: "10.0.0.1",
+				Count: 1,
+			},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
I am adding validation for the firstconsecutivestaticip when using an existing vnet.

The previous https://github.com/Azure/acs-engine/pull/3162 version broke the e2e openshift tests.

I ran the e2e tests locally for this PR and issue has been fixed.