### PR TITLE
Change dns healthcheck to look at external domain

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-kube-dns-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-kube-dns-deployment.yaml
@@ -146,12 +146,15 @@ spec:
         - mountPath: /kube-dns-config
           name: kube-dns-config
       - args:
-        - "--cmd=nslookup bing.com 127.0.0.1 >/dev/null"
+        - "--cmd=for d in $PROBE_DOMAINS; do nslookup $d 127.0.0.1 >/dev/null || exit 1; done"
         - "--url=/healthz-dnsmasq"
-        - "--cmd=nslookup bing.com 127.0.0.1:10053 >/dev/null"
+        - "--cmd=for d in $PROBE_DOMAINS; do nslookup $d 127.0.0.1:10053 >/dev/null || exit 1; done"
         - "--url=/healthz-kubedns"
         - "--port=8080"
         - "--quiet"
+        env:
+        - name: PROBE_DOMAINS
+          value: bing.com kubernetes.default.svc.<kubernetesKubeletClusterDomain>
         image: <kubernetesExecHealthzSpec>
         livenessProbe:
           failureThreshold: 5

--- a/parts/k8s/addons/kubernetesmasteraddons-kube-dns-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-kube-dns-deployment.yaml
@@ -146,9 +146,9 @@ spec:
         - mountPath: /kube-dns-config
           name: kube-dns-config
       - args:
-        - "--cmd=nslookup kubernetes.default.svc.<kubernetesKubeletClusterDomain> 127.0.0.1 >/dev/null"
+        - "--cmd=nslookup bing.com 127.0.0.1 >/dev/null"
         - "--url=/healthz-dnsmasq"
-        - "--cmd=nslookup kubernetes.default.svc.<kubernetesKubeletClusterDomain> 127.0.0.1:10053 >/dev/null"
+        - "--cmd=nslookup bing.com 127.0.0.1:10053 >/dev/null"
         - "--url=/healthz-kubedns"
         - "--port=8080"
         - "--quiet"


### PR DESCRIPTION
**What this PR does / why we need it**: The healthcheck for kube-dns should ensure it is possible with recursive queries to detect network issues outside the cluster. Related to #2971.

**Special notes for your reviewer**: Implements the suggested solution from [this comment](https://github.com/Azure/acs-engine/issues/2971#issuecomment-391882841)