### PR TITLE
openshift: output docker logs in event of failure to start service

### DIFF
--- a/parts/openshift/release-3.9/openshiftmasterscript.sh
+++ b/parts/openshift/release-3.9/openshiftmasterscript.sh
@@ -36,7 +36,11 @@ fi
 # to ResourceDisk.MountOptions in /etc/waagent.conf and remove this stanza.
 systemctl stop docker.service
 restorecon -R /var/lib/docker
-systemctl start docker.service
+rv=0; systemctl start docker.service || rv=$?
+if [ $rv -ne 0 ]; then
+	journalctl -u docker.service
+	exit $rv
+fi
 
 echo "BOOTSTRAP_CONFIG_NAME=node-config-master" >>/etc/sysconfig/${SERVICE_TYPE}-node
 

--- a/parts/openshift/unstable/openshiftmasterscript.sh
+++ b/parts/openshift/unstable/openshiftmasterscript.sh
@@ -37,7 +37,11 @@ fi
 # to ResourceDisk.MountOptions in /etc/waagent.conf and remove this stanza.
 systemctl stop docker.service
 restorecon -R /var/lib/docker
-systemctl start docker.service
+rv=0; systemctl start docker.service || rv=$?
+if [ $rv -ne 0 ]; then
+	journalctl -u docker.service
+	exit $rv
+fi
 
 echo "BOOTSTRAP_CONFIG_NAME=node-config-master" >>/etc/sysconfig/${SERVICE_TYPE}-node
 


### PR DESCRIPTION
trying to catch

```
TASK [debug] *******************************************************************
Friday 15 June 2018  11:54:39 +0000 (2:03:19.257)       2:03:21.590 *********** 
ok: [localhost] => {
    "msg": "\u001b[36mINFO\u001b[0m[0008] Starting ARM Deployment (ci-test_branch_origin_extended_c_azure-86-476310237). This will take some time... \n\u001b[36mINFO\u001b[0m[7398] Finished ARM Deployment (ci-test_branch_origin_extended_c_azure-86-476310237). Error: resources.DeploymentsClient#CreateOrUpdate: Failure sending request: StatusCode=200 -- Original Error: Long running operation terminated with status 'Failed': Code=\"DeploymentFailed\" Message=\"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-debug for usage details.\" \n\u001b[31mERRO\u001b[0m[7398] {\"status\":\"Failed\",\"error\":{\"code\":\"DeploymentFailed\",\"message\":\"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-debug for usage details.\",\"details\":[{\"code\":\"RequestTimeout\",\"message\":\"{\\r\\n  \\\"error\\\": {\\r\\n    \\\"code\\\": \\\"ResourceDeploymentFailure\\\",\\r\\n    \\\"message\\\": \\\"The resource provision operation did not complete within the allowed timeout period. Please see https://aka.ms/arm-deploy for usage details.\\\"\\r\\n  }\\r\\n}\"},{\"code\":\"RequestTimeout\",\"message\":\"{\\r\\n  \\\"error\\\": {\\r\\n    \\\"code\\\": \\\"ResourceDeploymentFailure\\\",\\r\\n    \\\"message\\\": \\\"The resource provision operation did not complete within the allowed timeout period. Please see https://aka.ms/arm-deploy for usage details.\\\"\\r\\n  }\\r\\n}\"},{\"code\":\"Conflict\",\"message\":\"{\\r\\n  \\\"status\\\": \\\"Failed\\\",\\r\\n  \\\"error\\\": {\\r\\n    \\\"code\\\": \\\"ResourceDeploymentFailure\\\",\\r\\n    \\\"message\\\": \\\"The resource operation completed with terminal provisioning state 'Failed'.\\\",\\r\\n    \\\"details\\\": [\\r\\n      {\\r\\n        \\\"code\\\": \\\"VMExtensionProvisioningError\\\",\\r\\n        \\\"message\\\": \\\"VM has reported a failure when processing extension 'cse-master-0'. Error message: \\\\\\\"Enable failed: failed to execute command: command terminated with exit status=1\\\\n[stdout]\\\\n\\\\n[stderr]\\\\n+ '[' -f /etc/sysconfig/atomic-openshift-node ']'\\\\n+ SERVICE_TYPE=origin\\\\n++ rpm -q origin --queryformat '%!{(MISSING)VERSION}'\\\\n+ VERSION=3.10.0\\\\n+ IP_ADDRESS=10.0.0.11\\\\n+ '[' -f /etc/sysconfig/atomic-openshift-node ']'\\\\n+ ANSIBLE_DEPLOY_TYPE=origin\\\\n+ IMAGE_TYPE=origin\\\\n+ IMAGE_PREFIX=openshift\\\\n+ ANSIBLE_CONTAINER_VERSION=v3.10\\\\n+ COCKPIT_PREFIX=cockpit\\\\n+ COCKPIT_BASENAME=kubernetes\\\\n+ COCKPIT_VERSION=latest\\\\n+ systemctl stop docker.service\\\\n+ restorecon -R /var/lib/docker\\\\n+ systemctl start docker.service\\\\nJob for docker.service failed because the control process exited with error code. See \\\\\\\"systemctl status docker.service\\\\\\\" and \\\\\\\"journalctl -xe\\\\\\\" for details.\\\\n\\\\\\\".\\\"\\r\\n      }\\r\\n    ]\\r\\n  }\\r\\n}\"}]}} \n\u001b[31mFATA\u001b[0m[7398] resources.DeploymentsClient#CreateOrUpdate: Failure sending request: StatusCode=200 -- Original Error: Long running operation terminated with status 'Failed': Code=\"DeploymentFailed\" Message=\"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-debug for usage details.\" "
}
```

example: https://ci.openshift.redhat.com/jenkins/job/test_branch_origin_extended_conformance_azure/86/consoleFull