### PR TITLE
Kubernetes: Run /usr/lib/apt/apt.systemd.daily in background

### DIFF
--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -496,7 +496,6 @@ fi
 
 installDeps
 installDocker
-runAptDaily
 configureK8s
 ensureDocker
 configNetworkPlugin
@@ -554,4 +553,6 @@ if $REBOOTREQUIRED; then
   # wait 1 minute to restart node, so that the custom script extension can complete
   echo 'reboot required, rebooting node in 1 minute'
   /bin/bash -c "shutdown -r 1 &"
+else
+  runAptDaily &
 fi

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -852,15 +852,6 @@ func Test_Properties_ValidateAddons(t *testing.T) {
 	}
 }
 
-func TestPropertiesValidationNil(t *testing.T) {
-	containerService := &ContainerService{}
-	err := containerService.Properties.Validate(true)
-	expected := "missing ContainerService Properties"
-	if err == nil || err.Error() != expected {
-		t.Errorf("Expected error with message %s", expected)
-	}
-}
-
 func TestWindowsVersions(t *testing.T) {
 	for _, version := range common.GetAllSupportedKubernetesVersionsWindows() {
 		p := getK8sDefaultProperties(true)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Run /usr/lib/apt/apt.systemd.daily in background as a convenience following successful CSE paving. If a reboot is required to apply system updates, skip apt.systemd.daily as we assume there are fixes that pre-empt the regular apt maintenance routines.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Run /usr/lib/apt/apt.systemd.daily in background
```