### PR TITLE
fix(oms): pull oms directly from docker

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -326,7 +326,7 @@ var (
 		Containers: []api.KubernetesContainerSpec{
 			{
 				Name:           "omsagent",
-				Image:          "dockerio.azureedge.net/microsoft/oms:ciprod06072018",
+				Image:          "microsoft/oms:ciprod06072018",
 				CPURequests:    "50m",
 				MemoryRequests: "100Mi",
 				CPULimits:      "150m",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: 

- We (Microsoft/AKS) maintain a CDN cache of docker.io at dockerio.azureedge.net that has become unreliable recently due a backend change by Docker. This unreliability manifests as returning HTTP 405 or HTTP 401 errors from the backend which are then passed to clients of dockerio.azureedge.net. - We are working with Docker to create a new image caching proxy. In the interim (and per their advice) this change pulls OMS directly from Docker Hub.

```release-note
pull from Docker directly instead of using unreliable CDN proxy
```
