### PR TITLE
Mount audit log file to disk

### DIFF
--- a/parts/k8s/manifests/kubernetesmaster-kube-apiserver.yaml
+++ b/parts/k8s/manifests/kubernetesmaster-kube-apiserver.yaml
@@ -23,6 +23,8 @@ spec:
           readOnly: true
         - name: "sock"
           mountPath: "/opt"
+        - name: "auditlog"
+          mountPath: "/var/log/kubeaudit"
   volumes:
     - name: "etc-kubernetes"
       hostPath:
@@ -36,3 +38,6 @@ spec:
     - name: "sock"
       hostPath:
         path: "/opt"
+    - name: "auditlog"
+      hostPath:
+        path: "/var/log/kubeaudit"

--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -15,7 +15,7 @@ func setAPIServerConfig(cs *api.ContainerService) {
 		"--advertise-address":          "<kubernetesAPIServerIP>",
 		"--allow-privileged":           "true",
 		"--anonymous-auth":             "false",
-		"--audit-log-path":             "/var/log/audit.log",
+		"--audit-log-path":             "/var/log/kubeaudit/audit.log",
 		"--insecure-port":              "8080",
 		"--secure-port":                "443",
 		"--service-account-lookup":     "true",


### PR DESCRIPTION
**What this PR does / why we need it**:
Audit logging in enabled by default in Kubernetes 1.8 and above, but you cannot get to the log file easy, because it is only accessible within the kube-apiserver container. This PR puts the file on the host instead.

**Special notes for your reviewer**:
The path of the audit log is changed, because I don't think it will be a good idea to mount the hosts ```/var/log``` to the container.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
