### PR TITLE
fix(addons): Adds missing cluster subnet substitution for flannel

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-flannel-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-flannel-daemonset.yaml
@@ -29,7 +29,7 @@ data:
     }
   net-conf.json: |
     {
-      "Network": "10.244.0.0/16",
+      "Network": "<kubeClusterCidr>",
       "Backend": {
         "Type": "vxlan"
       }

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -263,6 +263,10 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
     # If Calico Policy enabled then update Cluster Cidr
     sed -i "s|<kubeClusterCidr>|{{WrapAsVariable "kubeClusterCidr"}}|g" "/etc/kubernetes/addons/calico-daemonset.yaml"
 {{end}}
+{{if eq .OrchestratorProfile.KubernetesConfig.NetworkPlugin "flannel"}}
+    # If Flannel is enabled then update Cluster Cidr
+    sed -i "s|<kubeClusterCidr>|{{WrapAsVariable "kubeClusterCidr"}}|g" "/etc/kubernetes/addons/flannel-daemonset.yaml"
+{{end}}
 {{if eq .OrchestratorProfile.KubernetesConfig.NetworkPolicy "cilium"}}
     # If Cilium Policy enabled then update the etcd certs and address
     sed -i "s|<ETCD_URL>|{{WrapAsVerbatim "variables('masterEtcdClientURLs')[copyIndex(variables('masterOffset'))]"}}|g" "/etc/kubernetes/addons/cilium-daemonset.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:
The flannel configmap was using a hardcoded value for the cluster subnet, so when you used a custom one, it would not route traffic properly