### PR TITLE
fix nil panic in cluster autoscaler validation

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -113,6 +113,7 @@ More usefully, let's add some custom configuration to the above addons:
     "addons": [
         {
             "name": "tiller",
+            "enabled": true,
             "containers": [
                 {
                   "name": "tiller",
@@ -126,6 +127,7 @@ More usefully, let's add some custom configuration to the above addons:
         },
         {
             "name": "kubernetes-dashboard",
+            "enabled": true,
             "containers": [
                 {
                   "name": "kubernetes-dashboard",
@@ -138,6 +140,7 @@ More usefully, let's add some custom configuration to the above addons:
         },
         {
             "name": "cluster-autoscaler",
+            "enabled": true,
             "containers": [
               {
                 "name": "cluster-autoscaler",

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -409,7 +409,7 @@ func (a *Properties) validateAddons() error {
 		for _, addon := range a.OrchestratorProfile.KubernetesConfig.Addons {
 			switch addon.Name {
 			case "cluster-autoscaler":
-				if *addon.Enabled && isAvailabilitySets {
+				if helpers.IsTrueBoolPointer(addon.Enabled) && isAvailabilitySets {
 					return fmt.Errorf("Cluster Autoscaler add-on can only be used with VirtualMachineScaleSets. Please specify \"availabilityProfile\": \"%s\"", VirtualMachineScaleSets)
 				}
 			case "nvidia-device-plugin":


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3349 

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
