### PR TITLE
Kubernetes E2E: test for DNS failures before calico

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -670,6 +670,22 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 	})
 
+	Describe("after the cluster has been up for awhile", func() {
+		It("dns-liveness pod should not have any restarts", func() {
+			if !eng.HasWindowsAgents() {
+				pod, err := pod.Get("dns-liveness", "default")
+				Expect(err).NotTo(HaveOccurred())
+				running, err := pod.WaitOnReady(5*time.Second, 3*time.Minute)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(running).To(Equal(true))
+				restarts := pod.Status.ContainerStatuses[0].RestartCount
+				err = pod.Delete()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(restarts).To(Equal(0))
+			}
+		})
+	})
+
 	Describe("with calico network policy enabled", func() {
 		It("should apply a network policy and deny outbound internet access to nginx pod", func() {
 			if eng.HasNetworkPolicy("calico") {
@@ -831,21 +847,5 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Skip("No windows agent was provisioned for this Cluster Definition")
 			}
 		})*/
-	})
-
-	Describe("after the cluster has been up for awhile", func() {
-		It("dns-liveness pod should not have any restarts", func() {
-			if !eng.HasWindowsAgents() {
-				pod, err := pod.Get("dns-liveness", "default")
-				Expect(err).NotTo(HaveOccurred())
-				running, err := pod.WaitOnReady(5*time.Second, 3*time.Minute)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(running).To(Equal(true))
-				restarts := pod.Status.ContainerStatuses[0].RestartCount
-				err = pod.Delete()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(restarts).To(Equal(0))
-			}
-		})
 	})
 })


### PR DESCRIPTION
because calico test disables outbound internet

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
