### PR TITLE
Ensure the use of latest Ubuntu image

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -65,9 +65,9 @@ var (
 	//DefaultUbuntuImageConfig is the default Linux distribution.
 	DefaultUbuntuImageConfig = AzureOSImageConfig{
 		ImageOffer:     "UbuntuServer",
-		ImageSku:       "16.04-LTS",
+		ImageSku:       "16.04-DAILY-LTS",
 		ImagePublisher: "Canonical",
-		ImageVersion:   "16.04.201806220",
+		ImageVersion:   "latest",
 	}
 
 	//DefaultRHELOSImageConfig is the RHEL Linux distribution.

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -58,13 +58,13 @@ var _ = BeforeSuite(func() {
 var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", func() {
 	Describe("regardless of agent pool type", func() {
 
-		It("should display the installed Ubuntu version", func() {
+		It("should display the installed Ubuntu version on the master node", func() {
 			kubeConfig, err := GetConfig()
 			Expect(err).NotTo(HaveOccurred())
 			master := fmt.Sprintf("azureuser@%s", kubeConfig.GetServerName())
 			sshKeyPath := cfg.GetSSHKeyPath()
 
-			lsbReleaseCmd := fmt.Sprintf("lsb_release -a")
+			lsbReleaseCmd := fmt.Sprintf("lsb_release -a && uname -r")
 			cmd := exec.Command("ssh", "-i", sshKeyPath, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, lsbReleaseCmd)
 			util.PrintCommand(cmd)
 			out, err := cmd.CombinedOutput()

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -58,6 +58,22 @@ var _ = BeforeSuite(func() {
 var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", func() {
 	Describe("regardless of agent pool type", func() {
 
+		It("should display the installed Ubuntu version", func() {
+			kubeConfig, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			master := fmt.Sprintf("azureuser@%s", kubeConfig.GetServerName())
+			sshKeyPath := cfg.GetSSHKeyPath()
+
+			lsbReleaseCmd := fmt.Sprintf("lsb_release -a")
+			cmd := exec.Command("ssh", "-i", sshKeyPath, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, lsbReleaseCmd)
+			util.PrintCommand(cmd)
+			out, err := cmd.CombinedOutput()
+			log.Printf("%s\n", out)
+			if err != nil {
+				log.Printf("Error while getting Ubuntu image version: %s\n", out)
+			}
+		})
+
 		It("should have have the appropriate node count", func() {
 			nodeList, err := node.Get()
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This would save time if we decide to run apt dist-upgrade in the CSE and would ensure we run with the latest security patches for the kernel and libs if we don't.