### PR TITLE
Adding test for and fixing daemonsets that should not run on Windows

### DIFF
--- a/parts/k8s/addons/azure-cni-networkmonitor.yaml
+++ b/parts/k8s/addons/azure-cni-networkmonitor.yaml
@@ -20,6 +20,8 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
         - name: azure-cnms
           image: <azureCNINetworkMonitorImage>

--- a/parts/k8s/addons/kubernetesmasteraddons-azure-npm-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-azure-npm-daemonset.yaml
@@ -71,6 +71,8 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
         - name: azure-npm
           image: containernetworking/azure-npm:v0.0.2

--- a/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
@@ -210,6 +210,8 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/parts/k8s/addons/kubernetesmasteraddons-flannel-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-flannel-daemonset.yaml
@@ -56,6 +56,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
+        beta.kubernetes.io/os: linux
       tolerations:
         - key: node-role.kubernetes.io/master
           operator: Equal

--- a/parts/k8s/addons/kubernetesmasteraddons-kube-rescheduler-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-kube-rescheduler-deployment.yaml
@@ -19,6 +19,8 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
       - image: <kubernetesReschedulerSpec>
         name: rescheduler

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -777,6 +777,20 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			}
 		})
 
+		It("Should not have any unready or crashing pods right after deployment", func() {
+			if eng.HasWindowsAgents() {
+				By("Checking ready status of each pod in kube-system")
+				pods, err := pod.GetAll("kube-system")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(pods.Pods)).ToNot(BeZero())
+				for _, currentPod := range pods.Pods {
+					log.Printf("Checking %s", currentPod.Metadata.Name)
+					Expect(currentPod.Status.ContainerStatuses[0].Ready).To(BeTrue())
+					Expect(currentPod.Status.ContainerStatuses[0].RestartCount).To(BeNumerically("<", 3))
+				}
+			}
+		})
+
 		// Windows Bug 16598869
 		/*
 			It("should be able to reach hostport in an iis webserver", func() {


### PR DESCRIPTION
Will help prevent problems such as #3404

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)
