### PR TITLE
update azure-npm to version v0.0.3

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-azure-npm-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-azure-npm-daemonset.yaml
@@ -73,7 +73,7 @@ spec:
         operator: Exists
       containers:
         - name: azure-npm
-          image: containernetworking/azure-npm:v0.0.2
+          image: containernetworking/azure-npm:v0.0.3
           securityContext:
             privileged: true
           env:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates Azure-NPM to v0.0.3 to avoid port scanning. This enhances security of k8s cluster running Azure-NPM.
