### PR TITLE
remove version check from k8s e2e

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/Azure/acs-engine/pkg/api/common"
@@ -163,30 +162,6 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ready).To(Equal(true))
 			}
-		})
-
-		It("should be running the expected version", func() {
-			hasWindows := eng.HasWindowsAgents()
-			version, err := node.Version()
-			Expect(err).NotTo(HaveOccurred())
-
-			var expectedVersion string
-			if eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorRelease != "" ||
-				eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorVersion != "" {
-				expectedVersion = common.RationalizeReleaseAndVersion(
-					common.Kubernetes,
-					eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorRelease,
-					eng.ClusterDefinition.Properties.OrchestratorProfile.OrchestratorVersion,
-					hasWindows)
-			} else {
-				expectedVersion = common.RationalizeReleaseAndVersion(
-					common.Kubernetes,
-					eng.Config.OrchestratorRelease,
-					eng.Config.OrchestratorVersion,
-					hasWindows)
-			}
-			expectedVersionRationalized := strings.Split(expectedVersion, "-")[0] // to account for -alpha and -beta suffixes
-			Expect(version).To(Equal("v" + expectedVersionRationalized))
 		})
 
 		It("should have kube-dns running", func() {

--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	//ServerVersion is used to parse out the version of the API running
-	ServerVersion = `(Server Version:\s)+(v\d+.\d+.\d+)+`
+	ServerVersion = `(Server Version:\s)+(.*)`
 )
 
 // Node represents the kubernetes Node Resource


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: We should be doing this in unit tests, and in fact we have coverage for this at present. This current E2E check is brittle: unreliable for pre-release versions, and doesn't work on upgraded clusters.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
