### PR TITLE
E2E cleanup: "acse-test-infrastructure" is too long

### DIFF
--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -42,7 +42,7 @@ az account set -s $SUBSCRIPTION_ID_TO_CLEANUP
 (( deadline=$(date +%s)-${expirationInSecs%.*} ))
 # find resource groups created before our deadline
 echo "Looking for resource groups created over ${EXPIRATION_IN_HOURS} hours ago..."
-for resourceGroup in `az group list | jq --arg dl $deadline '.[] | select(.id | contains("acse-test-infrastructure") | not) | select(.tags.now < $dl).name' | tr -d '\"' || ""`; do
+for resourceGroup in `az group list | jq --arg dl $deadline '.[] | select(.id | contains("acse-test-infrastructure") or contains("acse-dnd") | not) | select(.tags.now < $dl).name' | tr -d '\"' || ""`; do
     for deployment in `az group deployment list -g $resourceGroup | jq '.[] | .name' | tr -d '\"' || ""`; do
         echo "Will delete deployment ${deployment} from resource group ${resourceGroup}..."
         az group deployment delete -n $deployment -g $resourceGroup || echo "unable to delete deployment ${deployment}, will continue..."

--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -26,8 +26,6 @@ if [ -z "$EXPIRATION_IN_HOURS" ]; then
     EXPIRATION_IN_HOURS=2
 fi
 
-set -eu -o pipefail
-
 az login --service-principal \
 		--username "${SERVICE_PRINCIPAL_CLIENT_ID}" \
 		--password "${SERVICE_PRINCIPAL_CLIENT_SECRET}" \

--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -42,7 +42,7 @@ az account set -s $SUBSCRIPTION_ID_TO_CLEANUP
 (( deadline=$(date +%s)-${expirationInSecs%.*} ))
 # find resource groups created before our deadline
 echo "Looking for resource groups created over ${EXPIRATION_IN_HOURS} hours ago..."
-for resourceGroup in `az group list | jq --arg dl $deadline '.[] | select(.id | contains("acse-test-infrastructure") or contains("acse-dnd") | not) | select(.tags.now < $dl).name' | tr -d '\"' || ""`; do
+for resourceGroup in `az group list | jq --arg dl $deadline '.[] | select(.name | startswith("acse-") | not) | select(.tags.now < $dl).name' | tr -d '\"' || ""`; do
     for deployment in `az group deployment list -g $resourceGroup | jq '.[] | .name' | tr -d '\"' || ""`; do
         echo "Will delete deployment ${deployment} from resource group ${resourceGroup}..."
         az group deployment delete -n $deployment -g $resourceGroup || echo "unable to delete deployment ${deployment}, will continue..."


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
