### PR TITLE
update azure-npm to v0.0.4

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-azure-npm-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-azure-npm-daemonset.yaml
@@ -75,7 +75,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
         - name: azure-npm
-          image: containernetworking/azure-npm:v0.0.3
+          image: containernetworking/azure-npm:v0.0.4
           securityContext:
             privileged: true
           env:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates Azure-npm to v0.0.4. This version fixes an issue that prevent Azure-npm with blocking traffic from other namespaces.

**Which issue this PR fixes**: 
https://github.com/Azure/azure-container-networking/issues/185