### PR TITLE
Add CertificateProfile to V20180331 AgentOnly

### DIFF
--- a/pkg/api/agentPoolOnlyApi/v20180331/types.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/types.go
@@ -43,6 +43,7 @@ type Properties struct {
 	EnableRBAC              *bool                    `json:"enableRBAC,omitempty"`
 	NetworkProfile          *NetworkProfile          `json:"networkProfile,omitempty"`
 	AADProfile              *AADProfile              `json:"aadProfile,omitempty"`
+	CertificateProfile      *CertificateProfile      `json:"certificateProfile,omitempty"`
 }
 
 // NetworkProfile represents network related definitions
@@ -103,6 +104,26 @@ type ManagedClusterAccessProfile struct {
 type ServicePrincipalProfile struct {
 	ClientID string `json:"clientId,omitempty" validate:"required"`
 	Secret   string `json:"secret,omitempty" conform:"redact"`
+}
+
+// CertificateProfile contains cert material for the Kubernetes cluster
+type CertificateProfile struct {
+	// CaCertificate is the certificate authority certificate.
+	CaCertificate string `json:"caCertificate,omitempty"`
+	// CaPrivateKey is the certificate authority key.
+	CaPrivateKey string `json:"caPrivateKey,omitempty"`
+	// ApiServerCertificate is the rest api server certificate, and signed by the CA
+	APIServerCertificate string `json:"apiServerCertificate,omitempty"`
+	// ApiServerPrivateKey is the rest api server private key, and signed by the CA
+	APIServerPrivateKey string `json:"apiServerPrivateKey,omitempty"`
+	// ClientCertificate is the certificate used by the client kubelet services and signed by the CA
+	ClientCertificate string `json:"clientCertificate,omitempty"`
+	// ClientPrivateKey is the private key used by the client kubelet services and signed by the CA
+	ClientPrivateKey string `json:"clientPrivateKey,omitempty"`
+	// KubeConfigCertificate is the client certificate used for kubectl cli and signed by the CA
+	KubeConfigCertificate string `json:"kubeConfigCertificate,omitempty"`
+	// KubeConfigPrivateKey is the client private key used for kubectl cli and signed by the CA
+	KubeConfigPrivateKey string `json:"kubeConfigPrivateKey,omitempty"`
 }
 
 // LinuxProfile represents the Linux configuration passed to the cluster

--- a/pkg/api/convertertoagentpoolonlyapi.go
+++ b/pkg/api/convertertoagentpoolonlyapi.go
@@ -296,6 +296,17 @@ func convertVLabsAgentPoolOnlyCertificateProfile(vlabs *vlabs.CertificateProfile
 	api.KubeConfigPrivateKey = vlabs.KubeConfigPrivateKey
 }
 
+func convertV20180331AgentPoolOnlyCertificateProfile(vlabs *v20180331.CertificateProfile, api *CertificateProfile) {
+	api.CaCertificate = vlabs.CaCertificate
+	api.CaPrivateKey = vlabs.CaPrivateKey
+	api.APIServerCertificate = vlabs.APIServerCertificate
+	api.APIServerPrivateKey = vlabs.APIServerPrivateKey
+	api.ClientCertificate = vlabs.ClientCertificate
+	api.ClientPrivateKey = vlabs.ClientPrivateKey
+	api.KubeConfigCertificate = vlabs.KubeConfigCertificate
+	api.KubeConfigPrivateKey = vlabs.KubeConfigPrivateKey
+}
+
 func isAgentPoolOnlyClusterJSON(contents []byte) bool {
 	properties, propertiesPresent := propertiesAsMap(contents)
 	if !propertiesPresent {
@@ -360,6 +371,11 @@ func convertV20180331AgentPoolOnlyProperties(obj *v20180331.Properties) *Propert
 
 	if obj.AADProfile != nil {
 		properties.AADProfile = convertV20180331AgentPoolOnlyAADProfile(obj.AADProfile)
+	}
+
+	if obj.CertificateProfile != nil {
+		properties.CertificateProfile = &CertificateProfile{}
+		convertV20180331AgentPoolOnlyCertificateProfile(obj.CertificateProfile, properties.CertificateProfile)
 	}
 
 	return properties


### PR DESCRIPTION
I'd like to add CertificateProfiles to the V20180331 AgentOnly profiles.  It's already in the vlabs API.  The code is copied/adapted from there.

**What this PR does / why we need it**:
This PR adds the ability to specify the certificates or keyvault references in the acs-engines model file.  The vlabs API already contains these features.  It's very useful and I'd like to see the same functionality in the v20180331 API.  Without it, I have to modify the resulting ARM parameters file and inject the certificate references.  If I don't the ARM apply fails since the certs are referenced in the ARM file but not the ARM parameters file.

**Release note**:
```release-note
NONE
```
