### PR TITLE
Using Fatalf instead of Fatalln when formatting characters are present in the string.

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -80,10 +80,10 @@ func newDeployCmd() *cobra.Command {
 				log.Fatalf("error merging API model in deployCmd: %s", err.Error())
 			}
 			if err := dc.loadAPIModel(cmd, args); err != nil {
-				log.Fatalln("failed to load apimodel: %s", err.Error())
+				log.Fatalf("failed to load apimodel: %s", err.Error())
 			}
 			if _, _, err := dc.validateApimodel(); err != nil {
-				log.Fatalln("Failed to validate the apimodel after populating values: %s", err.Error())
+				log.Fatalf("Failed to validate the apimodel after populating values: %s", err.Error())
 			}
 			return dc.run()
 		},
@@ -372,7 +372,7 @@ func (dc *deployCmd) run() error {
 
 	templateGenerator, err := acsengine.InitializeTemplateGenerator(ctx, dc.classicMode)
 	if err != nil {
-		log.Fatalln("failed to initialize template generator: %s", err.Error())
+		log.Fatalf("failed to initialize template generator: %s", err.Error())
 	}
 
 	template, parameters, certsgenerated, err := templateGenerator.GenerateTemplate(dc.containerService, acsengine.DefaultGeneratorCode, false, BuildTag)

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -179,7 +179,7 @@ func (gc *generateCmd) run() error {
 	}
 	templateGenerator, err := acsengine.InitializeTemplateGenerator(ctx, gc.classicMode)
 	if err != nil {
-		log.Fatalln("failed to initialize template generator: %s", err.Error())
+		log.Fatalf("failed to initialize template generator: %s", err.Error())
 	}
 
 	template, parameters, certsGenerated, err := templateGenerator.GenerateTemplate(gc.containerService, acsengine.DefaultGeneratorCode, false, BuildTag)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: I see logging messages "%s" printed in the cli output.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: We use Fatalf instead of FataLn wherever appropriate.

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
