### PR TITLE
Add manual steps for powershell remoting.

### DIFF
--- a/docs/kubernetes/windows.md
+++ b/docs/kubernetes/windows.md
@@ -304,7 +304,7 @@ Windows support is still in active development with many changes each week. Read
 
 ### Finding logs
 
-To connect to a Windows node using Remote Desktop and get logs, please read over this topic in the main [troubleshooting](troubleshooting.md#how-to-debug-cse-errors-windows) page first.
+To connect to a Windows node using Remote Desktop and get logs, please read over this topic in the main [troubleshooting](troubleshooting.md#connecting-to-windows-nodes) page first.
 
 ### Checking versions
 


### PR DESCRIPTION
I'd like to be able to connect to Windows nodes from the command line (#3460). This is technically feasible, so I'm documenting the manual steps first. To fully automate this, I need to investigate what the best approach is to secure the connections. My hope is that we can get SSL certs from Azure, rather than self-signed certs that will expire quickly.

Another possibility would be to put this in an acs-engine extension script instead