### PR TITLE
Adding 'make dev' equivalent for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The cluster definition file enables you to customize your Docker enabled cluster
 
 Follow the [developers guide](docs/developers.md) to set up your environment.
 
-To build acs-engine, run `make build`. If you are developing with a working [Docker environment](https://docs.docker.com/engine), you can also run `make dev` first to start a Docker container and run `make build` inside the container.
+To build acs-engine, run `make build`. If you are developing with a working [Docker environment](https://docs.docker.com/engine), you can also run `make dev` (or `makedev.ps1` on Windows) first to start a Docker container and run `make build` inside the container.
 
 Please follow these instructions before submitting a PR:
 

--- a/makedev.ps1
+++ b/makedev.ps1
@@ -1,0 +1,5 @@
+$REPO_PATH = "github.com/Azure/acs-engine"
+$DEV_ENV_IMAGE = "quay.io/deis/go-dev:v1.10.0"
+$DEV_ENV_WORK_DIR = "/go/src/$REPO_PATH"
+
+docker.exe run -it --rm -w $DEV_ENV_WORK_DIR -v `"$($PWD)`":$DEV_ENV_WORK_DIR $DEV_ENV_IMAGE bash


### PR DESCRIPTION
This is a quick script & doc note showing how to run the prebuilt Build environment in a Linux container on Windows.