### PR TITLE
Docs: Update user guide list to include Windows, update description of clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,17 @@ The cluster definition file enables you to customize your Docker enabled cluster
 
 ## User guides
 
+These guides show how to create your first deployment for each orchestrator:
 * [ACS Engine](docs/acsengine.md) - shows you how to build and use the ACS engine to generate custom container clusters
-* [Cluster Definition](docs/clusterdefinition.md) - describes the components of the cluster definition file
 * [DC/OS Walkthrough](docs/dcos.md) - shows how to create a DC/OS cluster on Azure
 * [Kubernetes Walkthrough](docs/kubernetes.md) - shows how to create a Kubernetes cluster on Azure
   * [Kubernetes Walkthrough (Windows)](docs/kubernetes/windows.md) - shows how to create a Kubernetes cluster on Azure for Windows containers
 * [OpenShift Walkthrough](docs/openshift.md) - shows how to create an OpenShift cluster on Azure
-* [Swarm Walkthrough](docs/swarm.md) - shows how to create a Swarm cluster on Azure
-* [Swarm Mode Walkthrough](docs/swarmmode.md) - shows how to create a Swarm Mode cluster on Azure
+* [Swarm Mode Walkthrough](docs/swarmmode.md) - shows how to create a [Docker Swarm Mode](https://docs.docker.com/engine/swarm/) cluster on Azure
+* [Standalone Swarm Walkthrough](docs/swarm.md) - shows how to create a [Docker Standalone Swarm](https://docs.docker.com/swarm/) cluster on Azure
+
+These guides cover more advanced features to try out after you have built your first cluster:
+* [Cluster Definition](docs/clusterdefinition.md) - describes the components of the cluster definition file
 * [Custom VNET](examples/vnet) - shows how to use a custom VNET
 * [Attached Disks](examples/disks-storageaccount) - shows how to attach up to 4 disks per node
 * [Managed Disks](examples/disks-managed) - shows how to use managed disks

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ The cluster definition file enables you to customize your Docker enabled cluster
 * Custom VNET
 * Extensions
 
+More info, including a thorough walkthrough is [here(docs/acsengine.md)].
+
 ## User guides
 
 These guides show how to create your first deployment for each orchestrator:
-* [ACS Engine](docs/acsengine.md) - shows you how to build and use the ACS engine to generate custom container clusters
 * [DC/OS Walkthrough](docs/dcos.md) - shows how to create a DC/OS cluster on Azure
-* [Kubernetes Walkthrough](docs/kubernetes.md) - shows how to create a Kubernetes cluster on Azure
-  * [Kubernetes Walkthrough (Windows)](docs/kubernetes/windows.md) - shows how to create a Kubernetes cluster on Azure for Windows containers
+* [Kubernetes Walkthrough](docs/kubernetes.md) - shows how to create a Linux or Windows Kubernetes cluster on Azure
 * [OpenShift Walkthrough](docs/openshift.md) - shows how to create an OpenShift cluster on Azure
 * [Swarm Mode Walkthrough](docs/swarmmode.md) - shows how to create a [Docker Swarm Mode](https://docs.docker.com/engine/swarm/) cluster on Azure
 * [Standalone Swarm Walkthrough](docs/swarm.md) - shows how to create a [Docker Standalone Swarm](https://docs.docker.com/swarm/) cluster on Azure

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The cluster definition file enables you to customize your Docker enabled cluster
 * Custom VNET
 * Extensions
 
-More info, including a thorough walkthrough is [here(docs/acsengine.md)].
+More info, including a thorough walkthrough is [here](docs/acsengine.md).
 
 ## User guides
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ The cluster definition file enables you to customize your Docker enabled cluster
 
 ## User guides
 
-* [ACS Engine](docs/acsengine.md) - shows you how to build and use the ACS engine to generate custom Docker enabled container clusters
+* [ACS Engine](docs/acsengine.md) - shows you how to build and use the ACS engine to generate custom container clusters
 * [Cluster Definition](docs/clusterdefinition.md) - describes the components of the cluster definition file
-* [DC/OS Walkthrough](docs/dcos.md) - shows how to create a DC/OS enabled Docker cluster on Azure
-* [Kubernetes Walkthrough](docs/kubernetes.md) - shows how to create a Kubernetes enabled Docker cluster on Azure
-* [OpenShift Walkthrough](docs/openshift.md) - shows how to create an OpenShift enabled Docker cluster on Azure
-* [Swarm Walkthrough](docs/swarm.md) - shows how to create a Swarm enabled Docker cluster on Azure
+* [DC/OS Walkthrough](docs/dcos.md) - shows how to create a DC/OS cluster on Azure
+* [Kubernetes Walkthrough](docs/kubernetes.md) - shows how to create a Kubernetes cluster on Azure
+  * [Kubernetes Walkthrough (Windows)](docs/kubernetes/windows.md) - shows how to create a Kubernetes cluster on Azure for Windows containers
+* [OpenShift Walkthrough](docs/openshift.md) - shows how to create an OpenShift cluster on Azure
+* [Swarm Walkthrough](docs/swarm.md) - shows how to create a Swarm cluster on Azure
 * [Swarm Mode Walkthrough](docs/swarmmode.md) - shows how to create a Swarm Mode cluster on Azure
 * [Custom VNET](examples/vnet) - shows how to use a custom VNET
 * [Attached Disks](examples/disks-storageaccount) - shows how to attach up to 4 disks per node

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -2,7 +2,7 @@
 
 * Create a Kubernetes Cluster
   * [Linux](kubernetes/deploy.md) - Create your first Linux Kubernetes cluster
-  * [Windows](docs/kubernetes/windows.md) - Create your first Windows Kubernetes cluster
+  * [Windows](kubernetes/windows.md) - Create your first Windows Kubernetes cluster
 * [Kubernetes Next Steps](kubernetes/walkthrough.md) - You have successfully deployed a Kubernetes cluster, now what?
 * [Troubleshooting](kubernetes/troubleshooting.md) - Running into issues? Start here to troubleshoot Kubernetes.
 * [Features](kubernetes/features.md) - Guide to alpha, beta, and stable functionality in acs-engine.

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,8 +1,9 @@
 # Microsoft Azure Container Service Engine - Kubernetes
 
-* [Create a Kubernetes Cluster](kubernetes/deploy.md) - Create your first Kubernetes cluster. Start here!
+* Create a Kubernetes Cluster
+  * [Linux](kubernetes/deploy.md) - Create your first Linux Kubernetes cluster
+  * [Windows](docs/kubernetes/windows.md) - Create your first Windows Kubernetes cluster
 * [Kubernetes Next Steps](kubernetes/walkthrough.md) - You have successfully deployed a Kubernetes cluster, now what?
-
 * [Troubleshooting](kubernetes/troubleshooting.md) - Running into issues? Start here to troubleshoot Kubernetes.
 * [Features](kubernetes/features.md) - Guide to alpha, beta, and stable functionality in acs-engine.
 * [For Kubernetes Developers](kubernetes/k8s-developers.md) - Info for devs working on Kubernetes upstream and wanting to test using acs-engine.


### PR DESCRIPTION
This adds a link to the Windows Kubernetes howto, and also organizes the user guide list to clearly separate per-orchestrator tutorials from the more advanced customizations.