### PR TITLE
removed datadisk to allow scale after upgrade

### DIFF
--- a/pkg/acsengine/transform/transform.go
+++ b/pkg/acsengine/transform/transform.go
@@ -299,7 +299,7 @@ func (t *Transformer) NormalizeMasterResourcesForScaling(logger *logrus.Entry, t
 			delete(hardwareProfile, vmSizeFieldName)
 		}
 
-		if !t.removeCustomData(logger, resourceProperties) || !t.removeImageReference(logger, resourceProperties) {
+		if !t.removeCustomData(logger, resourceProperties) || !t.removeDataDisks(logger, resourceProperties) || !t.removeImageReference(logger, resourceProperties) {
 			continue
 		}
 	}
@@ -317,6 +317,19 @@ func (t *Transformer) removeCustomData(logger *logrus.Entry, resourceProperties 
 
 	if osProfile[customDataFieldName] != nil {
 		delete(osProfile, customDataFieldName)
+	}
+	return ok
+}
+
+func (t *Transformer) removeDataDisks(logger *logrus.Entry, resourceProperties map[string]interface{}) bool {
+	storageProfile, ok := resourceProperties[storageProfileFieldName].(map[string]interface{})
+	if !ok {
+		logger.Warnf("Template improperly formatted. Could not find: %s", storageProfileFieldName)
+		return ok
+	}
+
+	if storageProfile[dataDisksFieldName] != nil {
+		delete(storageProfile, dataDisksFieldName)
 	}
 	return ok
 }

--- a/pkg/acsengine/transform/transformtestfiles/k8s_agent_upgrade_template.json
+++ b/pkg/acsengine/transform/transformtestfiles/k8s_agent_upgrade_template.json
@@ -1991,14 +1991,6 @@
           }
         },
         "storageProfile": {
-          "dataDisks": [
-            {
-              "createOption": "attach",
-              "diskSizeGB": "128",
-              "lun": 0,
-              "name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-etcddisk')]"
-            }
-          ],
           "osDisk": {
             "caching": "ReadWrite",
             "createOption": "FromImage"

--- a/pkg/acsengine/transform/transformtestfiles/k8s_scale_template.json
+++ b/pkg/acsengine/transform/transformtestfiles/k8s_scale_template.json
@@ -2173,14 +2173,6 @@
           }
         },
         "storageProfile": {
-          "dataDisks": [
-            {
-              "createOption": "Empty",
-              "diskSizeGB": "128",
-              "lun": 0,
-              "name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-etcddisk')]"
-            }
-          ],
           "osDisk": {
             "caching": "ReadWrite",
             "createOption": "FromImage"

--- a/pkg/acsengine/transform/transformtestfiles/k8s_vnet_scale_template.json
+++ b/pkg/acsengine/transform/transformtestfiles/k8s_vnet_scale_template.json
@@ -2117,14 +2117,6 @@
           }
         },
         "storageProfile": {
-          "dataDisks": [
-            {
-              "createOption": "Empty",
-              "diskSizeGB": "128",
-              "lun": 0,
-              "name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-etcddisk')]"
-            }
-          ],
           "osDisk": {
             "caching": "ReadWrite",
             "createOption": "FromImage"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
When upgrading then scaling a cluster with v0.19.1 or the current master branch, the deployment fails because dataDisk.CreateOption for master nodes in the scale template is "empty" instead of "attach". This part of the template is not needed for scaling agent pools and can be removed.

**Which issue this PR fixes:** fixes #3478

**Special notes for your reviewer**:
I had help from @JackQuincy though he may not be able to help with this immediately. I will need more help with testing.

**If applicable**:
- [ ] documentation
- [x] unit tests
- [x] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
