### PR TITLE
Do not enable AcceleratedNetworkingEnabled by default on upgrade

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -371,7 +371,7 @@ func setPropertiesDefaults(cs *api.ContainerService, isUpgrade bool) (bool, erro
 
 	setHostedMasterNetworkDefaults(properties)
 
-	setAgentNetworkDefaults(properties)
+	setAgentNetworkDefaults(properties, isUpgrade)
 
 	setStorageDefaults(properties)
 	setExtensionDefaults(properties)
@@ -792,7 +792,7 @@ func setMasterNetworkDefaults(a *api.Properties, isUpgrade bool) {
 }
 
 // SetAgentNetworkDefaults for agents
-func setAgentNetworkDefaults(a *api.Properties) {
+func setAgentNetworkDefaults(a *api.Properties, isUpgrade bool) {
 	// configure the subnets if not in custom VNET
 	if a.MasterProfile != nil && !a.MasterProfile.IsCustomVNET() {
 		subnetCounter := 0
@@ -818,7 +818,7 @@ func setAgentNetworkDefaults(a *api.Properties) {
 		// These supported series are: D/DSv2 and F/Fs // All the others are not supported
 		// On instances that support hyperthreading, Accelerated Networking is supported on VM instances with 4 or more vCPUs.
 		// Supported series are: D/DSv3, E/ESv3, Fsv2, and Ms/Mms.
-		if profile.AcceleratedNetworkingEnabled == nil {
+		if profile.AcceleratedNetworkingEnabled == nil && !isUpgrade {
 			profile.AcceleratedNetworkingEnabled = helpers.PointerToBool(helpers.AcceleratedNetworkingSupported(profile.VMSize))
 		}
 

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -818,8 +818,8 @@ func setAgentNetworkDefaults(a *api.Properties, isUpgrade bool) {
 		// These supported series are: D/DSv2 and F/Fs // All the others are not supported
 		// On instances that support hyperthreading, Accelerated Networking is supported on VM instances with 4 or more vCPUs.
 		// Supported series are: D/DSv3, E/ESv3, Fsv2, and Ms/Mms.
-		if profile.AcceleratedNetworkingEnabled == nil && !isUpgrade {
-			profile.AcceleratedNetworkingEnabled = helpers.PointerToBool(helpers.AcceleratedNetworkingSupported(profile.VMSize))
+		if profile.AcceleratedNetworkingEnabled == nil {
+			profile.AcceleratedNetworkingEnabled = !isUpgrade && helpers.PointerToBool(helpers.AcceleratedNetworkingSupported(profile.VMSize))
 		}
 
 		// don't default Distro for OpenShift

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -819,7 +819,7 @@ func setAgentNetworkDefaults(a *api.Properties, isUpgrade bool) {
 		// On instances that support hyperthreading, Accelerated Networking is supported on VM instances with 4 or more vCPUs.
 		// Supported series are: D/DSv3, E/ESv3, Fsv2, and Ms/Mms.
 		if profile.AcceleratedNetworkingEnabled == nil {
-			profile.AcceleratedNetworkingEnabled = !isUpgrade && helpers.PointerToBool(helpers.AcceleratedNetworkingSupported(profile.VMSize))
+			profile.AcceleratedNetworkingEnabled = helpers.PointerToBool(!isUpgrade && helpers.AcceleratedNetworkingSupported(profile.VMSize))
 		}
 
 		// don't default Distro for OpenShift

--- a/pkg/acsengine/defaults_test.go
+++ b/pkg/acsengine/defaults_test.go
@@ -548,7 +548,7 @@ func TestSetComponentsNetworkDefaults(t *testing.T) {
 		mockAPI := getMockAPIProperties("1.0.0")
 		mockAPI.OrchestratorProfile = &test.orchestratorProfile
 		setMasterNetworkDefaults(&mockAPI, false)
-		setAgentNetworkDefaults(&mockAPI)
+		setAgentNetworkDefaults(&mockAPI, false)
 		if mockAPI.MasterProfile.Distro != test.expectedDistro {
 			t.Fatalf("setMasterNetworkDefaults() test case %v did not return right Distro configurations %v != %v", test.name, mockAPI.MasterProfile.Distro, test.expectedDistro)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Follow up for https://github.com/Azure/acs-engine/pull/3449 which broke back compat upgrade: only enable Accelerated Networking on create.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
