### PR TITLE
fix(cni-networking): Enables `br_netfilter` kernel module

### DIFF
--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -257,6 +257,11 @@ function installCNI() {
     tar -xzf $CONTAINERNETWORKING_CNI_TGZ_TMP -C $CNI_BIN_DIR
     chown -R root:root $CNI_BIN_DIR
     chmod -R 755 $CNI_BIN_DIR
+    # Turn on br_netfilter (needed for the iptables rules to work on bridges)
+    # and permanently enable it
+    modprobe br_netfilter
+    # /etc/modules-load.d is the location used by systemd to load modules
+    echo -n "br_netfilter" > /etc/modules-load.d/br_netfilter.conf
 }
 
 function configAzureCNI() {


### PR DESCRIPTION
**What this PR does / why we need it**:'
Without this module, iptables rules do not apply to bridges and network overlays do not function

**Release note**:
```release-note
fix(cni-networking): Enables `br_netfilter` kernel module
```