### PR TITLE
Adding WinRM extension

### DIFF
--- a/extensions/winrm/README.md
+++ b/extensions/winrm/README.md
@@ -1,0 +1,56 @@
+# WinRM Extension
+
+This extension enabled WinRM with HTTPS and a self-signed certificate on each Windows node. This makes it possible to troubleshoot Windows nodes from the master over ssh, without needing Remote Desktop.
+
+If you want to pull all the logs off Windows nodes quickly, deploy with this extension, then SSH to the master node and run [logslurp](https://github.com/PatrickLang/logslurp) to gather them all at once.
+
+# Configuration
+
+|Name               |Required|Acceptable Value     |
+|-------------------|--------|---------------------|
+|name               |yes     |winrm                |
+|version            |yes     |v1                   |
+|rootURL            |optional|                     |
+
+# Example
+
+``` javascript
+    ...
+    "agentPoolProfiles": [
+      {
+        "name": "windowspool1",
+        "extensions": [
+          {
+            "name": "winrm"
+          }
+        ]
+      }
+    ],
+    ...
+    "extensionProfiles": [
+      {
+        "name": "winrm",
+        "version": "v1"
+      }
+    ]
+    ...
+```
+
+
+# Supported Orchestrators
+
+Kubernetes
+
+# Troubleshoot
+
+Extension execution output is logged to files found under the following directory on the target virtual machine.
+
+```sh
+C:\WindowsAzure\Logs\Plugins\Microsoft.Compute.CustomScriptExtension
+```
+
+The specified files are downloaded into the following directory on the target virtual machine.
+
+```sh
+C:\Packages\Plugins\Microsoft.Compute.CustomScriptExtension\1.*\Downloads\<n>
+```

--- a/extensions/winrm/v1/enableWinrm.ps1
+++ b/extensions/winrm/v1/enableWinrm.ps1
@@ -1,0 +1,3 @@
+$cert = New-SelfSignedCertificate -DnsName (hostname) -CertStoreLocation Cert:\LocalMachine\My
+winrm create winrm/config/Listener?Address=*+Transport=HTTPS "@{Hostname=`"$(hostname)`"; CertificateThumbprint=`"$($cert.Thumbprint)`"}"
+winrm set winrm/config/service/auth "@{Basic=`"true`"}"

--- a/extensions/winrm/v1/supported-orchestrators.json
+++ b/extensions/winrm/v1/supported-orchestrators.json
@@ -1,0 +1,1 @@
+["Kubernetes"]

--- a/extensions/winrm/v1/template-link.json
+++ b/extensions/winrm/v1/template-link.json
@@ -1,0 +1,39 @@
+{
+	"name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'winrm')]",
+	"type": "Microsoft.Resources/deployments",
+	"apiVersion": "[variables('apiVersionLinkDefault')]",
+	"dependsOn": [
+		"[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
+	],
+	"copy": {
+		"count": "EXTENSION_LOOP_COUNT",
+		"name": "winrmExtensionLoop"
+	},
+	"properties": {
+		"mode": "Incremental",
+		"templateLink": {
+			"uri": "EXTENSION_URL_REPLACEextensions/winrm/v1/template.json",
+			"contentVersion": "1.0.0.0"
+		},
+		"parameters": {
+			"artifactsLocation": {
+				"value": "EXTENSION_URL_REPLACE"
+			},
+			"apiVersionCompute": {
+				"value": "[variables('apiVersionDefault')]"
+			},
+			"targetVMName": {
+				"value": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET))]"
+			},
+			"targetVMType": {
+            	"value": "EXTENSION_TARGET_VM_TYPE"
+            },
+			"extensionParameters": {
+				"value": "EXTENSION_PARAMETERS_REPLACE"
+			},
+			"vmIndex":{
+				"value": "[copyIndex(EXTENSION_LOOP_OFFSET)]"
+			}
+		}
+	}
+}

--- a/extensions/winrm/v1/template.json
+++ b/extensions/winrm/v1/template.json
@@ -1,0 +1,72 @@
+{
+	"$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+	"contentVersion": "1.0.0.0",
+	"parameters": {
+		 "artifactsLocation": {
+			 "type": "string",
+			 "minLength": 1,
+			 "metadata": {
+				 "description": "Artifacts Location - URL"
+			 }
+		 },
+		 "apiVersionCompute": {
+			 "type": "string",
+			 "minLength": 1,
+			 "metadata": {
+				 "description": "Compute API Version"
+			 }
+		 },
+		 "targetVMName":{
+			 "type": "string",
+			 "minLength": 1,
+			 "metadata": {
+				 "description": "Name of the vm to run the extension on"
+			 }
+		 },
+		 "targetVMType":{
+			"type": "string",
+			"minLength": 1,
+			"metadata": {
+				"description": "Type of the vm to run the extension: master or agent "
+			}
+		},
+		"extensionParameters": {
+			"type": "securestring",
+			"minLength": 0,
+			"metadata": {
+				"description": "Custom Parameter for Extension - not used in winrm extension at the moment"
+			}
+		},
+		 "vmIndex": {
+			 "type": "int",
+			 "metadata": {
+				 "description": "index in the pool of the current agent, used so that we can get the extension name right"
+			 }
+		 }
+	},
+	"variables": {  },
+	"resources": [
+	 {
+	   "apiVersion": "[parameters('apiVersionCompute')]",
+	   "dependsOn": [],
+	   "location": "[resourceGroup().location]",
+	   "type": "Microsoft.Compute/virtualMachines/extensions",
+	   "name": "[concat(parameters('targetVMName'),'/cse', '-', parameters('targetVMType'), '-', parameters('vmIndex'))]", 
+	   "properties": {
+		 "publisher": "Microsoft.Compute",
+		 "type": "CustomScriptExtension",
+		 "typeHandlerVersion": "1.8",
+		 "autoUpgradeMinorVersion": true,
+		 "settings": {
+			 "fileUris": [
+				 "[concat(parameters('artifactsLocation'), 'extensions/winrm/v1/enableWinrm.ps1')]"
+			  ]
+		 },
+		 "protectedSettings": {
+			 "commandToExecute": "[concat('powershell.exe -ExecutionPolicy bypass \"& ./enableWinrm.ps1 -PackageList ', parameters('extensionParameters'), '\"')]"
+		 }
+	   }
+	 }
+	 ],
+	"outputs": {  }
+ }


### PR DESCRIPTION
This resolves #3460 for dev investigations. I'm making it an optional extension at first so I can do more tests on robustness and get some feedback on this from a security standpoint before it's enabled by default.

Using this extension will enable Windows Remote Management using HTTPS with a self-signed certificate. That's enough to enable some basic remote management from the commandline and enable tools like https://github.com/patricklang/logslurp to gather logs into a central place for troubleshooting.
