### PR TITLE
Kubernetes: enable docker health probe

### DIFF
--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -44,6 +44,19 @@ write_files:
         }
       }{{end}}{{end}}
     }
+
+- path: "/etc/systemd/system/docker-health-probe.service"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    [Unit]
+    Description=runs a script that checks docker health; restart if needed
+    After=docker.service
+    [Service]
+    ExecStart=/bin/bash -c "source /opt/azure/containers/provision_source.sh && docker_health_probe"
+    Restart=always
+    [Install]
+    WantedBy=multi-user.target
 {{end}}
 
 - path: "/etc/kubernetes/certs/ca.crt"

--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -406,6 +406,7 @@ function ensureContainerd() {
 function ensureDocker() {
     wait_for_file 600 1 $DOCKER || exit $ERR_FILE_WATCH_TIMEOUT
     systemctlEnableAndStart docker
+    systemctlEnableAndStart docker-health-probe
 }
 function ensureKMS() {
     systemctlEnableAndStart kms

--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -406,6 +406,7 @@ function ensureContainerd() {
 function ensureDocker() {
     wait_for_file 600 1 $DOCKER || exit $ERR_FILE_WATCH_TIMEOUT
     systemctlEnableAndStart docker
+    retrycmd_if_failure 6 1 10 docker pull busybox # pre-pull busybox, but don't exit if fail
     systemctlEnableAndStart docker-health-probe
 }
 function ensureKMS() {

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -15,14 +15,14 @@ write_files:
     {{WrapAsVariable "provisionSource"}}
 
 {{if .OrchestratorProfile.KubernetesConfig.RequiresDocker}}
-{{if not .MasterProfile.IsCoreOS}}
+    {{if not .MasterProfile.IsCoreOS}}
 - path: "/etc/systemd/system/docker.service.d/clear_mount_propagation_flags.conf"
   permissions: "0644"
   owner: "root"
   content: |
     [Service]
     MountFlags=shared
-{{end}}
+    {{end}}
 
 - path: "/etc/systemd/system/docker.service.d/exec_start.conf"
   permissions: "0644"
@@ -30,11 +30,11 @@ write_files:
   content: |
     [Service]
     ExecStart=
-{{if .MasterProfile.IsCoreOS}}
+    {{if .MasterProfile.IsCoreOS}}
     ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/dockerd --host=fd:// --containerd=/var/run/docker/libcontainerd/docker-containerd.sock --storage-driver=overlay2 --bip={{WrapAsVariable "dockerBridgeCidr"}} $DOCKER_SELINUX $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
-{{else}}
+    {{else}}
     ExecStart=/usr/bin/docker daemon -H fd:// --storage-driver=overlay2 --bip={{WrapAsVariable "dockerBridgeCidr"}}
-{{end}}
+    {{end}}
 - path: "/etc/docker/daemon.json"
   permissions: "0644"
   owner: "root"
@@ -47,6 +47,19 @@ write_files:
          "max-file": "5"
       }
     }
+
+- path: "/etc/systemd/system/docker-health-probe.service"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    [Unit]
+    Description=runs a script that checks docker health; restart if needed
+    After=docker.service
+    [Service]
+    ExecStart=/bin/bash -c "source /opt/azure/containers/provision_source.sh && docker_health_probe"
+    Restart=always
+    [Install]
+    WantedBy=multi-user.target
 {{end}}
 
 - path: "/etc/kubernetes/certs/ca.crt"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Adds a docker health probe to clusters. The health probe runs by systemd and probes docker health restart as needed. The health probe is designed to test the entire docker stack not just docker ps which has proven prone to false positives when healthy.

This is actually @khenidak's work :)

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Kubernetes: enable docker health probe
```