### PR TITLE
DCOS E2E: only do az vm list for k8s

### DIFF
--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -161,21 +161,23 @@ func (cli *CLIProvisioner) provision() error {
 		return errors.Wrap(err, "Error while trying to create deployment")
 	}
 
-	// Store the hosts for future introspection
-	hosts, err := cli.Account.GetHosts(cli.Config.Name)
-	if err != nil {
-		return err
-	}
-	var masters, agents []azure.VM
-	for _, host := range hosts {
-		if strings.Contains(host.Name, "master") {
-			masters = append(masters, host)
-		} else if strings.Contains(host.Name, "agent") {
-			agents = append(agents, host)
+	if cli.Config.IsKubernetes() {
+		// Store the hosts for future introspection
+		hosts, err := cli.Account.GetHosts(cli.Config.Name)
+		if err != nil {
+			return err
 		}
+		var masters, agents []azure.VM
+		for _, host := range hosts {
+			if strings.Contains(host.Name, "master") {
+				masters = append(masters, host)
+			} else if strings.Contains(host.Name, "agent") {
+				agents = append(agents, host)
+			}
+		}
+		cli.Masters = masters
+		cli.Agents = agents
 	}
-	cli.Masters = masters
-	cli.Agents = agents
 
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: We're doing an unnecessary `az vm list` in our DC/OS E2E flow, which may be contributing to flakiness

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
DCOS E2E: only do az vm list for k8s
```