### PR TITLE
Kubernetes CIS: apiserver: --insecure-port=0

### DIFF
--- a/pkg/acsengine/defaults-apiserver.go
+++ b/pkg/acsengine/defaults-apiserver.go
@@ -16,7 +16,7 @@ func setAPIServerConfig(cs *api.ContainerService) {
 		"--allow-privileged":           "true",
 		"--anonymous-auth":             "false",
 		"--audit-log-path":             "/var/log/kubeaudit/audit.log",
-		"--insecure-port":              "8080",
+		"--insecure-port":              "0",
 		"--secure-port":                "443",
 		"--service-account-lookup":     "true",
 		"--etcd-cafile":                "/etc/kubernetes/certs/ca.crt",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:  Sets apiserver runtime config option `--insecure-port` to "0"

See: https://github.com/Azure/acs-engine/issues/3507

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Kubernetes CIS: apiserver hardening
```