### PR TITLE
Tune kube-dns deployment to fix problems with Accelerated Networking

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-kube-dns-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-kube-dns-deployment.yaml
@@ -129,9 +129,11 @@ spec:
         - "-k"
         - "--cache-size=1000"
         - "--no-resolv"
-        - "--server=127.0.0.1#10053"
+        - "--server=/<kubernetesKubeletClusterDomain>/127.0.0.1#10053"
         - "--server=/in-addr.arpa/127.0.0.1#10053"
         - "--server=/ip6.arpa/127.0.0.1#10053"
+        - "--server=168.63.129.16"
+        - "--address=/com.svc.<kubernetesKubeletClusterDomain>/net.svc.<kubernetesKubeletClusterDomain>/org.svc.<kubernetesKubeletClusterDomain>/com.<kubernetesKubeletClusterDomain>/net.<kubernetesKubeletClusterDomain>/org.<kubernetesKubeletClusterDomain>/"
         - "--log-facility=-"
         image: <kubernetesDNSMasqSpec>
         name: dnsmasq
@@ -173,6 +175,11 @@ spec:
             cpu: 10m
             memory: 50Mi
       dnsPolicy: Default
+      dnsConfig:
+        options:
+        - name: attempts
+          value: "2"
+        - name: single-request-reopen
       serviceAccountName: kube-dns
       nodeSelector:
         beta.kubernetes.io/os: linux


### PR DESCRIPTION
Surprinsingly enough, turning Accelerated Networking on provokes random DNS requests timeouts.

This patch improves the configuration of dnsmasq and turn on glibc mechanism that circumvent the
problem I have diagnosed (although I still don't know why Accelerated Networking triggers it).

```
  # Forward cluster.local to skydns
  --server=/cluster.local/127.0.0.1#10053
  # Forward all other zones to Azure DNS
  --server=168.63.129.16
  # Force dnsmasq to directly return with a NXDomain response for bogus
  # request due to the search domains defined in /etc/resolv.conf
  --address=/com.svc.cluster.local/net.svc.cluster.local/org.svc.cluster.local/com.cluster.local/net.cluster.local/org.cluster.local/
```

```yaml
  # Tune /etc/resolv.conf to resend requests if response grouped and lost
  dnsConfig:
    options:
    - name: attempts
      value: "2"
    - name: single-request-reopen
```

https://github.com/Azure/acs-engine/issues/3546