### PR TITLE
Add validation when PodCidr is set in the Azure CNI case.

### DIFF
--- a/pkg/api/agentPoolOnlyApi/v20180331/errors.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/errors.go
@@ -5,6 +5,9 @@ import "github.com/pkg/errors"
 // ErrorInvalidNetworkProfile error
 var ErrorInvalidNetworkProfile = errors.New("ServiceCidr, DNSServiceIP, DockerBridgeCidr should all be empty or neither should be empty")
 
+// ErrorPodCidrNotSetableInAzureCNI error
+var ErrorPodCidrNotSetableInAzureCNI = errors.New("PodCidr should not be set when network plugin is set to Azure")
+
 // ErrorInvalidNetworkPlugin error
 var ErrorInvalidNetworkPlugin = errors.New("Network plugin should be either Azure or Kubenet")
 

--- a/pkg/api/agentPoolOnlyApi/v20180331/validate.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/validate.go
@@ -211,6 +211,11 @@ func validateVNET(a *Properties) error {
 			} else {
 				return ErrorInvalidNetworkProfile
 			}
+
+			// PodCidr should not be set for Azure CNI
+			if n.NetworkPlugin == Azure && n.PodCidr != "" {
+				return ErrorPodCidrNotSetableInAzureCNI
+			}
 		default:
 			return ErrorInvalidNetworkPlugin
 		}

--- a/pkg/api/agentPoolOnlyApi/v20180331/validate_test.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/validate_test.go
@@ -129,6 +129,35 @@ func TestValidateVNET(t *testing.T) {
 		t.Errorf("Failed to test validate VNET: expected %s but got %s", ErrorInvalidNetworkProfile, err.Error())
 	}
 
+	// network profile has NetworkPlugin set to azure and PodCidr set, should fail
+	n = &NetworkProfile{
+		NetworkPlugin: NetworkPlugin("azure"),
+		PodCidr:       "a.b.c.d",
+	}
+
+	p = []*AgentPoolProfile{
+		{
+			VnetSubnetID: vnetSubnetID1,
+			MaxPods:      &maxPods1,
+		},
+		{
+			VnetSubnetID: vnetSubnetID2,
+			MaxPods:      &maxPods2,
+		},
+	}
+
+	a = &Properties{
+		NetworkProfile:    n,
+		AgentPoolProfiles: p,
+	}
+
+	if err := validateVNET(a); err != ErrorPodCidrNotSetableInAzureCNI {
+		if err == nil {
+			t.Errorf("Failed to test validate VNET: expected %s but got no error", ErrorPodCidrNotSetableInAzureCNI)
+		}
+		t.Errorf("Failed to test validate VNET: expected %s but got %s", ErrorPodCidrNotSetableInAzureCNI, err.Error())
+	}
+
 	// NetworkPlugin is not azure or kubenet
 	n = &NetworkProfile{
 		NetworkPlugin:    NetworkPlugin("none"),


### PR DESCRIPTION
**What this PR does / why we need it**:
Add validation when PodCidr is set in the Azure CNI case. This should avoid confusion on the Terraform side, otherwise they will see PodCidr is changed and will think a new cluster needs to be created.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes
https://github.com/terraform-providers/terraform-provider-azurerm/issues/1648

