### PR TITLE
change outbound networking check to use more portable constructs

### DIFF
--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -62,7 +62,7 @@ else
 fi
 
 function testOutboundConnection() {
-    retrycmd_if_failure 20 1 3 curl -I https://www.google.com || retrycmd_if_failure 20 1 3 curl -I https://www.1688.com || exit $ERR_OUTBOUND_CONN_FAIL
+    retrycmd_if_failure 20 1 3 nc -v www.google.com 443 || retrycmd_if_failure 20 1 3 nc -v www.1688.com 443 || exit $ERR_OUTBOUND_CONN_FAIL
 }
 
 function waitForCloudInit() {

--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -62,7 +62,7 @@ else
 fi
 
 function testOutboundConnection() {
-    retrycmd_if_failure 20 1 3 nc -v 8.8.8.8 53 || retrycmd_if_failure 20 1 3 nc -v 8.8.4.4 53 || exit $ERR_OUTBOUND_CONN_FAIL
+    retrycmd_if_failure 20 1 3 curl -I https://www.google.com || retrycmd_if_failure 20 1 3 curl -I https://www.1688.com || exit $ERR_OUTBOUND_CONN_FAIL
 }
 
 function waitForCloudInit() {


### PR DESCRIPTION
(1) DNS lookup which may be local to a custom VNET, and (2) external site with port 443 which is not blocked by most corporate "on-prem" firewalls.

reasons:  the previous test of google's DNS server on port 53 is blocked by many "on-prem" (and private Azure Tenant) corporate deployments, and will accordingly fail to provision the k8s cluster

issue filed subsequently -> https://github.com/Azure/acs-engine/issues/3571

**What this PR does / why we need it**:

Was not possible to deploy ACS clusters to generally closed VNETs.  Most corporate deployments __DO__ allow outbound traffic to port 443 via https protocol

**Special notes for your reviewer**:

```release-note
```