### PR TITLE
Support bool values for `--set`

### DIFF
--- a/pkg/acsengine/transform/apimodel_merger_test.go
+++ b/pkg/acsengine/transform/apimodel_merger_test.go
@@ -15,9 +15,8 @@ func TestAPIModelMergerMapValues(t *testing.T) {
 	values := []string{"masterProfile.count=5", "agentPoolProfiles[0].name=agentpool1", "linuxProfile.adminUsername=admin"}
 
 	MapValues(m, values)
-	Expect(m["masterProfile.count"].intValue).To(BeIdenticalTo(int64(5)))
-	Expect(m["agentPoolProfiles[0].name"].arrayValue).To(BeTrue())
-	Expect(m["agentPoolProfiles[0].name"].arrayIndex).To(BeIdenticalTo(0))
+	Expect(*m["masterProfile.count"].intValue).To(BeIdenticalTo(int64(5)))
+	Expect(*m["agentPoolProfiles[0].name"].arrayIndex).To(BeIdenticalTo(0))
 	Expect(m["agentPoolProfiles[0].name"].arrayProperty).To(BeIdenticalTo("name"))
 	Expect(m["agentPoolProfiles[0].name"].arrayName).To(BeIdenticalTo("agentPoolProfiles"))
 	Expect(m["agentPoolProfiles[0].name"].stringValue).To(BeIdenticalTo("agentpool1"))
@@ -28,7 +27,7 @@ func TestMergeValuesWithAPIModel(t *testing.T) {
 	RegisterTestingT(t)
 
 	m := make(map[string]APIModelValue)
-	values := []string{"masterProfile.count=5", "agentPoolProfiles[0].name=agentpool1", "linuxProfile.adminUsername=admin"}
+	values := []string{"masterProfile.count=5", "agentPoolProfiles[0].name=agentpool1", "linuxProfile.adminUsername=admin", "orchestratorProfile.kubernetesConfig.useManagedIdentity=true"}
 
 	MapValues(m, values)
 	tmpFile, _ := MergeValuesWithAPIModel("../testdata/simple/kubernetes.json", m)
@@ -47,4 +46,7 @@ func TestMergeValuesWithAPIModel(t *testing.T) {
 
 	agentPoolProfileName := jsonAPIModel.Path("properties.agentPoolProfiles").Index(0).Path("name").Data().(string)
 	Expect(agentPoolProfileName).To(BeIdenticalTo("agentpool1"))
+
+	useManagedID := jsonAPIModel.Path("properties.orchestratorProfile.kubernetesConfig.useManagedIdentity").Data()
+	Expect(useManagedID).To(BeIdenticalTo(true))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Adds support for bool values to `--set`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [x] unit tests

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
support bool values for --set
```
