### PR TITLE
Update docs for some e2e environment variables

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -87,8 +87,8 @@ deploy and tear down a cluster as part of the test (this is enabled by default).
 You'll need access to an Azure subscription, as well as at least the following
 environment variables to be set:
 
-* `CLIENT_ID`: Azure client ID
-* `CLIENT_SECRET`: Azure client secret
+* `CLIENT_ID`: "name" field (a URL) from an Azure service principal
+* `CLIENT_SECRET`: "password" field from an Azure service principal
 * `SUBSCRIPTION_ID`: Azure subscription UUID
 * `TENANT_ID`: Azure tenant UUID
 


### PR DESCRIPTION
Describes the origin of two environment variables needed by `make test-kubernetes` more clearly.