### PR TITLE
add VM SKUs to acceleratedNetworking blacklist

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -91,6 +91,15 @@ func CreateSSH(rg io.Reader, s *i18n.Translator) (privateKey *rsa.PrivateKey, pu
 
 // AcceleratedNetworkingSupported check if the VmSKU support the Accelerated Networking
 func AcceleratedNetworkingSupported(sku string) bool {
+	if strings.Contains(sku, "Standard_D2s_v3") {
+		return false
+	}
+	if strings.Contains(sku, "Standard_DS3") {
+		return false
+	}
+	if strings.Contains(sku, "Standard_D2_v3") {
+		return false
+	}
 	if strings.Contains(sku, "Standard_A") {
 		return false
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: `Standard_D2s_v3`, `Standard_DS3`, `Standard_D2_v3` are complaining about not having accelerated networking support from our production data.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
add VM SKUs to acceleratedNetworking blacklist
```