### PR TITLE
feat(vsts-ci.yaml): Scaffolding to support VHD image building in vsts

### DIFF
--- a/.vsts-ci.yaml
+++ b/.vsts-ci.yaml
@@ -1,0 +1,9 @@
+# trigger:
+# - master
+
+phases:
+- phase: build_vhd
+  queue: Hosted Linux Preview
+  steps:
+  - script: make info
+    displayName: Building VHD


### PR DESCRIPTION
This just provides a basic `.vsts-ci.yaml` file which will be used to produce vhd images in vsts.