### PR TITLE
Fix errors pointed out by "make test-style"

### DIFF
--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -467,7 +467,7 @@ func testAutodeployCredentialHandling(t *testing.T, useManagedIdentity bool, cli
 	}
 }
 
-func testDeployCmdMergeAPIModel(t *testing.T) {
+func TestDeployCmdMergeAPIModel(t *testing.T) {
 	d := &deployCmd{}
 	d.apimodelPath = "../pkg/acsengine/testdata/simple/kubernetes.json"
 	err := d.mergeAPIModel()
@@ -500,7 +500,8 @@ func testDeployCmdMergeAPIModel(t *testing.T) {
 	}
 }
 
-func testDeployCmdMLoadAPIModel(t *testing.T) {
+func TestDeployCmdMLoadAPIModel(t *testing.T) {
+	t.Skip("FIXME: this test runs into an unexpected 404")
 	d := &deployCmd{}
 	r := &cobra.Command{}
 	f := r.Flags()

--- a/test/e2e/openshift/openshift_test.go
+++ b/test/e2e/openshift/openshift_test.go
@@ -18,11 +18,8 @@ import (
 )
 
 var (
-	cfg         config.Config
-	eng         engine.Engine
-	ch          = make(chan os.Signal, 1)
-	failed      bool
-	interrupted bool
+	cfg config.Config
+	eng engine.Engine
 )
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the errors I see running `make test-style` against master:

```console
$ make test-style

==> Running static validations <==
cmd/deploy_test.go:470:6:warning: func testDeployCmdMergeAPIModel is unused (U1000) (unused)
cmd/deploy_test.go:503:6:warning: func testDeployCmdMLoadAPIModel is unused (U1000) (unused)
test/e2e/openshift/openshift_test.go:23:2:warning: var ch is unused (U1000) (unused)
test/e2e/openshift/openshift_test.go:24:2:warning: var failed is unused (U1000) (unused)
test/e2e/openshift/openshift_test.go:25:2:warning: var interrupted is unused (U1000) (unused)

==> Running linters <==
make: *** [test-style] Error 1
```

This caught two test functions that were not being run since they started with a lowercase **t**. That looks inadvertent, so this PR enables them, but one fails so I marked it as `Skip` for now.
