### PR TITLE
Ensure calico daemonset manifest passes validation in k8s 1.11

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-calico-daemonset.yaml
@@ -439,9 +439,8 @@ spec:
 # Create all the CustomResourceDefinitions needed for
 # Calico policy-only mode.
 ---
-
+# Calico Felix Configuration
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Felix Configuration
 kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
@@ -457,9 +456,8 @@ spec:
     singular: felixconfiguration
 
 ---
-
+# Calico BGP Configuration
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico BGP Configuration
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
@@ -475,9 +473,8 @@ spec:
     singular: bgpconfiguration
 
 ---
-
+# Calico IP Pools
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico IP Pools
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
@@ -493,9 +490,8 @@ spec:
     singular: ippool
 
 ---
-
+# Calico Host Endpoints
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Host Endpoints
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
@@ -511,9 +507,8 @@ spec:
     singular: hostendpoint
 
 ---
-
+# Calico Cluster Information
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Cluster Information
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
@@ -529,9 +524,8 @@ spec:
     singular: clusterinformation
 
 ---
-
+# Calico Global Network Policies
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global Network Policies
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
@@ -547,9 +541,8 @@ spec:
     singular: globalnetworkpolicy
 
 ---
-
+# Calico Global Network Sets
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global Network Sets
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
@@ -565,9 +558,8 @@ spec:
     singular: globalnetworkset
 
 ---
-
+# Calico Network Policies
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Network Policies
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Calico fails when deploying k8s 1.11 clusters due to new validation on customresourcedefinitions introduced in https://github.com/kubernetes/kubernetes/pull/64267

**Which issue this PR fixes**:
fixes #3393

**Special notes for your reviewer**:
I moved the erroneous description field to a commented line instead. Tested deploying this template over a previously failing 1.11 cluster, and calico successfully gets set up.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
