### PR TITLE
add HyperV isolation by default

### DIFF
--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -321,7 +321,10 @@ c:\k\kubelet.exe --hostname-override=`$env:computername --pod-infra-container-im
         $KubeletArgList += "--api-servers=https://`${global:MasterIP}:443"
         $KubeletCommandLine += " --api-servers=https://`${global:MasterIP}:443"
     }
-
+    
+    # add HyperV isolation by default
+    $KubeletCommandLine += "  --feature-gates=HyperVContainer=true"
+    
     # more time is needed to pull windows server images
     $KubeletCommandLine += " --image-pull-progress-deadline=20m --cgroups-per-qos=false --enforce-node-allocatable=`"`""
     $KubeletCommandLine += " --volume-plugin-dir=`$global:VolumePluginDir"


### PR DESCRIPTION


**What this PR does / why we need it**:

As #2627 the `kubeletConfig` flag is ignored by the script creating the kubelet startup script on windows; however, Hyper-V isolation could be enabled by default on all Windows nodes safely as it doesn't affect startup of kubelet if not present (for example, when the VM size doesn't include virtualization). This patch just enables the flag on all Windows agent nodes, avoiding post-deployment fiddling with `c:\k\kubeletstart.ps1`. I'll follow up with a PR with documentation amendment. Tested on 1.11.1.

**Which issue this PR fixes** : 
fixes #2627 

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
