### PR TITLE
add support for Kubernetes 1.9.10

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -52,6 +52,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.9.7":          true,
 	"1.9.8":          true,
 	"1.9.9":          true,
+	"1.9.10":         true,
 	"1.10.0-beta.2":  true,
 	"1.10.0-beta.4":  true,
 	"1.10.0-rc.1":    true,


### PR DESCRIPTION
**What this PR does / why we need it**:

See https://github.com/kubernetes/kubernetes/releases/tag/v1.9.10

TODO:

- [ ] upload Windows binary

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add support for Kubernetes 1.9.10
```
