### PR TITLE
get FD count for managed disk based on region

### DIFF
--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -87,9 +87,9 @@
       "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
       "properties":
         {
-            "platformFaultDomainCount": 2,
+            "platformFaultDomainCount": "[variables('platformFaultDomainCount')]",
             "platformUpdateDomainCount": 3,
-		"managed" : "true"
+            "managed": true
         },
 
       "type": "Microsoft.Compute/availabilitySets"
@@ -348,4 +348,4 @@
       }
     }
     {{end}}
-    
+

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -5,9 +5,9 @@
       "name": "[variables('masterAvailabilitySet')]",
       "properties":
         {
-            "platformFaultDomainCount": 2,
+            "platformFaultDomainCount": "[variables('platformFaultDomainCount')]",
             "platformUpdateDomainCount": 3,
-		        "managed" : true
+            "managed": true
         },
       "type": "Microsoft.Compute/availabilitySets"
     },
@@ -640,7 +640,7 @@
        "apiVersion": "[variables('apiVersionKeyVault')]",
        "location": "[variables('location')]",
        {{ if UseManagedIdentity}}
-       "dependsOn": 
+       "dependsOn":
        [
           {{$max := .MasterProfile.Count}}
           {{$c := subtract $max 1}}
@@ -673,7 +673,7 @@
            }
          ],
  {{else}}
-         "accessPolicies": 
+         "accessPolicies":
          [
           {{$max := .MasterProfile.Count}}
           {{$c := subtract $max 1}}

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -200,6 +200,7 @@
     "primaryAvailabilitySetName": "",
     "vmType": "vmss",
 {{end}}
+    "platformFaultDomainCount": "[if(greater(parameters('platformFaultDomainCount'),0),parameters('platformFaultDomainCount'),if(contains(split('eastus,eastus2,westus,centralus,northcentralus,southcentralus,canadacentral,northeurope,westeurope',','),variables('location')),3,if(contains('centraluseuap',variables('location')),1,2)))]",
 {{if not IsHostedMaster }}
     {{if IsPrivateCluster}}
         "kubeconfigServer": "[concat('https://', variables('kubernetesAPIServerIP'), ':443')]",

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -806,6 +806,13 @@
         "description": "Encryption at rest key for etcd"
       },
       "type": "string"
+    },
+    "platformFaultDomainCount": {
+      "defaultValue": 0,
+      "metadata": {
+        "description": "Number of fault domains to use. Leave at 0 to have the template set a value appropriate to the Azure region"
+      },
+      "type": "int"
     }
 {{if ProvisionJumpbox}}
     ,"jumpboxVMName": {

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -67,9 +67,9 @@
       "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
       "properties":
         {
-            "platformFaultDomainCount": 2,
+            "platformFaultDomainCount": "[variables('platformFaultDomainCount')]",
             "platformUpdateDomainCount": 3,
-		        "managed" : "true"
+            "managed": true
         },
 
       "type": "Microsoft.Compute/availabilitySets"


### PR DESCRIPTION
**What this PR does / why we need it**: Assigns the fault domain count for managed disks based on region support. See:

https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/managed-disks-common-fault-domain-region-list.md

**Which issue this PR fixes**: 
Fixes #1509
Closes #2862

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
```release-note
get FD count for managed disk based on region
```
