### PR TITLE
Fix cni cleanup during kubelet start to be graceful & not loose any logs

### DIFF
--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -386,9 +386,31 @@ if (`$hnsNetwork)
 
     Write-Host "Cleaning up old HNS network found"
     Remove-HnsNetwork `$hnsNetwork
-    Start-Sleep 10
-    `$cnijson = "$global:KubeDir" + "\azure-vnet*"
-    remove-item `$cnijson  -ErrorAction SilentlyContinue
+    # Kill all cni instances & stale data left by cni
+    # Cleanup all files related to cni
+    `$cnijson = "$global:KubeDir" + "\azure-vnet-ipam.json"
+    if ((Test-Path `$cnijson))
+    {
+        Remove-Item `$cnijson
+    }
+    `$cnilock = "$global:KubeDir" + "\azure-vnet-ipam.lock"
+    if ((Test-Path `$cnilock))
+    {
+        Remove-Item `$cnilock
+    }
+    taskkill /IM azure-vnet-ipam.exe /f
+
+    `$cnijson = "$global:KubeDir" + "\azure-vnet.json"
+    if ((Test-Path `$cnijson))
+    {
+        Remove-Item `$cnijson
+    }
+    `$cnilock = "$global:KubeDir" + "\azure-vnet.lock"
+    if ((Test-Path `$cnilock))
+    {
+        Remove-Item `$cnilock
+    }
+    taskkill /IM azure-vnet.exe /f
 }
 
 # Restart Kubeproxy, which would wait, until the network is created


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
* Save the CNI Logs
* Gracefully shutdown CNI instances & cleanup CNI json & locks if any

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
