### PR TITLE
restore exechealthz defs for back compat

### DIFF
--- a/pkg/acsengine/k8s_versions.go
+++ b/pkg/acsengine/k8s_versions.go
@@ -11,6 +11,7 @@ var k8sComponentVersions = map[string]map[string]string{
 	"1.12": {
 		"dockerEngine":                     "1.13.*",
 		"dashboard":                        "kubernetes-dashboard-amd64:v1.8.3",
+		"exechealthz":                      "exechealthz-amd64:1.2",
 		"addon-resizer":                    "addon-resizer:1.8.1",
 		"heapster":                         "heapster-amd64:v1.5.3",
 		"metrics-server":                   "metrics-server-amd64:v0.2.1",
@@ -42,6 +43,7 @@ var k8sComponentVersions = map[string]map[string]string{
 	"1.11": {
 		"dockerEngine":                     "1.13.*",
 		"dashboard":                        "kubernetes-dashboard-amd64:v1.8.3",
+		"exechealthz":                      "exechealthz-amd64:1.2",
 		"addon-resizer":                    "addon-resizer:1.8.1",
 		"heapster":                         "heapster-amd64:v1.5.3",
 		"metrics-server":                   "metrics-server-amd64:v0.2.1",
@@ -285,6 +287,7 @@ func getK8sVersionComponents(version string, overrides map[string]string) map[st
 			"windowszip":                  "v" + version + "-1int.zip",
 			"dockerEngineVersion":         k8sComponentVersions["1.12"]["dockerEngine"],
 			DefaultDashboardAddonName:     k8sComponentVersions["1.12"]["dashboard"],
+			"exechealthz":                 k8sComponentVersions["1.12"]["exechealthz"],
 			"addonresizer":                k8sComponentVersions["1.12"]["addon-resizer"],
 			"heapster":                    k8sComponentVersions["1.12"]["heapster"],
 			DefaultMetricsServerAddonName: k8sComponentVersions["1.12"]["metrics-server"],
@@ -320,6 +323,7 @@ func getK8sVersionComponents(version string, overrides map[string]string) map[st
 			"windowszip":                  "v" + version + "-1int.zip",
 			"dockerEngineVersion":         k8sComponentVersions["1.11"]["dockerEngine"],
 			DefaultDashboardAddonName:     k8sComponentVersions["1.11"]["dashboard"],
+			"exechealthz":                 k8sComponentVersions["1.11"]["exechealthz"],
 			"addonresizer":                k8sComponentVersions["1.11"]["addon-resizer"],
 			"heapster":                    k8sComponentVersions["1.11"]["heapster"],
 			DefaultMetricsServerAddonName: k8sComponentVersions["1.11"]["metrics-server"],

--- a/pkg/acsengine/k8s_versions_test.go
+++ b/pkg/acsengine/k8s_versions_test.go
@@ -16,6 +16,7 @@ func TestGetK8sVersionComponents(t *testing.T) {
 		"windowszip":                  "v1.11.0-alpha.1-1int.zip",
 		"dockerEngineVersion":         k8sComponentVersions["1.11"]["dockerEngine"],
 		DefaultDashboardAddonName:     k8sComponentVersions["1.11"]["dashboard"],
+		"exechealthz":                 k8sComponentVersions["1.11"]["exechealthz"],
 		"addonresizer":                k8sComponentVersions["1.11"]["addon-resizer"],
 		"heapster":                    k8sComponentVersions["1.11"]["heapster"],
 		DefaultMetricsServerAddonName: k8sComponentVersions["1.11"]["metrics-server"],


### PR DESCRIPTION
**What this PR does / why we need it**:
AKS using acs-engine had a malformed image tag with the healthz container in kube-dns for 1.11.1:

```
  healthz:
    Container ID:
    Image:         k8s.gcr.io/
    Image ID:
    Port:          8080/TCP
    Args:
      --cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null
      --url=/healthz-dnsmasq
      --cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1:10053 >/dev/null
      --url=/healthz-kubedns
      --port=8080
      --quiet
```

I think #3595 didn't go far enough, so this adds the `exechealthz` def to 1.11 and 1.12.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
```release-note
restore exechealthz defs for back compat to 1.11 and 1.12
```
