### PR TITLE
add support for Kubernetes 1.11.2

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -72,6 +72,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.11.0-rc.3":    true,
 	"1.11.0":         true,
 	"1.11.1":         true,
+	"1.11.2":         true,
 	"1.12.0-alpha.1": true,
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

See https://github.com/kubernetes/kubernetes/releases/tag/v1.11.2

TODO:

- [x] upload Windows binary

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
```release-note
add support for Kubernetes 1.11.2
```
