### PR TITLE
Kubernetes: VMSS scale set name as 1st class cluster configuration

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -444,6 +444,7 @@ type AgentPoolProfile struct {
 	OSType                       OSType               `json:"osType,omitempty"`
 	Ports                        []int                `json:"ports,omitempty"`
 	AvailabilityProfile          string               `json:"availabilityProfile"`
+	ScaleSetName                 string               `json:"scaleSetName,omitempty"`
 	ScaleSetPriority             string               `json:"scaleSetPriority,omitempty"`
 	ScaleSetEvictionPolicy       string               `json:"scaleSetEvictionPolicy,omitempty"`
 	StorageProfile               string               `json:"storageProfile,omitempty"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: // TODO

- add a property "vmss scaleset name" to the agent pool profile api model
- use that property throughout the code where needed
- remove `primaryScaleSetName` dynamic ARM variable

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Kubernetes: VMSS scale set name as 1st class cluster configuration
```