### PR TITLE
Scale down shouldn't depend on VM index

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -264,7 +264,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 			}
 
 			vmsToDelete := make([]string, 0)
-			for i := len(vms) - 1; i >= sc.newDesiredAgentCount; i-- {
+			for i := currentNodeCount - 1; i >= sc.newDesiredAgentCount; i-- {
 				vmsToDelete = append(vmsToDelete, vms[i])
 			}
 

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"sort"
 	// "sort"
 	"strings"
 	"time"
@@ -213,8 +214,6 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 	orchestratorInfo := sc.containerService.Properties.OrchestratorProfile
 	var currentNodeCount, highestUsedIndex, index, winPoolIndex int
 	winPoolIndex = -1
-	// indexes := make([]int, 0)
-	// indexToVM := make(map[int]string)
 	vms := make([]string, 0)
 	if sc.agentPool.IsAvailabilitySets() {
 		for vmsListPage, err := sc.client.ListVirtualMachines(ctx, sc.resourceGroupName); vmsListPage.NotDone(); err = vmsListPage.Next() {
@@ -244,22 +243,18 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 					highestUsedIndex = index
 				}
 
-				// indexToVM[index] = *vm.Name
-				// indexes = append(indexes, index)
 				vms = append(vms, *vm.Name)
 			}
 		}
-		// sortedIndexes := sort.IntSlice(indexes)
-		// sortedIndexes.Sort()
-		// indexes = []int(sortedIndexes)
-		// currentNodeCount = len(indexes)
+		sortedVMs := sort.StringSlice(vms)
+		sortedVMs.Sort()
+		vms = []string(sortedVMs)
 		currentNodeCount = len(vms)
 
 		if currentNodeCount == sc.newDesiredAgentCount {
 			log.Info("Cluster is currently at the desired agent count.")
 			return nil
 		}
-		// highestUsedIndex = indexes[len(indexes)-1]
 
 		// Scale down Scenario
 		if currentNodeCount > sc.newDesiredAgentCount {
@@ -269,10 +264,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 			}
 
 			vmsToDelete := make([]string, 0)
-			// for i := currentNodeCount - 1; i >= sc.newDesiredAgentCount; i-- {
-			// 	vmsToDelete = append(vmsToDelete, indexToVM[i])
-			// }
-			for i := len(vms)-1; i >= sc.newDesiredAgentCount; i-- {
+			for i := len(vms) - 1; i >= sc.newDesiredAgentCount; i-- {
 				vmsToDelete = append(vmsToDelete, vms[i])
 			}
 

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -9,7 +9,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
-	"sort"
+	// "sort"
 	"strings"
 	"time"
 
@@ -213,8 +213,9 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 	orchestratorInfo := sc.containerService.Properties.OrchestratorProfile
 	var currentNodeCount, highestUsedIndex, index, winPoolIndex int
 	winPoolIndex = -1
-	indexes := make([]int, 0)
-	indexToVM := make(map[int]string)
+	// indexes := make([]int, 0)
+	// indexToVM := make(map[int]string)
+	vms := make([]string, 0)
 	if sc.agentPool.IsAvailabilitySets() {
 		for vmsListPage, err := sc.client.ListVirtualMachines(ctx, sc.resourceGroupName); vmsListPage.NotDone(); err = vmsListPage.Next() {
 			if err != nil {
@@ -239,20 +240,26 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 					_, _, index, err = utils.K8sLinuxVMNameParts(*vm.Name)
 				}
 
-				indexToVM[index] = *vm.Name
-				indexes = append(indexes, index)
+				if index > highestUsedIndex {
+					highestUsedIndex = index
+				}
+
+				// indexToVM[index] = *vm.Name
+				// indexes = append(indexes, index)
+				vms = append(vms, *vm.Name)
 			}
 		}
-		sortedIndexes := sort.IntSlice(indexes)
-		sortedIndexes.Sort()
-		indexes = []int(sortedIndexes)
-		currentNodeCount = len(indexes)
+		// sortedIndexes := sort.IntSlice(indexes)
+		// sortedIndexes.Sort()
+		// indexes = []int(sortedIndexes)
+		// currentNodeCount = len(indexes)
+		currentNodeCount = len(vms)
 
 		if currentNodeCount == sc.newDesiredAgentCount {
 			log.Info("Cluster is currently at the desired agent count.")
 			return nil
 		}
-		highestUsedIndex = indexes[len(indexes)-1]
+		// highestUsedIndex = indexes[len(indexes)-1]
 
 		// Scale down Scenario
 		if currentNodeCount > sc.newDesiredAgentCount {
@@ -262,8 +269,11 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 			}
 
 			vmsToDelete := make([]string, 0)
-			for i := currentNodeCount - 1; i >= sc.newDesiredAgentCount; i-- {
-				vmsToDelete = append(vmsToDelete, indexToVM[i])
+			// for i := currentNodeCount - 1; i >= sc.newDesiredAgentCount; i-- {
+			// 	vmsToDelete = append(vmsToDelete, indexToVM[i])
+			// }
+			for i := len(vms)-1; i >= sc.newDesiredAgentCount; i-- {
+				vmsToDelete = append(vmsToDelete, vms[i])
 			}
 
 			switch orchestratorInfo.OrchestratorType {

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path"
 	"sort"
-	// "sort"
 	"strings"
 	"time"
 

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -239,7 +239,6 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 					_, _, index, err = utils.K8sLinuxVMNameParts(*vm.Name)
 				}
 
-
 				indexToVM[index] = *vm.Name
 				indexes = append(indexes, index)
 			}
@@ -262,11 +261,6 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 				return errors.New("master-FQDN is required to scale down a kubernetes cluster's agent pool")
 			}
 
-			// still a problem if 0, 1, 3
-			// what if desired agent count is 3, so I try to delete 3 so it's 0,1,2, but it's only 0,1
-			// except that won't happen because it will start at index 2
-			// part of problem is this won't delete vm w/ index 3
-			// I could make a slice of indexes to go with map... iterate over indices. wait that already exists
 			vmsToDelete := make([]string, 0)
 			for i := currentNodeCount - 1; i >= sc.newDesiredAgentCount; i-- {
 				index = indexes[i]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
When upgrading a cluster, there can be gaps in the index in the VM names (e.g. there are 3 VMs with names k8s-agentpool1-00000000-0, k8s-agentpool1-00000000-1, k8s-agentpool1-00000000-3 but none ending in 2). This is a problem when scaling down a cluster with the `acs-engine scale` command because the index in the name is used for iterating over the VMs so there might be an attempt to drain a node with no name and the scale operation will fail. The index isn't needed for iterating over the VMs so they can be stored in a slice instead.

**Which issue this PR fixes**: fixes #2362

**Special notes for your reviewer**:
I want to know that I'm not breaking anything, though I've been using this change for a while without problems. This seems like a simple fix so I feel like I'm missing something.

**If applicable**:
- [ ] documentation
- [x] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```