### PR TITLE
Kubernetes: only enable blobfuse drivers on k8s 1.8 and above

### DIFF
--- a/pkg/acsengine/addons.go
+++ b/pkg/acsengine/addons.go
@@ -67,7 +67,7 @@ func setAddonsConfig(cs *api.ContainerService) {
 
 	defaultBlobfuseFlexVolumeAddonsConfig := api.KubernetesAddon{
 		Name:    DefaultBlobfuseFlexVolumeAddonName,
-		Enabled: helpers.PointerToBool(api.DefaultBlobfuseFlexVolumeAddonEnabled),
+		Enabled: helpers.PointerToBool(common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.8.0") && api.DefaultBlobfuseFlexVolumeAddonEnabled),
 		Containers: []api.KubernetesContainerSpec{
 			{
 				Name:           DefaultBlobfuseFlexVolumeAddonName,
@@ -81,7 +81,7 @@ func setAddonsConfig(cs *api.ContainerService) {
 
 	defaultSMBFlexVolumeAddonsConfig := api.KubernetesAddon{
 		Name:    DefaultSMBFlexVolumeAddonName,
-		Enabled: helpers.PointerToBool(api.DefaultSMBFlexVolumeAddonEnabled),
+		Enabled: helpers.PointerToBool(common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.8.0") && api.DefaultSMBFlexVolumeAddonEnabled),
 		Containers: []api.KubernetesContainerSpec{
 			{
 				Name:           DefaultSMBFlexVolumeAddonName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Blobfuse drivers are for 1.8 and greater clusters only. @andyzhangx FYI

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Kubernetes: only enable blobfuse drivers on k8s 1.8 and above
```