### PR TITLE
Fixing #3246 - Windows kubelet configs shouldn't overwrite Linux configs in hybrid cluster

### DIFF
--- a/pkg/acsengine/addons.go
+++ b/pkg/acsengine/addons.go
@@ -67,7 +67,7 @@ func setAddonsConfig(cs *api.ContainerService) {
 
 	defaultBlobfuseFlexVolumeAddonsConfig := api.KubernetesAddon{
 		Name:    DefaultBlobfuseFlexVolumeAddonName,
-		Enabled: helpers.PointerToBool(api.DefaultBlobfuseFlexVolumeAddonEnabled),
+		Enabled: helpers.PointerToBool(common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.8.0") && api.DefaultBlobfuseFlexVolumeAddonEnabled),
 		Containers: []api.KubernetesContainerSpec{
 			{
 				Name:           DefaultBlobfuseFlexVolumeAddonName,
@@ -81,7 +81,7 @@ func setAddonsConfig(cs *api.ContainerService) {
 
 	defaultSMBFlexVolumeAddonsConfig := api.KubernetesAddon{
 		Name:    DefaultSMBFlexVolumeAddonName,
-		Enabled: helpers.PointerToBool(api.DefaultSMBFlexVolumeAddonEnabled),
+		Enabled: helpers.PointerToBool(common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.8.0") && api.DefaultSMBFlexVolumeAddonEnabled),
 		Containers: []api.KubernetesContainerSpec{
 			{
 				Name:           DefaultSMBFlexVolumeAddonName,

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -80,8 +80,7 @@ func setKubeletConfig(cs *api.ContainerService) {
 
 	// We don't support user-configurable values for the following,
 	// so any of the value assignments below will override user-provided values
-	var overrideKubeletConfig map[string]string = staticLinuxKubeletConfig
-	for key, val := range overrideKubeletConfig {
+	for key, val := range staticLinuxKubeletConfig {
 		o.KubernetesConfig.KubeletConfig[key] = val
 	}
 
@@ -126,14 +125,13 @@ func setKubeletConfig(cs *api.ContainerService) {
 	// Agent-specific kubelet config changes go here
 	for _, profile := range cs.Properties.AgentPoolProfiles {
 		if profile.KubernetesConfig == nil {
-			// TODO [plang] finish this
-			// if cs.Properties.HasWindows() {
-			// 	overrideKubeletConfig = staticWindowsKubeletConfig
-			// } else {
-			// 	overrideKubeletConfig = staticLinuxKubeletConfig
-			// }
 			profile.KubernetesConfig = &api.KubernetesConfig{}
 			profile.KubernetesConfig.KubeletConfig = copyMap(profile.KubernetesConfig.KubeletConfig)
+			if profile.OSType == "Windows" {
+				for key, val := range staticWindowsKubeletConfig {
+					profile.KubernetesConfig.KubeletConfig[key] = val
+				}
+			}
 		}
 		setMissingKubeletValues(profile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
 

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -30,6 +30,12 @@ func setKubeletConfig(cs *api.ContainerService) {
 	for key, val := range staticLinuxKubeletConfig {
 		staticWindowsKubeletConfig[key] = val
 	}
+	staticWindowsKubeletConfig["--azure-container-registry-config"] = "c:\\k\\azure.json"
+	staticWindowsKubeletConfig["--pod-infra-container-image"] = "kubletwin/pause"
+	staticWindowsKubeletConfig["--kubeconfig"] = "c:\\k\\config"
+	staticWindowsKubeletConfig["--cloud-config"] = "c:\\k\\azure.json"
+	staticWindowsKubeletConfig["--cgroups-per-qos"] = "false"
+	staticWindowsKubeletConfig["--enforce-node-allocatable"] = "\"\""
 
 	// Default Kubelet config
 	defaultKubeletConfig := map[string]string{
@@ -74,12 +80,7 @@ func setKubeletConfig(cs *api.ContainerService) {
 
 	// We don't support user-configurable values for the following,
 	// so any of the value assignments below will override user-provided values
-	var overrideKubeletConfig map[string]string
-	if cs.Properties.HasWindows() {
-		overrideKubeletConfig = staticWindowsKubeletConfig
-	} else {
-		overrideKubeletConfig = staticLinuxKubeletConfig
-	}
+	var overrideKubeletConfig map[string]string = staticLinuxKubeletConfig
 	for key, val := range overrideKubeletConfig {
 		o.KubernetesConfig.KubeletConfig[key] = val
 	}
@@ -125,6 +126,12 @@ func setKubeletConfig(cs *api.ContainerService) {
 	// Agent-specific kubelet config changes go here
 	for _, profile := range cs.Properties.AgentPoolProfiles {
 		if profile.KubernetesConfig == nil {
+			// TODO [plang] finish this
+			// if cs.Properties.HasWindows() {
+			// 	overrideKubeletConfig = staticWindowsKubeletConfig
+			// } else {
+			// 	overrideKubeletConfig = staticLinuxKubeletConfig
+			// }
 			profile.KubernetesConfig = &api.KubernetesConfig{}
 			profile.KubernetesConfig.KubeletConfig = copyMap(profile.KubernetesConfig.KubeletConfig)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous code would apply Windows kubelet static configs over the Linux ones in a hybrid cluster. That would break the Linux nodes

**Which issue this PR fixes**:
fixes #3246 
