### PR TITLE
Kubernetes: disable accelerated networking if Azure CNI

### DIFF
--- a/examples/kubernetes-config/kubernetes-accelerated-network.json
+++ b/examples/kubernetes-config/kubernetes-accelerated-network.json
@@ -2,7 +2,10 @@
   "apiVersion": "vlabs",
   "properties": {
     "orchestratorProfile": {
-      "orchestratorType": "Kubernetes"
+      "orchestratorType": "Kubernetes",
+      "kubernetesConfig": {
+        "networkPlugin": "kubenet"
+      }
     },
     "masterProfile": {
       "count": 1,

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -562,7 +562,7 @@ func setAgentNetworkDefaults(a *api.Properties, isUpgrade, isScale bool) {
 		// On instances that support hyperthreading, Accelerated Networking is supported on VM instances with 4 or more vCPUs.
 		// Supported series are: D/DSv3, E/ESv3, Fsv2, and Ms/Mms.
 		if profile.AcceleratedNetworkingEnabled == nil {
-			profile.AcceleratedNetworkingEnabled = helpers.PointerToBool(!isUpgrade && !isScale && helpers.AcceleratedNetworkingSupported(profile.VMSize))
+			profile.AcceleratedNetworkingEnabled = helpers.PointerToBool(!isUpgrade && !isScale && !a.OrchestratorProfile.IsAzureCNI() && helpers.AcceleratedNetworkingSupported(profile.VMSize))
 		}
 
 		// don't default Distro for OpenShift


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: See #3546 and:

Azure/azure-container-networking#222

While we diagnose possible issues w/ Azure CNI on accelerated networking-backed VMs, let's disable this combination by default for folks who aren't explicitly enabling accelerated networking.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Kubernetes: disable accelerated networking if Azure CNI
```