### PR TITLE
Errors parsing templates (parts/*) are ignored instead of raised

### DIFF
--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -528,7 +528,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			str, err := t.getSingleLineForTemplate(kubernetesJumpboxCustomDataYaml, cs, p)
 
 			if err != nil {
-				panic(e)
+				panic(err)
 				return ""
 			}
 

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -278,7 +278,6 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			kubeConfig, err := GenerateKubeConfig(cs.Properties, cs.Location)
 			if err != nil {
 				panic(err)
-				return ""
 			}
 			return escapeSingleLine(kubeConfig)
 		},
@@ -467,7 +466,6 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			str, e := t.getSingleLineForTemplate(kubernetesMasterCustomDataYaml, cs, profile)
 			if e != nil {
 				panic(e)
-				return ""
 			}
 
 			// add manifests
@@ -511,7 +509,6 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 
 			if e != nil {
 				panic(e)
-				return ""
 			}
 
 			// add artifacts
@@ -529,7 +526,6 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 
 			if err != nil {
 				panic(err)
-				return ""
 			}
 
 			return fmt.Sprintf("\"customData\": \"[base64(concat('%s'))]\",", str)
@@ -608,7 +604,6 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			str, e := t.getSingleLineForTemplate(kubernetesWindowsAgentCustomDataPS1, cs, profile)
 			if e != nil {
 				panic(e)
-				return ""
 			}
 			preprovisionCmd := ""
 			if profile.PreprovisionExtension != nil {

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -277,6 +277,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"GetKubeConfig": func() string {
 			kubeConfig, err := GenerateKubeConfig(cs.Properties, cs.Location)
 			if err != nil {
+				panic(err)
 				return ""
 			}
 			return escapeSingleLine(kubeConfig)
@@ -465,7 +466,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"GetKubernetesMasterCustomData": func(profile *api.Properties) string {
 			str, e := t.getSingleLineForTemplate(kubernetesMasterCustomDataYaml, cs, profile)
 			if e != nil {
-				fmt.Printf("%#v\n", e)
+				panic(e)
 				return ""
 			}
 
@@ -509,6 +510,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			str, e := t.getSingleLineForTemplate(kubernetesAgentCustomDataYaml, cs, profile)
 
 			if e != nil {
+				panic(e)
 				return ""
 			}
 
@@ -526,6 +528,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			str, err := t.getSingleLineForTemplate(kubernetesJumpboxCustomDataYaml, cs, p)
 
 			if err != nil {
+				panic(e)
 				return ""
 			}
 
@@ -604,6 +607,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"GetKubernetesWindowsAgentCustomData": func(profile *api.AgentPoolProfile) string {
 			str, e := t.getSingleLineForTemplate(kubernetesWindowsAgentCustomDataPS1, cs, profile)
 			if e != nil {
+				panic(e)
 				return ""
 			}
 			preprovisionCmd := ""


### PR DESCRIPTION
**What this PR does / why we need it**:

I was changing some templates and had an error in one of the formatting strings. Instead of `acs-engine generate` failing, it succeeded. The end result was that the customData script extension was missing from `azuredeploy.json`. Deploying this would create VMs that would never join the cluster. The deployment would eventually time out, rather than failing fast.

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
