### PR TITLE
Updating Azure-CNI to v1.0.11

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -22,7 +22,7 @@ const (
 	// AzureCniPluginVer specifies version of Azure CNI plugin, which has been mirrored from
 	// https://github.com/Azure/azure-container-networking/releases/download/${AZURE_PLUGIN_VER}/azure-vnet-cni-linux-amd64-${AZURE_PLUGIN_VER}.tgz
 	// to https://acs-mirror.azureedge.net/cni
-	AzureCniPluginVer = "v1.0.7"
+	AzureCniPluginVer = "v1.0.11"
 	// CNIPluginVer specifies the version of CNI implementation
 	// https://github.com/containernetworking/plugins
 	CNIPluginVer = "v0.7.1"


### PR DESCRIPTION
Resolves #3389 / #3447 / #3153

Includes two important Azure-CNI changes for Windows
  Fix for unparseable error returned by CNI (#195)
  Fix for IP Address leak in HNS failure scenario in windows CNI (#218)
Full notes at https://github.com/Azure/azure-container-networking/releases
