### PR TITLE
Revert "get FD count for managed disk based on region"

### DIFF
--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -87,9 +87,9 @@
       "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
       "properties":
         {
-            "platformFaultDomainCount": "[variables('platformFaultDomainCount')]",
+            "platformFaultDomainCount": 2,
             "platformUpdateDomainCount": 3,
-            "managed": true
+		"managed" : "true"
         },
 
       "type": "Microsoft.Compute/availabilitySets"
@@ -348,4 +348,4 @@
       }
     }
     {{end}}
-
+    

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -5,9 +5,9 @@
       "name": "[variables('masterAvailabilitySet')]",
       "properties":
         {
-            "platformFaultDomainCount": "[variables('platformFaultDomainCount')]",
+            "platformFaultDomainCount": 2,
             "platformUpdateDomainCount": 3,
-            "managed": true
+		        "managed" : true
         },
       "type": "Microsoft.Compute/availabilitySets"
     },
@@ -640,7 +640,7 @@
        "apiVersion": "[variables('apiVersionKeyVault')]",
        "location": "[variables('location')]",
        {{ if UseManagedIdentity}}
-       "dependsOn":
+       "dependsOn": 
        [
           {{$max := .MasterProfile.Count}}
           {{$c := subtract $max 1}}
@@ -673,7 +673,7 @@
            }
          ],
  {{else}}
-         "accessPolicies":
+         "accessPolicies": 
          [
           {{$max := .MasterProfile.Count}}
           {{$c := subtract $max 1}}

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -200,7 +200,6 @@
     "primaryAvailabilitySetName": "",
     "vmType": "vmss",
 {{end}}
-    "platformFaultDomainCount": "[if(greater(parameters('platformFaultDomainCount'),0),parameters('platformFaultDomainCount'),if(contains(split('eastus,eastus2,westus,centralus,northcentralus,southcentralus,canadacentral,northeurope,westeurope',','),variables('location')),3,if(contains('centraluseuap',variables('location')),1,2)))]",
 {{if not IsHostedMaster }}
     {{if IsPrivateCluster}}
         "kubeconfigServer": "[concat('https://', variables('kubernetesAPIServerIP'), ':443')]",

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -806,13 +806,6 @@
         "description": "Encryption at rest key for etcd"
       },
       "type": "string"
-    },
-    "platformFaultDomainCount": {
-      "defaultValue": 0,
-      "metadata": {
-        "description": "Number of fault domains to use. Leave at 0 to have the template set a value appropriate to the Azure region"
-      },
-      "type": "int"
     }
 {{if ProvisionJumpbox}}
     ,"jumpboxVMName": {

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -67,9 +67,9 @@
       "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
       "properties":
         {
-            "platformFaultDomainCount": "[variables('platformFaultDomainCount')]",
+            "platformFaultDomainCount": 2,
             "platformUpdateDomainCount": 3,
-            "managed": true
+		        "managed" : "true"
         },
 
       "type": "Microsoft.Compute/availabilitySets"


### PR DESCRIPTION
We need to make this change w/ guards against upgrade/scale scenarios, because previously deployed clusters won't be able to change their FD configuration later:

```
INFO[0062] Finished ARM Deployment (kubernetes-westus-67584-1365703662). Error: Code="DeploymentFailed" Message="At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-debug for usage details." Details=[{"code":"Conflict","message":"{\r\n  \"error\": {\r\n    \"code\": \"PropertyChangeNotAllowed\",\r\n    \"target\": \"platformFaultDomainCount\",\r\n    \"message\": \"Changing property 'platformFaultDomainCount' is not allowed.\"\r\n  }\r\n}"},{"code":"Conflict","message":"{\r\n  \"error\": {\r\n    \"code\": \"PropertyChangeNotAllowed\",\r\n    \"target\": \"platformFaultDomainCount\",\r\n    \"message\": \"Changing property 'platformFaultDomainCount' is not allowed.\"\r\n  }\r\n}"}]```