### PR TITLE
Updating Azure-CNI to v1.0.11 for Windows 

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -19,10 +19,14 @@ import (
 )
 
 const (
-	// AzureCniPluginVer specifies version of Azure CNI plugin, which has been mirrored from
+	// AzureCniPluginVerLinux specifies version of Azure CNI plugin, which has been mirrored from
 	// https://github.com/Azure/azure-container-networking/releases/download/${AZURE_PLUGIN_VER}/azure-vnet-cni-linux-amd64-${AZURE_PLUGIN_VER}.tgz
 	// to https://acs-mirror.azureedge.net/cni
-	AzureCniPluginVer = "v1.0.7"
+	AzureCniPluginVerLinux = "v1.0.7"
+	// AzureCniPluginVerWindows specifies version of Azure CNI plugin, which has been mirrored from
+	// https://github.com/Azure/azure-container-networking/releases/download/${AZURE_PLUGIN_VER}/azure-vnet-cni-windows-amd64-${AZURE_PLUGIN_VER}.tgz
+	// to https://acs-mirror.azureedge.net/cni
+	AzureCniPluginVerWindows = "v1.0.11"
 	// CNIPluginVer specifies the version of CNI implementation
 	// https://github.com/containernetworking/plugins
 	CNIPluginVer = "v0.7.1"
@@ -41,8 +45,8 @@ var (
 		WindowsPackageSASURLBase:         "https://acs-mirror.azureedge.net/wink8s/",
 		WindowsTelemetryGUID:             "fb801154-36b9-41bc-89c2-f4d4f05472b0",
 		CNIPluginsDownloadURL:            "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-" + CNIPluginVer + ".tgz",
-		VnetCNILinuxPluginsDownloadURL:   "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-" + AzureCniPluginVer + ".tgz",
-		VnetCNIWindowsPluginsDownloadURL: "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-" + AzureCniPluginVer + ".zip",
+		VnetCNILinuxPluginsDownloadURL:   "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-" + AzureCniPluginVerLinux + ".tgz",
+		VnetCNIWindowsPluginsDownloadURL: "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-" + AzureCniPluginVerWindows + ".zip",
 	}
 
 	//DefaultDCOSSpecConfig is the default DC/OS binary download URL.


### PR DESCRIPTION
This is a cherry-pick of #3660 to update Azure-CNI to v1.11.0 for Windows only. Linux is not changed.
