### PR TITLE
container registry proxy change for azure china cloud

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -183,8 +183,8 @@ var (
 		},
 		//KubernetesSpecConfig - Due to Chinese firewall issue, the default containers from google is blocked, use the Chinese local mirror instead
 		KubernetesSpecConfig: KubernetesSpecConfig{
-			KubernetesImageBase:              "crproxy.trafficmanager.net:6000/google_containers/",
-			TillerImageBase:                  "crproxy.trafficmanager.net:6000/kubernetes-helm/",
+			KubernetesImageBase:              "gcr.akscn.io/google_containers/",
+			TillerImageBase:                  "gcr.akscn.io/kubernetes-helm/",
 			ACIConnectorImageBase:            DefaultKubernetesSpecConfig.ACIConnectorImageBase,
 			EtcdDownloadURLBase:              DefaultKubernetesSpecConfig.EtcdDownloadURLBase,
 			KubeBinariesSASURLBase:           DefaultKubernetesSpecConfig.KubeBinariesSASURLBase,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
We have set up a new container registry proxy(`gcr.akscn.io`) in azure china, `crproxy.trafficmanager.net` is located in west us, it's too slow. As comparision, I deployed a k8s cluster with 100 nodes by acs-engine in azure china, it would cost about 2 hours, while if using `gcr.akscn.io`, it only costs 15 min to complete, that's a magnificant change.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:


@jackfrancis 
FYI @karataliu @feiskyer 

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
container registry proxy change for azure china cloud
```