### PR TITLE
Add dkms to manage nvidia gpu kmod compliation across different linux kernels

### DIFF
--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -81,16 +81,18 @@ write_files:
 {{end}}
 
 {{if IsNSeriesSKU .}}
-- path: "/etc/systemd/system/dkms.service"
+- path: "/etc/systemd/system/nvidia-modprobe.service"
   permissions: "0644"
   owner: "root"
   content: |
     [Unit]
-    Description=Builds and install new kernel modules through DKMS
+    Description=Installs and loads Nvidia GPU kernel module
     [Service]
     Type=oneshot
     RemainAfterExit=true
-    ExecStart=/bin/sh -c "dkms autoinstall --verbose"
+    ExecStartPre=/bin/sh -c "dkms autoinstall --verbose"
+    ExecStart=/bin/sh -c "nvidia-modprobe -u -c0"
+    ExecStartPost=/bin/sh -c "sleep 10 && systemctl restart kubelet"
     [Install]
     WantedBy=multi-user.target
 {{end}}

--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -80,6 +80,21 @@ write_files:
     WantedBy=multi-user.target
 {{end}}
 
+{{if IsNSeriesSKU .}}
+- path: "/etc/systemd/system/dkms.service"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    [Unit]
+    Description=Builds and install new kernel modules through DKMS
+    [Service]
+    Type=oneshot
+    RemainAfterExit=true
+    ExecStart=/bin/sh -c "dkms autoinstall --verbose"
+    [Install]
+    WantedBy=multi-user.target
+{{end}}
+
 - path: "/etc/kubernetes/certs/ca.crt"
   permissions: "0644"
   encoding: "base64"

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -512,7 +512,7 @@ func getGPUDriversInstallScript(profile *api.AgentPoolProfile) string {
 - nvidia-modprobe -u -c0
 - %s/bin/nvidia-smi
 - sudo ldconfig
-- systemctl enable dkms
+- systemctl enable nvidia-modprobe
 - retrycmd_if_failure 5 10 60 systemctl restart kubelet`, dv, dest, dest, fmt.Sprintf("%s/lib64", dest), dest)
 
 	/* If a new GPU sku becomes available, add a key to this map, but only provide an installation script if you have a confirmation

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -484,7 +484,7 @@ func getGPUDriversInstallScript(profile *api.AgentPoolProfile) string {
 - retrycmd_if_failure_no_stats 180 1 5 curl -fsSL https://nvidia.github.io/nvidia-docker/ubuntu16.04/amd64/nvidia-docker.list > /tmp/nvidia-docker.list
 - cat /tmp/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
 - apt_get_update
-- retrycmd_if_failure 5 5 300 apt-get install -y linux-headers-$(uname -r) gcc make
+- retrycmd_if_failure 5 5 300 apt-get install -y linux-headers-$(uname -r) gcc make dkms
 - retrycmd_if_failure 5 5 300 apt-get -o Dpkg::Options::="--force-confold" install -y nvidia-docker2=%s+docker%s nvidia-container-runtime=%s+docker%s
 - sudo pkill -SIGHUP dockerd
 - mkdir -p %s
@@ -505,13 +505,14 @@ func getGPUDriversInstallScript(profile *api.AgentPoolProfile) string {
 		Run nvidia-smi to test the installation, unmount overlayfs and restard kubelet (GPUs are only discovered when kubelet starts)
 	*/
 	installScript += fmt.Sprintf(`
-- sh nvidia-drivers-%s --silent --accept-license --no-drm --utility-prefix="%s" --opengl-prefix="%s"
+- sh nvidia-drivers-%s --silent --accept-license --no-drm --dkms --utility-prefix="%s" --opengl-prefix="%s"
 - echo "%s" > /etc/ld.so.conf.d/nvidia.conf
 - sudo ldconfig
 - umount -l /usr/lib/x86_64-linux-gnu
 - nvidia-modprobe -u -c0
 - %s/bin/nvidia-smi
 - sudo ldconfig
+- systemctl enable dkms
 - retrycmd_if_failure 5 10 60 systemctl restart kubelet`, dv, dest, dest, fmt.Sprintf("%s/lib64", dest), dest)
 
 	/* If a new GPU sku becomes available, add a key to this map, but only provide an installation script if you have a confirmation


### PR DESCRIPTION
This PR adds DKMS to manage Nvidia GPU kmod compilation across different versions of the Linux kernel - https://wiki.archlinux.org/index.php/Dynamic_Kernel_Module_Support

Specifically it does the following
* Add dkms package
* Installs nividia drivers using dkms flag which registers the kmod in dkms
* Creates dkms.service in systemd that autoinstalls any missing registered kmods for the running version of the linux kernel
* This systemd unit is a run to complete job and only runs once when the VM boots