### PR TITLE
Don't print errors as info output

### DIFF
--- a/pkg/api/apiloader.go
+++ b/pkg/api/apiloader.go
@@ -71,14 +71,9 @@ func (a *Apiloader) DeserializeContainerService(contents []byte, validate, isUpd
 		if isAgentPoolOnlyClusterJSON(contents) {
 			log.Info("No masterProfile: interpreting API model as agent pool only")
 			service, _, err := a.LoadContainerServiceForAgentPoolOnlyCluster(contents, version, validate, isUpdate, "", existingContainerService)
-			if service == nil || err != nil {
-				log.Infof("Error returned by LoadContainerServiceForAgentPoolOnlyCluster: %+v", err)
-			}
 			return service, version, err
 		}
-		log.Infof("Error returned by LoadContainerService: %+v", err)
 	}
-
 	return service, version, err
 }
 


### PR DESCRIPTION
Before:
```
root@e08797b4f336:/go/src/github.com/Azure/acs-engine# bin/acs-engine generate examples/kubernetes.cecile.json
INFO[0000] Error returned by LoadContainerService: the following OrchestratorProfile configuration is not supported: OrchestratorType: "Kubernetes", Orchest
ratorRelease: "", OrchestratorVersion: "1.10.12". Please use one of the following versions: [1.6.6 1.6.9 1.6.11 1.6.12 1.6.13 1.7.0 1.7.1 1.7.2 1.7.4 1.7.5
1.7.7 1.7.9 1.7.10 1.7.12 1.7.13 1.7.14 1.7.15 1.7.16 1.8.0 1.8.1 1.8.2 1.8.4 1.8.6 1.8.7 1.8.8 1.8.9 1.8.10 1.8.11 1.8.12 1.8.13 1.8.14 1.8.15 1.9.0 1.9.1
1.9.2 1.9.3 1.9.4 1.9.5 1.9.6 1.9.7 1.9.8 1.9.9 1.9.10 1.10.0-beta.2 1.10.0-beta.4 1.10.0-rc.1 1.10.0 1.10.1 1.10.2 1.10.3 1.10.4 1.10.5 1.10.6 1.11.0-alpha
.1 1.11.0-alpha.2 1.11.0-beta.1 1.11.0-beta.2 1.11.0-rc.1 1.11.0-rc.2 1.11.0-rc.3 1.11.0 1.11.1 1.11.2 1.12.0-alpha.1]
github.com/Azure/acs-engine/pkg/api/vlabs.(*Properties).validateOrchestratorProfile
        /go/src/github.com/Azure/acs-engine/pkg/api/vlabs/validate.go:181
github.com/Azure/acs-engine/pkg/api/vlabs.(*Properties).Validate
        /go/src/github.com/Azure/acs-engine/pkg/api/vlabs/validate.go:107
github.com/Azure/acs-engine/pkg/api.(*Apiloader).LoadContainerService
        /go/src/github.com/Azure/acs-engine/pkg/api/apiloader.go:210
github.com/Azure/acs-engine/pkg/api.(*Apiloader).DeserializeContainerService
        /go/src/github.com/Azure/acs-engine/pkg/api/apiloader.go:69
github.com/Azure/acs-engine/pkg/api.(*Apiloader).LoadContainerServiceFromFile
        /go/src/github.com/Azure/acs-engine/pkg/api/apiloader.go:35
github.com/Azure/acs-engine/cmd.(*generateCmd).loadAPIModel
        /go/src/github.com/Azure/acs-engine/cmd/generate.go:133
github.com/Azure/acs-engine/cmd.newGenerateCmd.func1
        /go/src/github.com/Azure/acs-engine/cmd/generate.go:56
github.com/Azure/acs-engine/vendor/github.com/spf13/cobra.(*Command).execute
        /go/src/github.com/Azure/acs-engine/vendor/github.com/spf13/cobra/command.go:647
github.com/Azure/acs-engine/vendor/github.com/spf13/cobra.(*Command).ExecuteC
        /go/src/github.com/Azure/acs-engine/vendor/github.com/spf13/cobra/command.go:726
github.com/Azure/acs-engine/vendor/github.com/spf13/cobra.(*Command).Execute
        /go/src/github.com/Azure/acs-engine/vendor/github.com/spf13/cobra/command.go:685
main.main
        /go/src/github.com/Azure/acs-engine/main.go:12
runtime.main
        /usr/local/go/src/runtime/proc.go:198
runtime.goexit
        /usr/local/go/src/runtime/asm_amd64.s:2361
FATA[0000] error loading API model in generateCmd: error parsing the api model: the following OrchestratorProfile configuration is not supported: Orchestrat
orType: "Kubernetes", OrchestratorRelease: "", OrchestratorVersion: "1.10.12". Please use one of the following versions: [1.6.6 1.6.9 1.6.11 1.6.12 1.6.13 1
.7.0 1.7.1 1.7.2 1.7.4 1.7.5 1.7.7 1.7.9 1.7.10 1.7.12 1.7.13 1.7.14 1.7.15 1.7.16 1.8.0 1.8.1 1.8.2 1.8.4 1.8.6 1.8.7 1.8.8 1.8.9 1.8.10 1.8.11 1.8.12 1.8.
13 1.8.14 1.8.15 1.9.0 1.9.1 1.9.2 1.9.3 1.9.4 1.9.5 1.9.6 1.9.7 1.9.8 1.9.9 1.9.10 1.10.0-beta.2 1.10.0-beta.4 1.10.0-rc.1 1.10.0 1.10.1 1.10.2 1.10.3 1.10
.4 1.10.5 1.10.6 1.11.0-alpha.1 1.11.0-alpha.2 1.11.0-beta.1 1.11.0-beta.2 1.11.0-rc.1 1.11.0-rc.2 1.11.0-rc.3 1.11.0 1.11.1 1.11.2 1.12.0-alpha.1]
```


After:
```
root@e08797b4f336:/go/src/github.com/Azure/acs-engine# bin/acs-engine generate examples/kubernetes.cecile.json
FATA[0000] error loading API model in generateCmd: error parsing the api model: the following OrchestratorProfile configuration is not supported: Orchestrat
orType: "Kubernetes", OrchestratorRelease: "", OrchestratorVersion: "1.10.12". Please use one of the following versions: [1.6.6 1.6.9 1.6.11 1.6.12 1.6.13 1
.7.0 1.7.1 1.7.2 1.7.4 1.7.5 1.7.7 1.7.9 1.7.10 1.7.12 1.7.13 1.7.14 1.7.15 1.7.16 1.8.0 1.8.1 1.8.2 1.8.4 1.8.6 1.8.7 1.8.8 1.8.9 1.8.10 1.8.11 1.8.12 1.8.
13 1.8.14 1.8.15 1.9.0 1.9.1 1.9.2 1.9.3 1.9.4 1.9.5 1.9.6 1.9.7 1.9.8 1.9.9 1.9.10 1.10.0-beta.2 1.10.0-beta.4 1.10.0-rc.1 1.10.0 1.10.1 1.10.2 1.10.3 1.10
.4 1.10.5 1.10.6 1.11.0-alpha.1 1.11.0-alpha.2 1.11.0-beta.1 1.11.0-beta.2 1.11.0-rc.1 1.11.0-rc.2 1.11.0-rc.3 1.11.0 1.11.1 1.11.2 1.12.0-alpha.1]
```