### PR TITLE
Remove allow_kube_tls rule when no masters as is not required

### DIFF
--- a/parts/k8s/kubernetesbase.t
+++ b/parts/k8s/kubernetesbase.t
@@ -156,20 +156,6 @@
               "sourceAddressPrefix": "*",
               "sourcePortRange": "*"
             }
-          },
-          {
-            "name": "allow_kube_tls",
-            "properties": {
-              "access": "Allow",
-              "description": "Allow kube-apiserver (tls) traffic to master",
-              "destinationAddressPrefix": "*",
-              "destinationPortRange": "443-443",
-              "direction": "Inbound",
-              "priority": 100,
-              "protocol": "Tcp",
-              "sourceAddressPrefix": "*",
-              "sourcePortRange": "*"
-            }
           }
         ]
       },


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the allow_kube_tls rule from the network security group. This rule allows traffic from Any source to any destination on port 443, and it being present prevents traffic inbound to 443 being further restricted on the NSG. 

For example when creating a rule to restrict ingress traffic on 443 to a specified IP range using loadBalancerSourceRanges this has no affect as the allow_kube_tls allows all traffic.

The annotation on the allow_kube_tls rule is "Allow kube-apiserver (tls) traffic to master", if there are masters (i.e. not AKS), then the rule is still added (defined in kubernetesmasterresources.t  ) in the existing code below:

```
  {{if not IsHostedMaster}}
      ,{{template "k8s/kubernetesmasterresources.t" .}}
    {{else}}
```

Feedback welcome.

**Special notes for your reviewer**:
I cannot think of any issues removing this rule would create to existing users, I have manually removed it from a couple of my clusters and operations do not seem to be affected.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

