### PR TITLE
Remove security rules from NSG.

### DIFF
--- a/parts/k8s/kubernetesbase.t
+++ b/parts/k8s/kubernetesbase.t
@@ -126,52 +126,7 @@
       "location": "[variables('location')]",
       "name": "[variables('nsgName')]",
       "properties": {
-        "securityRules": [
-{{if .HasWindows}}
-          {
-            "name": "allow_rdp",
-            "properties": {
-              "access": "Allow",
-              "description": "Allow RDP traffic to master",
-              "destinationAddressPrefix": "*",
-              "destinationPortRange": "3389-3389",
-              "direction": "Inbound",
-              "priority": 102,
-              "protocol": "Tcp",
-              "sourceAddressPrefix": "*",
-              "sourcePortRange": "*"
-            }
-          },
-{{end}}
-          {
-            "name": "allow_ssh",
-            "properties": {
-              "access": "Allow",
-              "description": "Allow SSH traffic to master",
-              "destinationAddressPrefix": "*",
-              "destinationPortRange": "22-22",
-              "direction": "Inbound",
-              "priority": 101,
-              "protocol": "Tcp",
-              "sourceAddressPrefix": "*",
-              "sourcePortRange": "*"
-            }
-          },
-          {
-            "name": "allow_kube_tls",
-            "properties": {
-              "access": "Allow",
-              "description": "Allow kube-apiserver (tls) traffic to master",
-              "destinationAddressPrefix": "*",
-              "destinationPortRange": "443-443",
-              "direction": "Inbound",
-              "priority": 100,
-              "protocol": "Tcp",
-              "sourceAddressPrefix": "*",
-              "sourcePortRange": "*"
-            }
-          }
-        ]
+
       },
       "type": "Microsoft.Network/networkSecurityGroups"
     }


### PR DESCRIPTION

**What this PR does / why we need it**:
Please look at #3693 first, as this is a priority, although this PR could replace #3693 .

As per https://github.com/Azure/acs-engine/pull/3693 the allow_kube_tls rule may not be required. In addition there is no need to allow SSH or RDP through the NSG if there are no masters - they are annotated "Allow SSH traffic to master"/"Allow RDP traffic to master".

The case with masters is dealt with in k8s/kubernetesmasterresources.t as per:

```
 {{if not IsHostedMaster}}
      ,{{template "k8s/kubernetesmasterresources.t" .}}
    {{else}}
```

If a user needs to RDP or SSH onto nodes, then they should be aware they are opening the ports, and removing a layer of security.

In addition the SSH rule is flagged as a risk by Azure Security Centre.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Again I do not believe any adverse affect, although users may be relying on these rules to administer agent pool nodes.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

