### PR TITLE
suspend openshift certgen go-bindata generation

### DIFF
--- a/pkg/openshift/certgen/release39/templates/templates.go
+++ b/pkg/openshift/certgen/release39/templates/templates.go
@@ -1,4 +1,1 @@
-//go:generate go-bindata -nometadata -pkg $GOPACKAGE master/... node/...
-//go:generate gofmt -s -l -w bindata.go
-
 package templates

--- a/pkg/openshift/certgen/unstable/templates/templates.go
+++ b/pkg/openshift/certgen/unstable/templates/templates.go
@@ -1,4 +1,1 @@
-//go:generate go-bindata -nometadata -pkg $GOPACKAGE master/... node/...
-//go:generate gofmt -s -l -w bindata.go
-
 package templates


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This surface area isn't being actively maintained, so removing go generation will address some build-time flakiness.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
