### PR TITLE
Log time waiting for cloud-init in CSE

### DIFF
--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -x
-echo `date`,`hostname`, startscript>>/opt/m
+echo `date`,`hostname`, startcustomscript>>/opt/m
 source /opt/azure/containers/provision_source.sh
 source /opt/azure/containers/provision_installs.sh
 source /opt/azure/containers/provision_configs.sh
@@ -35,7 +35,9 @@ function testOutboundConnection() {
 }
 
 function waitForCloudInit() {
+    echo `date`,`hostname`, startwaitingforcloudinit>>/opt/m
     wait_for_file 900 1 /var/log/azure/cloud-init.complete || exit $ERR_CLOUD_INIT_TIMEOUT
+    echo `date`,`hostname`, finishwaitingforcloudinit>>/opt/m
 }
 
 function holdWALinuxAgent() {
@@ -120,8 +122,10 @@ fi
 
 echo "Custom script finished successfully"
 
+echo `date`,`hostname`, endcustomscript>>/opt/m
 mkdir -p /opt/azure/containers && touch /opt/azure/containers/provision.complete
 ps auxfww > /opt/azure/provision-ps.log &
+
 
 if $REBOOTREQUIRED; then
   # wait 1 minute to restart node, so that the custom script extension can complete


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Log time before and after waiting for cloud-init

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
