### PR TITLE
Adding use cases and example for WinRM extension

### DIFF
--- a/extensions/winrm/README.md
+++ b/extensions/winrm/README.md
@@ -2,6 +2,29 @@
 
 This extension enabled WinRM with HTTPS and a self-signed certificate on each Windows node. This makes it possible to troubleshoot Windows nodes from the master over ssh, without needing Remote Desktop.
 
+
+## Use Cases
+
+### Remote Shells
+
+PowerShell can be used to connect to the Windows node from the same Azure vNet. If you want to connect from the Linux master, then it's easiest to run PowerShell as a container:
+
+```bash
+docker run -it mcr.microsoft.com/powershell pwsh
+```
+
+Then, you can run a few PowerShell commands to connect to the Windows node:
+
+```powershell
+# This will prompt for the Windows node's username & password
+$credential = Get-Credential
+
+# Now connect
+Enter-PsSession <hostname> -Credential $credential -Authentication Basic -UseSSL
+```
+
+### Log Gathering
+
 If you want to pull all the logs off Windows nodes quickly, deploy with this extension, then SSH to the master node and run [logslurp](https://github.com/PatrickLang/logslurp) to gather them all at once.
 
 # Configuration

--- a/extensions/winrm/v1/enableWinrm.ps1
+++ b/extensions/winrm/v1/enableWinrm.ps1
@@ -1,3 +1,4 @@
 $cert = New-SelfSignedCertificate -DnsName (hostname) -CertStoreLocation Cert:\LocalMachine\My
 winrm create winrm/config/Listener?Address=*+Transport=HTTPS "@{Hostname=`"$(hostname)`"; CertificateThumbprint=`"$($cert.Thumbprint)`"}"
 winrm set winrm/config/service/auth "@{Basic=`"true`"}"
+New-NetFirewallRule -DisplayName "Windows Remote Management (HTTPS-In)" -Name "WINRM-HTTP-In-TCP-Any" -Profile Any -LocalPort 5986 -Protocol TCP


### PR DESCRIPTION
**What this PR does / why we need it**:

After discussion with @jsturtevant , I thought it would be good to update the doc to show how to use this extension to connect from the Linux master nodes to a Windows agent node.

I also noticed that an explicit firewall rule wasn't set. I fixed that so that this extension won't break when the firewall is reenabled soon.