### PR TITLE
standardize ARM ops timeout to 2.5 hours

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -301,7 +301,7 @@ func autofillApimodel(dc *deployCmd) error {
 		dc.containerService.Properties.LinuxProfile.SSH.PublicKeys = []api.PublicKey{{KeyData: publicKey}}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
 	defer cancel()
 	_, err = dc.client.EnsureResourceGroup(ctx, dc.resourceGroup, dc.location, nil)
 	if err != nil {
@@ -439,7 +439,7 @@ func (dc *deployCmd) run() error {
 	}
 
 	deploymentSuffix := dc.random.Int31()
-	cx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	cx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
 	defer cancel()
 
 	if res, err := dc.client.DeployTemplate(

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -301,7 +301,7 @@ func autofillApimodel(dc *deployCmd) error {
 		dc.containerService.Properties.LinuxProfile.SSH.PublicKeys = []api.PublicKey{{KeyData: publicKey}}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), armhelpers.DefaultARMOperationTimeout)
 	defer cancel()
 	_, err = dc.client.EnsureResourceGroup(ctx, dc.resourceGroup, dc.location, nil)
 	if err != nil {
@@ -439,7 +439,7 @@ func (dc *deployCmd) run() error {
 	}
 
 	deploymentSuffix := dc.random.Int31()
-	cx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
+	cx, cancel := context.WithTimeout(context.Background(), armhelpers.DefaultARMOperationTimeout)
 	defer cancel()
 
 	if res, err := dc.client.DeployTemplate(

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -130,7 +130,7 @@ func (sc *scaleCmd) load(cmd *cobra.Command) error {
 		return errors.Wrap(err, "failed to get client")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), armhelpers.DefaultARMOperationTimeout)
 	defer cancel()
 	_, err = sc.client.EnsureResourceGroup(ctx, sc.resourceGroupName, sc.location, nil)
 	if err != nil {
@@ -208,7 +208,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to load existing container service")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), armhelpers.DefaultARMOperationTimeout)
 	defer cancel()
 	orchestratorInfo := sc.containerService.Properties.OrchestratorProfile
 	var currentNodeCount, highestUsedIndex, index, winPoolIndex int

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -130,7 +130,7 @@ func (sc *scaleCmd) load(cmd *cobra.Command) error {
 		return errors.Wrap(err, "failed to get client")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
 	defer cancel()
 	_, err = sc.client.EnsureResourceGroup(ctx, sc.resourceGroupName, sc.location, nil)
 	if err != nil {
@@ -208,7 +208,7 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to load existing container service")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
 	defer cancel()
 	orchestratorInfo := sc.containerService.Properties.OrchestratorProfile
 	var currentNodeCount, highestUsedIndex, index, winPoolIndex int

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -122,7 +122,7 @@ func (uc *upgradeCmd) loadCluster(cmd *cobra.Command) error {
 		return errors.Wrap(err, "Failed to get client")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
 	defer cancel()
 	_, err = uc.client.EnsureResourceGroup(ctx, uc.resourceGroupName, uc.location, nil)
 	if err != nil {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -122,7 +122,7 @@ func (uc *upgradeCmd) loadCluster(cmd *cobra.Command) error {
 		return errors.Wrap(err, "Failed to get client")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), armhelpers.DefaultARMOperationTimeout)
 	defer cancel()
 	_, err = uc.client.EnsureResourceGroup(ctx, uc.resourceGroupName, uc.location, nil)
 	if err != nil {

--- a/pkg/acsengine/tenantid.go
+++ b/pkg/acsengine/tenantid.go
@@ -14,6 +14,7 @@ import (
 // GetTenantID figures out the AAD tenant ID of the subscription by making an
 // unauthenticated request to the Get Subscription Details endpoint and parses
 // the value from WWW-Authenticate header.
+// TODO this should probably to to the armhelpers library
 func GetTenantID(resourceManagerEndpoint string, subscriptionID string) (string, error) {
 	const hdrKey = "WWW-Authenticate"
 	c := subscriptions.NewClientWithBaseURI(resourceManagerEndpoint)
@@ -23,7 +24,7 @@ func GetTenantID(resourceManagerEndpoint string, subscriptionID string) (string,
 	// we expect this request to fail (err != nil), but we are only interested
 	// in headers, so surface the error if the Response is not present (i.e.
 	// network error etc)
-	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*150)
 	defer cancel()
 	subs, err := c.Get(ctx, subscriptionID)
 	if subs.Response.Response == nil {

--- a/pkg/acsengine/tenantid.go
+++ b/pkg/acsengine/tenantid.go
@@ -23,7 +23,7 @@ func GetTenantID(resourceManagerEndpoint string, subscriptionID string) (string,
 	// we expect this request to fail (err != nil), but we are only interested
 	// in headers, so surface the error if the Response is not present (i.e.
 	// network error etc)
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
 	defer cancel()
 	subs, err := c.Get(ctx, subscriptionID)
 	if subs.Response.Response == nil {

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -172,4 +172,5 @@ const (
 	AgentPoolProfileRoleMaster AgentPoolProfileRole = "master"
 )
 
+// DefaultARMOperationTimeout defines a default (permissive) ARM operation timeout
 const DefaultARMOperationTimeout = 150 * time.Minute

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -1,7 +1,5 @@
 package api
 
-import "time"
-
 // the orchestrators supported by vlabs
 const (
 	// Mesos is the string constant for MESOS orchestrator type
@@ -171,6 +169,3 @@ const (
 	// AgentPoolProfileRoleMaster is the master role
 	AgentPoolProfileRoleMaster AgentPoolProfileRole = "master"
 )
-
-// DefaultARMOperationTimeout defines a default (permissive) ARM operation timeout
-const DefaultARMOperationTimeout = 150 * time.Minute

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -1,5 +1,7 @@
 package api
 
+import "time"
+
 // the orchestrators supported by vlabs
 const (
 	// Mesos is the string constant for MESOS orchestrator type
@@ -169,3 +171,5 @@ const (
 	// AgentPoolProfileRoleMaster is the master role
 	AgentPoolProfileRoleMaster AgentPoolProfileRole = "master"
 )
+
+const DefaultARMOperationTimeout = 150 * time.Minute

--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -327,7 +327,7 @@ func getClient(env azure.Environment, subscriptionID, tenantID string, armSpt *a
 
 // EnsureProvidersRegistered checks if the AzureClient is registered to required resource providers and, if not, register subscription to providers
 func (az *AzureClient) EnsureProvidersRegistered(subscriptionID string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultARMOperationTimeout)
 	defer cancel()
 	registeredProviders, err := az.providersClient.List(ctx, to.Int32Ptr(100), "")
 	if err != nil {

--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -327,7 +327,7 @@ func getClient(env azure.Environment, subscriptionID, tenantID string, armSpt *a
 
 // EnsureProvidersRegistered checks if the AzureClient is registered to required resource providers and, if not, register subscription to providers
 func (az *AzureClient) EnsureProvidersRegistered(subscriptionID string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
 	defer cancel()
 	registeredProviders, err := az.providersClient.List(ctx, to.Int32Ptr(100), "")
 	if err != nil {

--- a/pkg/armhelpers/const.go
+++ b/pkg/armhelpers/const.go
@@ -1,0 +1,6 @@
+package armhelpers
+
+import "time"
+
+// DefaultARMOperationTimeout defines a default (permissive) ARM operation timeout
+const DefaultARMOperationTimeout = 150 * time.Minute

--- a/pkg/armhelpers/deploymentError.go
+++ b/pkg/armhelpers/deploymentError.go
@@ -58,7 +58,7 @@ func (e *DeploymentValidationError) Error() string {
 
 // DeployTemplateSync deploys the template and returns ArmError
 func DeployTemplateSync(az ACSEngineClient, logger *logrus.Entry, resourceGroupName, deploymentName string, template map[string]interface{}, parameters map[string]interface{}) error {
-	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultARMOperationTimeout)
 	defer cancel()
 	deploymentExtended, err := az.DeployTemplate(ctx, resourceGroupName, deploymentName, template, parameters)
 	if err == nil {

--- a/pkg/armhelpers/deploymentError.go
+++ b/pkg/armhelpers/deploymentError.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/Azure/acs-engine/pkg/api"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
@@ -59,7 +58,7 @@ func (e *DeploymentValidationError) Error() string {
 
 // DeployTemplateSync deploys the template and returns ArmError
 func DeployTemplateSync(az ACSEngineClient, logger *logrus.Entry, resourceGroupName, deploymentName string, template map[string]interface{}, parameters map[string]interface{}) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
 	defer cancel()
 	deploymentExtended, err := az.DeployTemplate(ctx, resourceGroupName, deploymentName, template, parameters)
 	if err == nil {

--- a/pkg/operations/deletevm.go
+++ b/pkg/operations/deletevm.go
@@ -3,7 +3,6 @@ package operations
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/Azure/acs-engine/pkg/armhelpers"
 	"github.com/Azure/acs-engine/pkg/armhelpers/utils"
@@ -18,7 +17,7 @@ const (
 
 // CleanDeleteVirtualMachine deletes a VM and any associated OS disk
 func CleanDeleteVirtualMachine(az armhelpers.ACSEngineClient, logger *log.Entry, subscriptionID, resourceGroup, name string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), armhelpers.DefaultARMOperationTimeout)
 	defer cancel()
 	logger.Infof("fetching VM: %s/%s", resourceGroup, name)
 	vm, err := az.GetVirtualMachine(ctx, resourceGroup, name)

--- a/pkg/operations/deletevm.go
+++ b/pkg/operations/deletevm.go
@@ -18,7 +18,7 @@ const (
 
 // CleanDeleteVirtualMachine deletes a VM and any associated OS disk
 func CleanDeleteVirtualMachine(az armhelpers.ACSEngineClient, logger *log.Entry, subscriptionID, resourceGroup, name string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
 	defer cancel()
 	logger.Infof("fetching VM: %s/%s", resourceGroup, name)
 	vm, err := az.GetVirtualMachine(ctx, resourceGroup, name)

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -145,7 +145,7 @@ func (uc *UpgradeCluster) UpgradeCluster(subscriptionID uuid.UUID, kubeConfig, r
 func (uc *UpgradeCluster) getClusterNodeStatus(subscriptionID uuid.UUID, resourceGroup string) error {
 	targetOrchestratorTypeVersion := fmt.Sprintf("%s:%s", uc.DataModel.Properties.OrchestratorProfile.OrchestratorType, uc.DataModel.Properties.OrchestratorProfile.OrchestratorVersion)
 
-	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), armhelpers.DefaultARMOperationTimeout)
 	defer cancel()
 	for vmScaleSetPage, err := uc.Client.ListVirtualMachineScaleSets(ctx, resourceGroup); vmScaleSetPage.NotDone(); err = vmScaleSetPage.Next() {
 		if err != nil {

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -145,7 +145,7 @@ func (uc *UpgradeCluster) UpgradeCluster(subscriptionID uuid.UUID, kubeConfig, r
 func (uc *UpgradeCluster) getClusterNodeStatus(subscriptionID uuid.UUID, resourceGroup string) error {
 	targetOrchestratorTypeVersion := fmt.Sprintf("%s:%s", uc.DataModel.Properties.OrchestratorProfile.OrchestratorType, uc.DataModel.Properties.OrchestratorProfile.OrchestratorVersion)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	ctx, cancel := context.WithTimeout(context.Background(), api.DefaultARMOperationTimeout)
 	defer cancel()
 	for vmScaleSetPage, err := uc.Client.ListVirtualMachineScaleSets(ctx, resourceGroup); vmScaleSetPage.NotDone(); err = vmScaleSetPage.Next() {
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: ARM, for long running operations, enforces "eventual goal state reconciliation" so we want to have a good reason for interrupting that enforcement for long-running operations. In the meantime, restore the previous high timeout value (2.5 hours) configured for azure-sdk-for-go before it was updated.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
standardize ARM ops timeout to 2.5 hours
```