### PR TITLE
only hold walinux during VHD image creation

### DIFF
--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -49,13 +49,14 @@ function holdWALinuxAgent() {
 
 testOutboundConnection
 waitForCloudInit
-holdWALinuxAgent
+
 
 if [[ ! -z "${MASTER_NODE}" ]]; then
     installEtcd
 fi
 
 if $FULL_INSTALL_REQUIRED; then
+    holdWALinuxAgent
     installDeps
 else 
     echo "Golden image; skipping dependencies installation"
@@ -117,12 +118,14 @@ if [[ ! -z "${MASTER_NODE}" ]]; then
     fi
 fi
 
-if [[ $OS == $UBUNTU_OS_NAME ]]; then
-    # mitigation for bug https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1676635
-    echo 2dd1ce17-079e-403c-b352-a1921ee207ee > /sys/bus/vmbus/drivers/hv_util/unbind
-    sed -i "13i\echo 2dd1ce17-079e-403c-b352-a1921ee207ee > /sys/bus/vmbus/drivers/hv_util/unbind\n" /etc/rc.local
+if $FULL_INSTALL_REQUIRED; then
+    if [[ $OS == $UBUNTU_OS_NAME ]]; then
+        # mitigation for bug https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1676635
+        echo 2dd1ce17-079e-403c-b352-a1921ee207ee > /sys/bus/vmbus/drivers/hv_util/unbind
+        sed -i "13i\echo 2dd1ce17-079e-403c-b352-a1921ee207ee > /sys/bus/vmbus/drivers/hv_util/unbind\n" /etc/rc.local
 
-    retrycmd_if_failure 20 5 30 apt-mark unhold walinuxagent || exit $ERR_RELEASE_HOLD_WALINUXAGENT
+        retrycmd_if_failure 20 5 30 apt-mark unhold walinuxagent || exit $ERR_RELEASE_HOLD_WALINUXAGENT
+    fi
 fi
 
 echo "Custom script finished successfully"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: To protect against apt dependency race conditions, we hold walinux apt package updates as we grab other dependencies. But we only need to worry about this during VHD image creation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
only hold walinux during VHD image creation
```