### PR TITLE
Add new Azure client from a tenant

### DIFF
--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -157,6 +157,26 @@ func NewAzureClientWithClientSecret(env azure.Environment, subscriptionID, clien
 	return getClient(env, subscriptionID, tenantID, armSpt, graphSpt), nil
 }
 
+// NewAzureClientWithClientSecretExternalTenant returns an AzureClient via client_id and client_secret from a tenant
+func NewAzureClientWithClientSecretExternalTenant(env azure.Environment, subscriptionID, tenantID, clientID, clientSecret string) (*AzureClient, error) {
+	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	armSpt, err := adal.NewServicePrincipalToken(*oauthConfig, clientID, clientSecret, env.ServiceManagementEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	graphSpt, err := adal.NewServicePrincipalToken(*oauthConfig, clientID, clientSecret, env.GraphEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	graphSpt.Refresh()
+
+	return getClient(env, subscriptionID, tenantID, armSpt, graphSpt), nil
+}
+
 // NewAzureClientWithClientCertificateFile returns an AzureClient via client_id and jwt certificate assertion
 func NewAzureClientWithClientCertificateFile(env azure.Environment, subscriptionID, clientID, certificatePath, privateKeyPath string) (*AzureClient, error) {
 	certificateData, err := ioutil.ReadFile(certificatePath)


### PR DESCRIPTION
**What this PR does / why we need it**:
We are using this in the RP for getting an azure client from a specific tenant.
I see other clients are used in the CLI, I can add this there as well if needed

