### PR TITLE
AzureCNI/Custom VNET - Remove ip address network configuration race condition

### DIFF
--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -1,3 +1,4 @@
+{{ $Context := . }}
 {{if .MasterProfile.IsManagedDisks}}
     {
       "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
@@ -233,81 +234,120 @@
       },
       "type": "Microsoft.Network/loadBalancers/inboundNatRules"
     },
+    {{/* allocate all static ips separately and BEFORE dynamic ips */}}
+      {{range $seq := loop 0 (subtract .MasterProfile.Count 1) }}
+         {{ $MasterProfile := $Context.MasterProfile }}
+        {
+          "apiVersion": "[variables('apiVersionDefault')]",
+          "dependsOn": [
+            "[variables('nsgID')]"
+            {{if not $MasterProfile.IsCustomVNET}}
+            ,"[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),'{{$seq}}')]"
+            {{ end }}
+
+            ,"[variables('masterLbID')]"
+            {{if gt $MasterProfile.Count 1}}
+               ,"[variables('masterInternalLbID')]"
+            {{ end }}
+
+          ],
+          "location": "[variables('location')]",
+          "name": "[concat(variables('masterVMNamePrefix'), 'nic-{{$seq}}')]",
+          "properties": {
+            "ipConfigurations": [
+              {
+                "name": "ipconfig{{add $seq 1}}",
+                "properties": {
+                  {{/* the 1st static ip is primary and gets set for the balancer*/}}
+                  "loadBalancerBackendAddressPools": [
+                    {
+                      "id": "[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"
+                    }
+                    {{if gt $MasterProfile.Count 1}}
+                    ,{
+                      "id": "[concat(variables('masterInternalLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"
+                    }
+                    {{end}}
+                  ],
+                  "loadBalancerInboundNatRules": [
+                    {{if not $MasterProfile.IsCustomVNET}}
+                    {
+                      "id": "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),'{{$seq}}')]"
+                    }
+                    {{ end }}
+                  ],
+                  "primary": true,
+                  "privateIPAddress": "[variables('masterPrivateIpAddrs')[{{$seq}}]]",
+                  "privateIPAllocationMethod": "Static",
+                  "subnet": {
+                    "id": "[variables('vnetSubnetID')]"
+                  }
+                }
+              }
+            ]
+
+          {{if not IsAzureCNI}}
+                  ,
+                      "enableIPForwarding": true
+          {{end}}
+          {{if HasCustomNodesDNS}}
+           ,"dnsSettings": {
+                    "dnsServers": [
+                        "[variables('dnsServer')]"
+                    ]
+                }
+          {{end}}
+          {{if or $MasterProfile.IsCustomVNET IsOpenShift}}
+                  ,"networkSecurityGroup": {
+                    "id": "[variables('nsgID')]"
+                  }
+          {{end}}
+            }
+          ,"type": "Microsoft.Network/networkInterfaces"
+        },
+    {{ end }}
+
+    {{/* the dynamic nics get created AFTER the static addresses are allocated azure cni case else there is a race condition */}}
+    {{if IsAzureCNI}}
+        {{ range $seq := loop 0 (subtract (subtract .MasterProfile.IPAddressCount .MasterProfile.Count) 1) }}
+        {{ $MasterProfile := $Context.MasterProfile }}
+        {{ $nicId := (add $MasterProfile.Count $seq)}}
     {
       "apiVersion": "[variables('apiVersionDefault')]",
-      "copy": {
-        "count": "[sub(variables('masterCount'), variables('masterOffset'))]",
-        "name": "nicLoopNode"
-      },
       "dependsOn": [
 {{if not IsOpenShift}}
-{{if .MasterProfile.IsCustomVNET}}
+{{if $MasterProfile.IsCustomVNET}}
         "[variables('nsgID')]",
 {{else}}
         "[variables('vnetID')]",
 {{end}}
 {{else}}
         "[variables('nsgID')]",
-{{if not .MasterProfile.IsCustomVNET}}
+{{if not $MasterProfile.IsCustomVNET}}
         "[variables('vnetID')]",
 {{end}}
 {{end}}
-        "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')))]"
-{{if gt .MasterProfile.Count 1}}
-        ,"[variables('masterInternalLbName')]"
-{{end}}
+        {{ range $seq2 := loop 0 (subtract $MasterProfile.Count 1) }}
+        {{/* key bit to make sure that ALL the static ips are allocated BEFORE dynamic address assignment */}}
+        {{ if gt $seq2 0}} , {{ end }}
+        "[concat(variables('masterVMNamePrefix'), 'nic-{{$seq2}}')]"
+        {{ end}}
       ],
       "location": "[variables('location')]",
-      "name": "[concat(variables('masterVMNamePrefix'), 'nic-', copyIndex(variables('masterOffset')))]",
+      "name": "[concat(variables('masterVMNamePrefix'), 'nic-{{ $nicId}}')]",
       "properties": {
         "ipConfigurations": [
           {
-            "name": "ipconfig1",
+            "name": "ipconfig{{ $nicId }}",
             "properties": {
-              "loadBalancerBackendAddressPools": [
-                {
-                  "id": "[concat(variables('masterLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"
-                }
-{{if gt .MasterProfile.Count 1}}
-                ,
-                {
-                   "id": "[concat(variables('masterInternalLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"
-                }
-{{end}}
-              ],
-              "loadBalancerInboundNatRules": [
-                {
-                  "id": "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')))]"
-                }
-              ],
-              "privateIPAddress": "[variables('masterPrivateIpAddrs')[copyIndex(variables('masterOffset'))]]",
               "primary": true,
-              "privateIPAllocationMethod": "Static",
-              "subnet": {
-                "id": "[variables('vnetSubnetID')]"
-              }
-            }
-          }
-{{if IsAzureCNI}}
-          {{range $seq := loop 2 .MasterProfile.IPAddressCount}}
-          ,
-          {
-            "name": "ipconfig{{$seq}}",
-            "properties": {
-              "primary": false,
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
                 "id": "[variables('vnetSubnetID')]"
               }
             }
           }
-          {{end}}
-{{end}}
         ]
-{{if not IsAzureCNI}}
-        ,
-        "enableIPForwarding": true
-{{end}}
 {{if HasCustomNodesDNS}}
  ,"dnsSettings": {
           "dnsServers": [
@@ -315,7 +355,7 @@
           ]
       }
 {{end}}
-{{if or .MasterProfile.IsCustomVNET IsOpenShift}}
+{{if or $MasterProfile.IsCustomVNET IsOpenShift}}
         ,"networkSecurityGroup": {
           "id": "[variables('nsgID')]"
         }
@@ -323,6 +363,8 @@
       },
       "type": "Microsoft.Network/networkInterfaces"
     },
+    {{ end }} {{/* range $MasterProfile.Count */}}
+    {{ end }} {{/*IsAzureCNI */}}
 {{else}}
       {
         "apiVersion": "[variables('apiVersionDefault')]",
@@ -355,11 +397,9 @@
               "name": "ipconfig1",
               "properties": {
                 "loadBalancerBackendAddressPools": [
-  {{if gt .MasterProfile.Count 1}}
                   {
                     "id": "[concat(variables('masterInternalLbID'), '/backendAddressPools/', variables('masterLbBackendPoolName'))]"
                   }
-  {{end}}
                 ],
                 "loadBalancerInboundNatRules": [
                 ],

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -847,6 +847,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"subtract": func(a, b int) int {
 			return a - b
 		},
+		"add": func(a, b int) int {
+			return a + b
+		},
 		"IsCustomVNET": func() bool {
 			return isCustomVNET(cs.Properties.AgentPoolProfiles)
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Case handled:  AzureCNI/Custom Vnet

[There is a documented race condition](https://github.com/Azure/acs-engine/blob/master/docs/kubernetes/features.md) whereby it is impossible to ensure that master ip addresses are allocated serially as REQUIRED by k8 bootstrap scripts.  I hit this problem every time i.e. the cluster fails to start. 

This PR guarantees the 'MasterCount' ip addresses are allocated serially beginning with *firstConsecutiveStaticIP* **before** dynamic ip allocation begins. 

The generated dynamic ips stanza are made dependent on the static ip (masterCount) stanzas.
  
To implement this, both the static and dynamic ips are in separate arm stanzas.
The static network interfaces reference the lb and intlb(for masterCount> 1) as before.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

It passes all tests and works predictably with automation onto existing subnets.

Tested with v0.20.7 and v0.21.1

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ x] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
Strike 
```
If possible, assign to the firstConsecutiveStaticIP configuration property an IP address that is near the "end" of the available IP address space in the desired subnet.
For example, if the desired subnet is a /24, choose the "239" address in that network space
```
And change to: 
```Ensure that firstConsecutiveStaticIP + (masterCount-1) ip addresses are free within the master subnet as required by k8 installation scripts.```  