### PR TITLE
Fix kubeletConfig for Windows agent nodes

### DIFF
--- a/examples/windows/README.md
+++ b/examples/windows/README.md
@@ -18,5 +18,6 @@ These cluster definition examples demonstrate how to create customized Docker En
 - kubernetes.json - this is the simplest case for a 2-node Windows Kubernetes cluster
 - kubernetes-custom-image.json - example using an existing Azure Managed Disk for Windows nodes. For example if you need a prerelease OS version, you can build a VHD, upload it and use this sample.
 - kubernetes-hybrid.json - example with both Windows & Linux nodes in the same cluster
+- kubernetes-hyperv.json - example with 2 Windows nodes with the [alpha Hyper-V isolation support](https://kubernetes.io/docs/getting-started-guides/windows/#hyper-v-containers) enabled
 - kubernetes-wincni.json - example using kubenet plugin on Linux nodes and WinCNI on Windows
 - kubernetes-windows-version.json - example of how to build a cluster with a specific Windows patch version

--- a/examples/windows/kubernetes-hyperv.json
+++ b/examples/windows/kubernetes-hyperv.json
@@ -1,0 +1,61 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "1.10",
+      "kubernetesConfig": {
+               "apiServerConfig" : {
+                 "--feature-gates": "HyperVContainer=true"
+               },
+               "kubeletConfig" : {
+                    "--feature-gates": "HyperVContainer=true"
+                }
+          }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "hypervtest",
+      "vmSize": "Standard_D2_v3"
+    },
+    "agentPoolProfiles": [
+	    {
+		"name": "windowspool",
+		"count": 2,
+		"vmSize": "Standard_D2_v3",
+		"availabilityProfile": "AvailabilitySet",
+		"osType": "Windows",
+		"osDiskSizeGB": 128,
+		"extensions": [
+		    {
+                        "name": "winrm"
+		    }
+		]
+	    }
+    ],
+    "windowsProfile": {
+      "adminUsername": "azureuser",
+      "adminPassword": "replacepassword1234$"
+    },
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    },
+    "extensionProfiles": [
+      {
+        "name": "winrm",
+        "version": "v1"
+      }
+    ]
+  }
+}

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -80,7 +80,7 @@ $global:CNIPath = [Io.path]::Combine("$global:KubeDir", "cni")
 $global:NetworkMode = "L2Bridge"
 $global:CNIConfig = [Io.path]::Combine($global:CNIPath, "config", "`$global:NetworkMode.conf")
 $global:CNIConfigPath = [Io.path]::Combine("$global:CNIPath", "config")
-$global:WindowsCNIKubeletOptions = @("--network-plugin=cni", "--cni-bin-dir=$global:CNIPath", "--cni-conf-dir=$global:CNIConfigPath")
+$global:WindowsCNIKubeletOptions = @("--cni-bin-dir=$global:CNIPath", "--cni-conf-dir=$global:CNIConfigPath")
 $global:HNSModule = [Io.path]::Combine("$global:KubeDir", "hns.psm1")
 
 $global:VolumePluginDir = [Io.path]::Combine("$global:KubeDir", "volumeplugins")
@@ -92,7 +92,7 @@ $global:VNetCNIPluginsURL = "{{WrapAsParameter "vnetCniWindowsPluginsURL"}}"
 $global:AzureCNIDir = [Io.path]::Combine("$global:KubeDir", "azurecni")
 $global:AzureCNIBinDir = [Io.path]::Combine("$global:AzureCNIDir", "bin")
 $global:AzureCNIConfDir = [Io.path]::Combine("$global:AzureCNIDir", "netconf")
-$global:AzureCNIKubeletOptions = @("--network-plugin=cni", "--cni-bin-dir=$global:AzureCNIBinDir", "--cni-conf-dir=$global:AzureCNIConfDir")
+$global:AzureCNIKubeletOptions = @("--cni-bin-dir=$global:AzureCNIBinDir", "--cni-conf-dir=$global:AzureCNIConfDir")
 $global:AzureCNIEnabled = $false
 
 filter Timestamp {"$(Get-Date -Format o): $_"}
@@ -331,7 +331,6 @@ Write-KubernetesStartFiles($podCIDR)
     $KubeletArgList = $global:KubeletConfigArgs # This is the initial list passed in from acs-engine
     $KubeletArgList += "--node-labels=`$global:KubeletNodeLabels"
     $KubeletArgList += "--hostname-override=`$global:AzureHostname"
-    $KubeletArgList += "--cluster-dns=`$global:KubeDnsServiceIp"
     $KubeletArgList += "--volume-plugin-dir=`$global:VolumePluginDir"
     # If you are thinking about adding another arg here, you should be considering pkg/acsengine/defaults-kubelet.go first
     # Only args that need to be calculated or combined with other ones on the Windows agent should be added here.

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -371,6 +371,7 @@ Write-KubernetesStartFiles($podCIDR)
 `$global:HNSModule = "$global:HNSModule"
 `$global:VolumePluginDir = "$global:VolumePluginDir"
 `$global:NetworkPlugin="$global:NetworkPlugin"
+`$global:KubeletNodeLabels="$global:KubeletNodeLabels"
 
 "@
 

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -33,13 +33,14 @@ func setKubeletConfig(cs *api.ContainerService) {
 	}
 
 	// Add Windows-specific overrides
+	// Eventually paths should not be hardcoded here. They should be relative to $global:KubeDir in the PowerShell script
 	staticWindowsKubeletConfig["--azure-container-registry-config"] = "c:\\k\\azure.json"
 	staticWindowsKubeletConfig["--pod-infra-container-image"] = "kubletwin/pause"
 	staticWindowsKubeletConfig["--kubeconfig"] = "c:\\k\\config"
 	staticWindowsKubeletConfig["--cloud-config"] = "c:\\k\\azure.json"
 	staticWindowsKubeletConfig["--cgroups-per-qos"] = "false"
 	staticWindowsKubeletConfig["--enforce-node-allocatable"] = "\"\"\"\""
-	staticWindowsKubeletConfig["--client-ca-file"] = "" // BUG - #3747 implement this on Windows
+	staticWindowsKubeletConfig["--client-ca-file"] = "c:\\k\\ca.crt"
 	staticWindowsKubeletConfig["--hairpin-mode"] = "promiscuous-bridge"
 	staticWindowsKubeletConfig["--image-pull-progress-deadline"] = "20m"
 	staticWindowsKubeletConfig["--resolv-conf"] = "\"\"\"\""
@@ -145,9 +146,7 @@ func setKubeletConfig(cs *api.ContainerService) {
 
 		if profile.OSType == "Windows" {
 			// Remove Linux-specific values
-			delete(profile.KubernetesConfig.KubeletConfig, "--client-ca-file")
 			delete(profile.KubernetesConfig.KubeletConfig, "--pod-manifest-path")
-			delete(profile.KubernetesConfig.KubeletConfig, "--anonymous-auth") // BUG: enable secure kubelet on Windows #3747
 		}
 
 		// For N Series (GPU) VMs

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -26,16 +26,23 @@ func setKubeletConfig(cs *api.ContainerService) {
 		"--keep-terminated-pod-volumes": "false",
 	}
 
+	// Start with copy of Linux config
 	staticWindowsKubeletConfig := make(map[string]string)
 	for key, val := range staticLinuxKubeletConfig {
 		staticWindowsKubeletConfig[key] = val
 	}
+
+	// Add Windows-specific overrides
 	staticWindowsKubeletConfig["--azure-container-registry-config"] = "c:\\k\\azure.json"
 	staticWindowsKubeletConfig["--pod-infra-container-image"] = "kubletwin/pause"
 	staticWindowsKubeletConfig["--kubeconfig"] = "c:\\k\\config"
 	staticWindowsKubeletConfig["--cloud-config"] = "c:\\k\\azure.json"
 	staticWindowsKubeletConfig["--cgroups-per-qos"] = "false"
-	staticWindowsKubeletConfig["--enforce-node-allocatable"] = "\"\""
+	staticWindowsKubeletConfig["--enforce-node-allocatable"] = "\"\"\"\""
+	staticWindowsKubeletConfig["--client-ca-file"] = "" // BUG - #3747 implement this on Windows
+	staticWindowsKubeletConfig["--hairpin-mode"] = "promiscuous-bridge"
+	staticWindowsKubeletConfig["--image-pull-progress-deadline"] = "20m"
+	staticWindowsKubeletConfig["--resolv-conf"] = "\"\"\"\""
 
 	// Default Kubelet config
 	defaultKubeletConfig := map[string]string{
@@ -135,6 +142,13 @@ func setKubeletConfig(cs *api.ContainerService) {
 			}
 		}
 		setMissingKubeletValues(profile.KubernetesConfig, o.KubernetesConfig.KubeletConfig)
+
+		if profile.OSType == "Windows" {
+			// Remove Linux-specific values
+			delete(profile.KubernetesConfig.KubeletConfig, "--client-ca-file")
+			delete(profile.KubernetesConfig.KubeletConfig, "--pod-manifest-path")
+			delete(profile.KubernetesConfig.KubeletConfig, "--anonymous-auth") // BUG: enable secure kubelet on Windows #3747
+		}
 
 		// For N Series (GPU) VMs
 		if strings.Contains(profile.VMSize, "Standard_N") {

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -216,6 +216,26 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			}
 			return buf.String()
 		},
+		"GetKubeletConfigKeyValsPsh": func(kc *api.KubernetesConfig) string {
+			if kc == nil {
+				return ""
+			}
+			kubeletConfig := cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+			if kc.KubeletConfig != nil {
+				kubeletConfig = kc.KubeletConfig
+			}
+			// Order by key for consistency
+			keys := []string{}
+			for key := range kubeletConfig {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			var buf bytes.Buffer
+			for _, key := range keys {
+				buf.WriteString(fmt.Sprintf("\"%s=%s\", ", key, kubeletConfig[key]))
+			}
+			return strings.TrimSuffix(buf.String(), ", ")
+		},
 		"GetK8sRuntimeConfigKeyVals": func(config map[string]string) string {
 			// Order by key for consistency
 			keys := []string{}


### PR DESCRIPTION
**What this PR does / why we need it**

Windows kubelet configs were fixed, and could not be overridden in the acs-engine apimodel. This meant that optional feature gates couldn't be enabled for Windows nodes.

**Which issue this PR fixes**: fixes #2627, #3266 

**Special notes for your reviewer**:

Example apimodel.json:

```json
{
  "apiVersion": "vlabs",
  "properties": {
    "orchestratorProfile": {
      "orchestratorType": "Kubernetes",
      "orchestratorVersion": "1.10.6",
      "kubernetesConfig": {
               "apiServerConfig" : {
                 "--feature-gates": "HyperVContainer=true"
               },
               "kubeletConfig" : {
                    "--feature-gates": "HyperVContainer=true"
                }
          }
    },
    "masterProfile": {
      "count": 1,
      "dnsPrefix": "plang0607a",
      "vmSize": "Standard_D2_v3"
    },
    "agentPoolProfiles": [
	    {
		"name": "windowspool",
		"count": 2,
		"vmSize": "Standard_D2_v3",
		"availabilityProfile": "AvailabilitySet",
		"osType": "Windows",
		"osDiskSizeGB": 127,
		"extensions": [
		    {
                        "name": "winrm"
		    }
		]
	    },
	    {
		"name": "linuxpool",
		"count": 2,
		"vmSize": "Standard_D2_v2",
		"availabilityProfile": "AvailabilitySet",
		"osType": "Linux"
	    }
    ],
    "windowsProfile": {
	    "adminUsername": "",
	    "adminPassword": "",
	    "windowsPublisher": "MicrosoftWindowsServer",
	    "windowsOffer": "WindowsServerSemiAnnual",
	    "windowsSku": "Datacenter-Core-1803-with-Containers-smalldisk"
     },
    "extensionProfiles": [
      {
        "name": "winrm",
        "version": "v1"
      }
    ],
    "linuxProfile": {
      "adminUsername": "",
      "ssh": {
        "publicKeys": [
          {
            "keyData": ""
          }
        ]
      }
    },
    "servicePrincipalProfile": {
      "clientId": "",
      "secret": ""
    }
  }
}
```

Once the cluster is deployed - I can run Windows Server version 1709 and 1803 pods successfully. 2016 is crashing for an unrelated issue that's a new bug.

I deployed these [samples](https://github.com/PatrickLang/Windows-K8s-Samples/tree/master/HyperVExamples)

```none
kubectl get pod -o wide
NAME                           READY     STATUS             RESTARTS   AGE       IP             NODE
iis-797554d796-mzx54           1/1       Running            0          21m       10.240.0.129   26559k8s9001
whoami-1709-7bc765bdd-hh8w2    1/1       Running            0          21m       10.240.0.108   26559k8s9000
whoami-1803-78cf76cdb-qzlhk    1/1       Running            0          21m       10.240.0.146   26559k8s9001
whoami-2016-56f6d987c6-qrc24   0/1       CrashLoopBackOff   9          21m       <none>         26559k8s9000

$ kubectl get svc
NAME              TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)        AGE
iis-svc           LoadBalancer   10.0.199.157   13.77.163.204    80:32230/TCP   21m
kubernetes        ClusterIP      10.0.0.1       <none>           443/TCP        26m
whoami-1709-svc   LoadBalancer   10.0.115.101   52.246.250.167   80:32058/TCP   21m
whoami-1803-svc   LoadBalancer   10.0.101.19    13.66.167.155    80:31961/TCP   21m
whoami-2016-svc   LoadBalancer   10.0.118.76    13.66.170.249    80:30238/TCP   21m

$ curl http://13.66.167.155
I'm 2073d5f95141 running on windows/amd64

$ curl http://52.246.250.167
I'm b5cba1e43131 running on windows/amd64
```



**Release note**:
```release-note
`KubernetesConfig.kubeletConfig` now works for Windows nodes
```
