### PR TITLE
AzureCNI/Custom VNET - Remove ip address network configuration race condition

### DIFF
--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -983,6 +983,9 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"subtract": func(a, b int) int {
 			return a - b
 		},
+		"add": func(a, b int) int {
+			return a + b
+		},
 		"IsCustomVNET": func() bool {
 			return cs.Properties.AreAgentProfilesCustomVNET()
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Case handled:  AzureCNI/Custom Vnet

[There is a documented race condition](https://github.com/Azure/acs-engine/blob/master/docs/kubernetes/features.md) whereby it is impossible to ensure that master ip addresses are allocated serially as REQUIRED by k8 bootstrap scripts.  I hit this problem every time i.e. the cluster fails to start. 

This PR guarantees the 'MasterCount' ip addresses are allocated serially beginning with *firstConsecutiveStaticIP* **before** dynamic ip allocation begins. 

The generated dynamic ips stanza are made dependent on the static ip (masterCount) stanzas.
  
To implement this, both the static and dynamic ips are in separate arm stanzas.
The static network interfaces reference the lb and intlb(for masterCount> 1) as before.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

It passes all tests and works predictably with automation onto existing subnets.

Tested with v0.20.7 and v0.21.1

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ x] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
Strike 
```
If possible, assign to the firstConsecutiveStaticIP configuration property an IP address that is near the "end" of the available IP address space in the desired subnet.
For example, if the desired subnet is a /24, choose the "239" address in that network space
```
And change to: 
```Ensure that firstConsecutiveStaticIP + (masterCount-1) ip addresses are free within the master subnet as required by k8 installation scripts.```  