### PR TITLE
Make cmd more testable by abstracting authArgs and AzureClient

### DIFF
--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -66,14 +66,14 @@ type mockAuthProvider struct {
 	*authArgs
 }
 
-func (provider mockAuthProvider) getClient() (armhelpers.ACSEngineClient, error) {
+func (provider *mockAuthProvider) getClient() (armhelpers.ACSEngineClient, error) {
 	if provider.getClientMock == nil {
 		return &armhelpers.MockACSEngineClient{}, nil
-	} else {
-		return provider.getClientMock, nil
 	}
+	return provider.getClientMock, nil
+
 }
-func (provider mockAuthProvider) getAuthArgs() *authArgs {
+func (provider *mockAuthProvider) getAuthArgs() *authArgs {
 	return provider.authArgs
 }
 

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -222,6 +222,9 @@ func TestAutoSufixWithDnsPrefixInApiModel(t *testing.T) {
 		apiVersion:       ver,
 
 		client: &armhelpers.MockACSEngineClient{},
+		authProvider: &mockAuthProvider{
+			authArgs: &authArgs{},
+		},
 	}
 
 	err = autofillApimodel(deployCmd)
@@ -263,9 +266,12 @@ func TestAPIModelWithoutServicePrincipalProfileAndClientIdAndSecretInCmd(t *test
 		apiVersion:       ver,
 
 		client: &armhelpers.MockACSEngineClient{},
+		authProvider: &mockAuthProvider{
+			authArgs: &authArgs{},
+		},
 	}
-	deployCmd.ClientID = TestClientIDInCmd
-	deployCmd.ClientSecret = TestClientSecretInCmd
+	deployCmd.getAuthArgs().ClientID = TestClientIDInCmd
+	deployCmd.getAuthArgs().ClientSecret = TestClientSecretInCmd
 
 	err = autofillApimodel(deployCmd)
 	if err != nil {
@@ -313,9 +319,12 @@ func TestAPIModelWithEmptyServicePrincipalProfileAndClientIdAndSecretInCmd(t *te
 		apiVersion:       ver,
 
 		client: &armhelpers.MockACSEngineClient{},
+		authProvider: &mockAuthProvider{
+			authArgs: &authArgs{},
+		},
 	}
-	deployCmd.ClientID = TestClientIDInCmd
-	deployCmd.ClientSecret = TestClientSecretInCmd
+	deployCmd.getAuthArgs().ClientID = TestClientIDInCmd
+	deployCmd.getAuthArgs().ClientSecret = TestClientSecretInCmd
 	err = autofillApimodel(deployCmd)
 	if err != nil {
 		t.Fatalf("unexpected error autofilling the example apimodel: %s", err)
@@ -356,6 +365,9 @@ func TestAPIModelWithoutServicePrincipalProfileAndWithoutClientIdAndSecretInCmd(
 		apiVersion:       ver,
 
 		client: &armhelpers.MockACSEngineClient{},
+		authProvider: &mockAuthProvider{
+			authArgs: &authArgs{},
+		},
 	}
 	err = autofillApimodel(deployCmd)
 	if err != nil {
@@ -390,6 +402,9 @@ func TestAPIModelWithEmptyServicePrincipalProfileAndWithoutClientIdAndSecretInCm
 		apiVersion:       ver,
 
 		client: &armhelpers.MockACSEngineClient{},
+		authProvider: &mockAuthProvider{
+			authArgs: &authArgs{},
+		},
 	}
 	err = autofillApimodel(deployCmd)
 	if err != nil {
@@ -439,6 +454,9 @@ func testAutodeployCredentialHandling(t *testing.T, useManagedIdentity bool, cli
 		apiVersion:       ver,
 
 		client: &armhelpers.MockACSEngineClient{},
+		authProvider: &mockAuthProvider{
+			authArgs: &authArgs{},
+		},
 	}
 
 	err = autofillApimodel(deployCmd)
@@ -501,12 +519,21 @@ func TestDeployCmdMergeAPIModel(t *testing.T) {
 }
 
 func TestDeployCmdMLoadAPIModel(t *testing.T) {
-	t.Skip("FIXME: this test runs into an unexpected 404")
-	d := &deployCmd{}
+	d := &deployCmd{
+		client: &armhelpers.MockACSEngineClient{},
+		authProvider: &mockAuthProvider{
+			authArgs: &authArgs{},
+		},
+		apimodelPath:    "./this/is/unused.json",
+		outputDirectory: "_test_output",
+		forceOverwrite:  true,
+		location:        "westus",
+	}
+
 	r := &cobra.Command{}
 	f := r.Flags()
 
-	addAuthFlags(&d.authArgs, f)
+	addAuthFlags(d.getAuthArgs(), f)
 
 	fakeRawSubscriptionID := "6dc93fae-9a76-421f-bbe5-cc6460ea81cb"
 	fakeSubscriptionID, err := uuid.FromString(fakeRawSubscriptionID)
@@ -516,8 +543,8 @@ func TestDeployCmdMLoadAPIModel(t *testing.T) {
 
 	d.apimodelPath = "../pkg/acsengine/testdata/simple/kubernetes.json"
 	d.set = []string{"agentPoolProfiles[0].count=1"}
-	d.SubscriptionID = fakeSubscriptionID
-	d.rawSubscriptionID = fakeRawSubscriptionID
+	d.getAuthArgs().SubscriptionID = fakeSubscriptionID
+	d.getAuthArgs().rawSubscriptionID = fakeRawSubscriptionID
 
 	d.validateArgs(r, []string{"../pkg/acsengine/testdata/simple/kubernetes.json"})
 	d.mergeAPIModel()

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -55,6 +55,18 @@ const ExampleAPIModelWithoutServicePrincipalProfile = `{
   }
   `
 
+//mockAuthProvider implements AuthProvider and allows in particular to stub out getClient()
+type mockAuthProvider struct {
+	*authArgs
+}
+
+func (provider mockAuthProvider) getClient() (armhelpers.ACSEngineClient, error) {
+	return &armhelpers.MockACSEngineClient{}, nil
+}
+func (provider mockAuthProvider) getAuthArgs() *authArgs {
+	return provider.authArgs
+}
+
 func getExampleAPIModel(useManagedIdentity bool, clientID, clientSecret string) string {
 	return getAPIModel(ExampleAPIModel, useManagedIdentity, clientID, clientSecret)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,6 +85,23 @@ func writeDefaultModel(out io.Writer) error {
 	return nil
 }
 
+type authProvider interface {
+	getAuthArgs() *authArgs
+	getClient() (armhelpers.ACSEngineClient, error)
+}
+
+//MockAuthProvider implements AuthProvider and allows in particular to stub out getClient()
+type mockAuthProvider struct {
+	*authArgs
+}
+
+func (provider mockAuthProvider) getClient() (armhelpers.ACSEngineClient, error) {
+	return &armhelpers.MockACSEngineClient{}, nil
+}
+func (provider mockAuthProvider) getAuthArgs() *authArgs {
+	return provider.authArgs
+}
+
 type authArgs struct {
 	RawAzureEnvironment string
 	rawSubscriptionID   string
@@ -108,6 +125,11 @@ func addAuthFlags(authArgs *authArgs, f *flag.FlagSet) {
 	f.StringVar(&authArgs.CertificatePath, "certificate-path", "", "path to client certificate (used with --auth-method=client_certificate)")
 	f.StringVar(&authArgs.PrivateKeyPath, "private-key-path", "", "path to private key (used with --auth-method=client_certificate)")
 	f.StringVar(&authArgs.language, "language", "en-us", "language to return error messages in")
+}
+
+//this allows the authArgs to be stubbed behind the authProvider interface, and be its own provider when not in tests.
+func (authArgs *authArgs) getAuthArgs() *authArgs {
+	return authArgs
 }
 
 func (authArgs *authArgs) validateAuthArgs() error {
@@ -180,7 +202,7 @@ func getCloudSubFromAzConfig(cloud string, f *ini.File) (uuid.UUID, error) {
 	return uuid.FromString(sub.String())
 }
 
-func (authArgs *authArgs) getClient() (*armhelpers.AzureClient, error) {
+func (authArgs *authArgs) getClient() (armhelpers.ACSEngineClient, error) {
 	var client *armhelpers.AzureClient
 	env, err := azure.EnvironmentFromName(authArgs.RawAzureEnvironment)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,18 +90,6 @@ type authProvider interface {
 	getClient() (armhelpers.ACSEngineClient, error)
 }
 
-//MockAuthProvider implements AuthProvider and allows in particular to stub out getClient()
-type mockAuthProvider struct {
-	*authArgs
-}
-
-func (provider mockAuthProvider) getClient() (armhelpers.ACSEngineClient, error) {
-	return &armhelpers.MockACSEngineClient{}, nil
-}
-func (provider mockAuthProvider) getAuthArgs() *authArgs {
-	return provider.authArgs
-}
-
 type authArgs struct {
 	RawAzureEnvironment string
 	rawSubscriptionID   string


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve testability of the cmd package by abstracting the authArgs dependency.  
This allows tests to stub the `authArgs.getClient()` call and return a fake `ACSEngineClient` instead of the concrete `AzureClient` instance

**Special notes for your reviewer**:
If this is ok, the same pattern can be applied for other command that depends on the `AzureClient`.