### PR TITLE
set remaining ARM context timeouts to 2.5 hours

### DIFF
--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -107,7 +107,7 @@ func NewAzureClientWithDeviceAuth(env azure.Environment, subscriptionID string) 
 	}
 
 	client := &autorest.Client{
-		PollingDuration: 1 * time.Hour,
+		PollingDuration: DefaultARMOperationTimeout,
 	}
 
 	deviceCode, err := adal.InitiateDeviceAuth(client, *oauthConfig, acsEngineClientID, env.ServiceManagementEndpoint)
@@ -304,19 +304,19 @@ func getClient(env azure.Environment, subscriptionID, tenantID string, armSpt *a
 	c.resourcesClient.PollingDelay = time.Second * 5
 
 	// Set permissive timeouts to accommodate long-running operations
-	c.deploymentsClient.PollingDuration = time.Hour * 1
-	c.deploymentOperationsClient.PollingDuration = time.Hour * 1
-	c.applicationsClient.PollingDuration = time.Hour * 1
-	c.authorizationClient.PollingDuration = time.Hour * 1
-	c.disksClient.PollingDuration = time.Hour * 1
-	c.groupsClient.PollingDuration = time.Hour * 1
-	c.interfacesClient.PollingDuration = time.Hour * 1
-	c.providersClient.PollingDuration = time.Hour * 1
-	c.resourcesClient.PollingDuration = time.Hour * 1
-	c.storageAccountsClient.PollingDuration = time.Hour * 1
-	c.virtualMachineScaleSetsClient.PollingDuration = time.Hour * 1
-	c.virtualMachineScaleSetVMsClient.PollingDuration = time.Hour * 1
-	c.virtualMachinesClient.PollingDuration = time.Hour * 1
+	c.deploymentsClient.PollingDuration = DefaultARMOperationTimeout
+	c.deploymentOperationsClient.PollingDuration = DefaultARMOperationTimeout
+	c.applicationsClient.PollingDuration = DefaultARMOperationTimeout
+	c.authorizationClient.PollingDuration = DefaultARMOperationTimeout
+	c.disksClient.PollingDuration = DefaultARMOperationTimeout
+	c.groupsClient.PollingDuration = DefaultARMOperationTimeout
+	c.interfacesClient.PollingDuration = DefaultARMOperationTimeout
+	c.providersClient.PollingDuration = DefaultARMOperationTimeout
+	c.resourcesClient.PollingDuration = DefaultARMOperationTimeout
+	c.storageAccountsClient.PollingDuration = DefaultARMOperationTimeout
+	c.virtualMachineScaleSetsClient.PollingDuration = DefaultARMOperationTimeout
+	c.virtualMachineScaleSetVMsClient.PollingDuration = DefaultARMOperationTimeout
+	c.virtualMachinesClient.PollingDuration = DefaultARMOperationTimeout
 
 	graphAuthorizer := autorest.NewBearerAuthorizer(graphSpt)
 	c.applicationsClient.Authorizer = graphAuthorizer


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
set remaining ARM context timeouts to 2.5 hours
```