### PR TITLE
Add acs-engine deploy e2e test

### DIFF
--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -85,6 +85,9 @@ func (c *Config) SetKubeConfig() {
 
 // GetSSHKeyPath will return the absolute path to the ssh private key
 func (c *Config) GetSSHKeyPath() string {
+	if c.UseDeployCommand {
+		return filepath.Join(c.CurrentWorkingDir, "_output", c.Name, "azureuser_rsa")
+	}
 	return filepath.Join(c.CurrentWorkingDir, "_output", c.Name+"-ssh")
 }
 

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	CurrentWorkingDir   string
 	SoakClusterName     string `envconfig:"SOAK_CLUSTER_NAME"`
 	ForceDeploy         bool   `envconfig:"FORCE_DEPLOY"`
+	UseDeployCommand    bool   `envconfig:"USE_DEPLOY_COMMAND"`
 }
 
 const (

--- a/test/e2e/engine/cli.go
+++ b/test/e2e/engine/cli.go
@@ -20,3 +20,22 @@ func (e *Engine) Generate() error {
 	}
 	return nil
 }
+
+// Deploy will run acs-engine deploy on a given cluster definition
+func (e *Engine) Deploy(location string) error {
+	cmd := exec.Command("./bin/acs-engine", "deploy",
+		"--location", e.ClusterDefinition.Location,
+		"--apimodel", e.Config.ClusterDefinitionPath,
+		"--dns-prefix", e.Config.DefinitionName,
+		"--output-directory", e.Config.GeneratedDefinitionPath,
+		"--resource-group", e.ClusterDefinition.ContainerService.Properties.AzProfile.ResourceGroup,
+	)
+	util.PrintCommand(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Error while trying to deploy acs-engine template with cluster definition - %s: %s\n", e.Config.ClusterDefinitionTemplate, err)
+		log.Printf("Output:%s\n", out)
+		return err
+	}
+	return nil
+}

--- a/test/e2e/engine/cli.go
+++ b/test/e2e/engine/cli.go
@@ -24,11 +24,11 @@ func (e *Engine) Generate() error {
 // Deploy will run acs-engine deploy on a given cluster definition
 func (e *Engine) Deploy(location string) error {
 	cmd := exec.Command("./bin/acs-engine", "deploy",
-		"--location", e.ClusterDefinition.Location,
-		"--apimodel", e.Config.ClusterDefinitionPath,
+		"--location", location,
+		"--api-model", e.Config.ClusterDefinitionPath,
 		"--dns-prefix", e.Config.DefinitionName,
 		"--output-directory", e.Config.GeneratedDefinitionPath,
-		"--resource-group", e.ClusterDefinition.ContainerService.Properties.AzProfile.ResourceGroup,
+		"--resource-group", e.Config.DefinitionName,
 	)
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -42,7 +42,7 @@ func main() {
 
 	err := acct.Login()
 	if err != nil {
-		log.Fatal("Error while trying to login to azure account!")
+		log.Fatalf("Error while trying to login to azure account! %s\n", err)
 	}
 
 	err = acct.SetSubscription()

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -105,15 +105,17 @@ func (cli *CLIProvisioner) provision() error {
 	os.Setenv("NAME", cli.Config.Name)
 
 	outputPath := filepath.Join(cli.Config.CurrentWorkingDir, "_output")
-	publicSSHKey, err := createSaveSSH(outputPath, cli.Config.Name+"-ssh")
-	if err != nil {
-		return errors.Wrap(err, "Error while generating ssh keys")
+	if !cli.Config.UseDeployCommand {
+		publicSSHKey, err := createSaveSSH(outputPath, cli.Config.Name+"-ssh")
+		if err != nil {
+			return errors.Wrap(err, "Error while generating ssh keys")
+		}
+		os.Setenv("PUBLIC_SSH_KEY", publicSSHKey)
 	}
 
-	os.Setenv("PUBLIC_SSH_KEY", publicSSHKey)
 	os.Setenv("DNS_PREFIX", cli.Config.Name)
 
-	err = cli.Account.CreateGroup(cli.Config.Name, cli.Config.Location)
+	err := cli.Account.CreateGroup(cli.Config.Name, cli.Config.Location)
 	if err != nil {
 		return errors.Wrap(err, "Error while trying to create resource group")
 	}


### PR DESCRIPTION
see #3776 and #3756
e2e tests always set the cluster up using `acs-engine generate`, followed by a `az deployment create` on the generated arm template. https://github.com/Azure/acs-engine/blob/708c688ba25c89fbf605428d46739ee39c44cfc8/test/e2e/runner/cli_provisioner.go#L133

Q: Should all functional tests be run on both `generate` and `deploy` setup? 

- [x] add Deploy cmd to [cli.go](https://github.com/Azure/acs-engine/blob/master/test/e2e/engine/cli.go)
- [x] parameterize provisioner to use deploy or generate setup
- [x] refactor cli_provisioner to allow using the deploy command
- [ ] add deploy e2e test to ci
