### PR TITLE
Ensuring etcd is not installed twice on VHD images

### DIFF
--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -41,13 +41,12 @@ function holdWALinuxAgent() {
     fi
 }
 
-if [[ ! -z "${MASTER_NODE}" ]]; then
-    installEtcd
-fi
-
 if $FULL_INSTALL_REQUIRED; then
     testOutboundConnection
     holdWALinuxAgent
+    if [[ ! -z "${MASTER_NODE}" ]]; then
+        installEtcd
+    fi
     installDeps
 else 
     echo "Golden image; skipping dependencies installation"


### PR DESCRIPTION
Currently, we seem to be installing etcd before we make the check for golden image. This potentially leads to redundant etcd installs. This PR should hopefully fix that