### PR TITLE
Remove non-existing priority class from Azure Network Policy Manager

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-azure-npm-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-azure-npm-daemonset.yaml
@@ -89,7 +89,6 @@ spec:
             mountPath: /run/xtables.lock
           - name: log
             mountPath: /var/log
-      priorityClassName: azure-npm-priority-class
       hostNetwork: true
       volumes:
       - name: log


### PR DESCRIPTION
This PR removes the non-existing priority class from Azure NPM daemonset. This is required for Kubernetes version >1.11