### PR TITLE
Enable "gosimple" linter plugin

### DIFF
--- a/pkg/acsengine/defaults_test.go
+++ b/pkg/acsengine/defaults_test.go
@@ -618,12 +618,12 @@ func TestSetVMSSDefaults(t *testing.T) {
 
 	properties.AgentPoolProfiles[0].Count = 110
 	setPropertiesDefaults(&mockCS, false, false)
-	if *properties.AgentPoolProfiles[0].SinglePlacementGroup != false {
+	if *properties.AgentPoolProfiles[0].SinglePlacementGroup {
 		t.Fatalf("AgentPoolProfile[0].SinglePlacementGroup did not have the expected configuration, got %t, expected %t",
 			*properties.AgentPoolProfiles[0].SinglePlacementGroup, false)
 	}
 
-	if *properties.AgentPoolProfiles[0].SinglePlacementGroup == false && properties.AgentPoolProfiles[0].StorageProfile != api.ManagedDisks {
+	if !*properties.AgentPoolProfiles[0].SinglePlacementGroup && properties.AgentPoolProfiles[0].StorageProfile != api.ManagedDisks {
 		t.Fatalf("AgentPoolProfile[0].StorageProfile did not have the expected configuration, got %s, expected %s",
 			properties.AgentPoolProfiles[0].StorageProfile, api.ManagedDisks)
 	}

--- a/pkg/acsengine/defaults_test.go
+++ b/pkg/acsengine/defaults_test.go
@@ -618,7 +618,7 @@ func TestSetVMSSDefaults(t *testing.T) {
 
 	properties.AgentPoolProfiles[0].Count = 110
 	setPropertiesDefaults(&mockCS, false, false)
-	if *properties.AgentPoolProfiles[0].SinglePlacementGroup {
+	if helpers.IsTrueBoolPointer(properties.AgentPoolProfiles[0].SinglePlacementGroup) {
 		t.Fatalf("AgentPoolProfile[0].SinglePlacementGroup did not have the expected configuration, got %t, expected %t",
 			*properties.AgentPoolProfiles[0].SinglePlacementGroup, false)
 	}

--- a/pkg/acsengine/tenantid_test.go
+++ b/pkg/acsengine/tenantid_test.go
@@ -50,7 +50,6 @@ func TestGetTenantID_UnexpectedResponse(t *testing.T) {
 
 	mux.HandleFunc("/subscriptions/foobarsubscription", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
-		return
 	})
 
 	_, err := GetTenantID(server.URL, "foobarsubscription")
@@ -70,7 +69,6 @@ func TestGetTenantID_InvalidHeader(t *testing.T) {
 	mux.HandleFunc("/subscriptions/foobarsubscription", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Header().Set("fookey", "bazvalue")
-		return
 	})
 
 	_, err := GetTenantID(server.URL, "foobarsubscription")

--- a/pkg/acsengine/transform/apimodel_merger.go
+++ b/pkg/acsengine/transform/apimodel_merger.go
@@ -23,7 +23,7 @@ type APIModelValue struct {
 
 // MapValues converts an arraw of rwa ApiModel values (like ["masterProfile.count=4","linuxProfile.adminUsername=admin"]) to a map
 func MapValues(m map[string]APIModelValue, setFlagValues []string) {
-	if setFlagValues == nil || len(setFlagValues) == 0 {
+	if len(setFlagValues) == 0 {
 		return
 	}
 

--- a/pkg/api/agentPoolOnlyApi/v20180331/validate.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/validate.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Azure/acs-engine/pkg/api/common"
+	"github.com/Azure/acs-engine/pkg/helpers"
 	"github.com/pkg/errors"
 	validator "gopkg.in/go-playground/validator.v9"
 )
@@ -40,7 +41,7 @@ func (l *LinuxProfile) Validate() error {
 
 // Validate implements APIObject
 func (a *AADProfile) Validate(rbacEnabled *bool) error {
-	if rbacEnabled == nil || !*rbacEnabled {
+	if !helpers.IsTrueBoolPointer(rbacEnabled) {
 		return ErrorRBACNotEnabledForAAD
 	}
 

--- a/pkg/api/agentPoolOnlyApi/v20180331/validate.go
+++ b/pkg/api/agentPoolOnlyApi/v20180331/validate.go
@@ -40,7 +40,7 @@ func (l *LinuxProfile) Validate() error {
 
 // Validate implements APIObject
 func (a *AADProfile) Validate(rbacEnabled *bool) error {
-	if rbacEnabled == nil || *rbacEnabled == false {
+	if rbacEnabled == nil || !*rbacEnabled {
 		return ErrorRBACNotEnabledForAAD
 	}
 

--- a/pkg/api/converterfromagentpoolonlyapi_test.go
+++ b/pkg/api/converterfromagentpoolonlyapi_test.go
@@ -230,7 +230,7 @@ func TestConvertToV20180331AddonProfile(t *testing.T) {
 	if _, ok := p[addonName]; !ok {
 		t.Error("addon is not found")
 	}
-	if p[addonName].Enabled != true {
+	if !p[addonName].Enabled {
 		t.Error("addon should be enabled")
 	}
 	v, ok := p[addonName].Config["opt1"]
@@ -244,7 +244,6 @@ func TestConvertToV20180331AddonProfile(t *testing.T) {
 
 func TestConvertKubernetesConfigToEnableRBACV20180331AgentPoolOnly(t *testing.T) {
 	var kc *KubernetesConfig
-	kc = nil
 	enableRBAC := convertKubernetesConfigToEnableRBACV20180331AgentPoolOnly(kc)
 	if enableRBAC == nil {
 		t.Error("EnableRBAC expected not to be nil")

--- a/pkg/api/convertertoagentpoolonlyapi.go
+++ b/pkg/api/convertertoagentpoolonlyapi.go
@@ -384,7 +384,7 @@ func convertV20180331AgentPoolOnlyWindowsProfile(obj *v20180331.WindowsProfile) 
 }
 
 func convertV20180331AgentPoolOnlyKubernetesConfig(enableRBAC *bool) *KubernetesConfig {
-	if enableRBAC != nil && *enableRBAC == true {
+	if enableRBAC != nil && *enableRBAC {
 		// We set default behavior to be false
 		return &KubernetesConfig{
 			EnableRbac:          helpers.PointerToBool(true),

--- a/pkg/api/convertertoagentpoolonlyapi.go
+++ b/pkg/api/convertertoagentpoolonlyapi.go
@@ -384,7 +384,7 @@ func convertV20180331AgentPoolOnlyWindowsProfile(obj *v20180331.WindowsProfile) 
 }
 
 func convertV20180331AgentPoolOnlyKubernetesConfig(enableRBAC *bool) *KubernetesConfig {
-	if enableRBAC != nil && *enableRBAC {
+	if helpers.IsTrueBoolPointer(enableRBAC) {
 		// We set default behavior to be false
 		return &KubernetesConfig{
 			EnableRbac:          helpers.PointerToBool(true),

--- a/pkg/api/convertertoagentpoolonlyapi_test.go
+++ b/pkg/api/convertertoagentpoolonlyapi_test.go
@@ -226,11 +226,11 @@ func TestConvertV20170831AgentPoolOnlyOrchestratorProfile_KubernetesConfig(t *te
 		t.Error("OrchestratorProfile.KubernetesConfig expected not to be nil")
 	}
 
-	if op.KubernetesConfig.EnableRbac == nil || *op.KubernetesConfig.EnableRbac {
+	if helpers.IsTrueBoolPointer(op.KubernetesConfig.EnableRbac) {
 		t.Error("OrchestratorProfile.KubernetesConfig.EnableRbac expected to be *false")
 	}
 
-	if op.KubernetesConfig.EnableSecureKubelet == nil || *op.KubernetesConfig.EnableSecureKubelet {
+	if helpers.IsTrueBoolPointer(op.KubernetesConfig.EnableSecureKubelet) {
 		t.Error("OrchestratorProfile.KubernetesConfig.EnableSecureKubelet expected to be *false")
 	}
 
@@ -271,7 +271,7 @@ func TestConvertV20180331AgentPoolOnlyKubernetesConfig(t *testing.T) {
 		t.Error("EnableRbac expected not to be nil")
 	}
 
-	if *kc.EnableRbac {
+	if helpers.IsTrueBoolPointer(kc.EnableRbac) {
 		t.Error("EnableRbac expected to be false")
 	}
 
@@ -279,7 +279,7 @@ func TestConvertV20180331AgentPoolOnlyKubernetesConfig(t *testing.T) {
 		t.Error("EnableSecureKubelet expected not to be nil")
 	}
 
-	if *kc.EnableSecureKubelet {
+	if helpers.IsTrueBoolPointer(kc.EnableSecureKubelet) {
 		t.Error("EnableSecureKubelet expected to be false")
 	}
 
@@ -296,7 +296,7 @@ func TestConvertV20180331AgentPoolOnlyKubernetesConfig(t *testing.T) {
 		t.Error("EnableRbac expected not to be nil")
 	}
 
-	if *kc.EnableRbac {
+	if helpers.IsTrueBoolPointer(kc.EnableRbac) {
 		t.Error("EnableRbac expected to be false")
 	}
 
@@ -304,7 +304,7 @@ func TestConvertV20180331AgentPoolOnlyKubernetesConfig(t *testing.T) {
 		t.Error("EnableSecureKubelet expected not to be nil")
 	}
 
-	if *kc.EnableSecureKubelet {
+	if helpers.IsTrueBoolPointer(kc.EnableSecureKubelet) {
 		t.Error("EnableSecureKubelet expected to be false")
 	}
 

--- a/pkg/api/convertertoagentpoolonlyapi_test.go
+++ b/pkg/api/convertertoagentpoolonlyapi_test.go
@@ -204,7 +204,7 @@ func TestConvertFromV20180331AddonProfile(t *testing.T) {
 	if _, ok := api[addonName]; !ok {
 		t.Error("addon is not found")
 	}
-	if api[addonName].Enabled != true {
+	if !api[addonName].Enabled {
 		t.Error("addon should be enabled")
 	}
 	v, ok := api[addonName].Config["opt1"]
@@ -226,19 +226,18 @@ func TestConvertV20170831AgentPoolOnlyOrchestratorProfile_KubernetesConfig(t *te
 		t.Error("OrchestratorProfile.KubernetesConfig expected not to be nil")
 	}
 
-	if op.KubernetesConfig.EnableRbac == nil || *op.KubernetesConfig.EnableRbac == true {
+	if op.KubernetesConfig.EnableRbac == nil || *op.KubernetesConfig.EnableRbac {
 		t.Error("OrchestratorProfile.KubernetesConfig.EnableRbac expected to be *false")
 	}
 
-	if op.KubernetesConfig.EnableSecureKubelet == nil || *op.KubernetesConfig.EnableSecureKubelet == true {
+	if op.KubernetesConfig.EnableSecureKubelet == nil || *op.KubernetesConfig.EnableSecureKubelet {
 		t.Error("OrchestratorProfile.KubernetesConfig.EnableSecureKubelet expected to be *false")
 	}
 
 }
 
 func TestConvertV20180331AgentPoolOnlyKubernetesConfig(t *testing.T) {
-	var kc *KubernetesConfig
-	kc = convertV20180331AgentPoolOnlyKubernetesConfig(helpers.PointerToBool(true))
+	var kc = convertV20180331AgentPoolOnlyKubernetesConfig(helpers.PointerToBool(true))
 	if kc == nil {
 		t.Error("kubernetesConfig expected not to be nil")
 	}
@@ -247,7 +246,7 @@ func TestConvertV20180331AgentPoolOnlyKubernetesConfig(t *testing.T) {
 		t.Error("EnableRbac expected not to be nil")
 	}
 
-	if *kc.EnableRbac != true {
+	if !*kc.EnableRbac {
 		t.Error("EnableRbac expected to be true")
 	}
 
@@ -255,7 +254,7 @@ func TestConvertV20180331AgentPoolOnlyKubernetesConfig(t *testing.T) {
 		t.Error("EnableSecureKubelet expected not to be nil")
 	}
 
-	if *kc.EnableSecureKubelet != true {
+	if !*kc.EnableSecureKubelet {
 		t.Error("EnableSecureKubelet expected to be true")
 	}
 
@@ -272,7 +271,7 @@ func TestConvertV20180331AgentPoolOnlyKubernetesConfig(t *testing.T) {
 		t.Error("EnableRbac expected not to be nil")
 	}
 
-	if *kc.EnableRbac != false {
+	if *kc.EnableRbac {
 		t.Error("EnableRbac expected to be false")
 	}
 
@@ -280,7 +279,7 @@ func TestConvertV20180331AgentPoolOnlyKubernetesConfig(t *testing.T) {
 		t.Error("EnableSecureKubelet expected not to be nil")
 	}
 
-	if *kc.EnableSecureKubelet != false {
+	if *kc.EnableSecureKubelet {
 		t.Error("EnableSecureKubelet expected to be false")
 	}
 
@@ -297,7 +296,7 @@ func TestConvertV20180331AgentPoolOnlyKubernetesConfig(t *testing.T) {
 		t.Error("EnableRbac expected not to be nil")
 	}
 
-	if *kc.EnableRbac != false {
+	if *kc.EnableRbac {
 		t.Error("EnableRbac expected to be false")
 	}
 
@@ -305,7 +304,7 @@ func TestConvertV20180331AgentPoolOnlyKubernetesConfig(t *testing.T) {
 		t.Error("EnableSecureKubelet expected not to be nil")
 	}
 
-	if *kc.EnableSecureKubelet != false {
+	if *kc.EnableSecureKubelet {
 		t.Error("EnableSecureKubelet expected to be false")
 	}
 

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -853,8 +853,9 @@ func TestIsTillerEnabled(t *testing.T) {
 		},
 	}
 	enabled := c.IsTillerEnabled()
-	if enabled != DefaultTillerAddonEnabled {
-		t.Fatalf("KubernetesConfig.IsTillerEnabled() should return %t when no tiller addon has been specified, instead returned %t", DefaultTillerAddonEnabled, enabled)
+	enabledDefault := DefaultTillerAddonEnabled
+	if enabled != enabledDefault {
+		t.Fatalf("KubernetesConfig.IsTillerEnabled() should return %t when no tiller addon has been specified, instead returned %t", enabledDefault, enabled)
 	}
 	c.Addons = append(c.Addons, getMockAddon(DefaultTillerAddonName))
 	enabled = c.IsTillerEnabled()
@@ -883,8 +884,9 @@ func TestIsACIConnectorEnabled(t *testing.T) {
 		},
 	}
 	enabled := c.IsACIConnectorEnabled()
-	if enabled != DefaultACIConnectorAddonEnabled {
-		t.Fatalf("KubernetesConfig.IsACIConnectorEnabled() should return %t when no ACI connector addon has been specified, instead returned %t", DefaultACIConnectorAddonEnabled, enabled)
+	enabledDefault := DefaultACIConnectorAddonEnabled
+	if enabled != enabledDefault {
+		t.Fatalf("KubernetesConfig.IsACIConnectorEnabled() should return %t when no ACI connector addon has been specified, instead returned %t", enabledDefault, enabled)
 	}
 	c.Addons = append(c.Addons, getMockAddon(DefaultACIConnectorAddonName))
 	enabled = c.IsACIConnectorEnabled()
@@ -913,8 +915,9 @@ func TestIsClusterAutoscalerEnabled(t *testing.T) {
 		},
 	}
 	enabled := c.IsClusterAutoscalerEnabled()
-	if enabled != DefaultClusterAutoscalerAddonEnabled {
-		t.Fatalf("KubernetesConfig.IsAutoscalerEnabled() should return %t when no cluster autoscaler addon has been specified, instead returned %t", DefaultClusterAutoscalerAddonEnabled, enabled)
+	enabledDefault := DefaultClusterAutoscalerAddonEnabled
+	if enabled != enabledDefault {
+		t.Fatalf("KubernetesConfig.IsAutoscalerEnabled() should return %t when no cluster autoscaler addon has been specified, instead returned %t", enabledDefault, enabled)
 	}
 	c.Addons = append(c.Addons, getMockAddon(DefaultClusterAutoscalerAddonName))
 	enabled = c.IsClusterAutoscalerEnabled()
@@ -995,8 +998,9 @@ func TestIsContainerMonitoringEnabled(t *testing.T) {
 		},
 	}
 	enabled := o.KubernetesConfig.IsContainerMonitoringEnabled()
-	if enabled != DefaultContainerMonitoringAddonEnabled {
-		t.Fatalf("KubernetesConfig.IsContainerMonitoringEnabled() should return %t for kubernetes version %s when no container-monitoring addon has been specified, instead returned %t", DefaultContainerMonitoringAddonEnabled, v, enabled)
+	enabledDefault := DefaultContainerMonitoringAddonEnabled
+	if enabled != enabledDefault {
+		t.Fatalf("KubernetesConfig.IsContainerMonitoringEnabled() should return %t for kubernetes version %s when no container-monitoring addon has been specified, instead returned %t", enabledDefault, v, enabled)
 	}
 
 	b := true
@@ -1004,7 +1008,7 @@ func TestIsContainerMonitoringEnabled(t *testing.T) {
 	cm.Enabled = &b
 	o.KubernetesConfig.Addons = append(o.KubernetesConfig.Addons, cm)
 	enabled = o.KubernetesConfig.IsContainerMonitoringEnabled()
-	if enabled != true {
+	if !enabled {
 		t.Fatalf("KubernetesConfig.IsContainerMonitoringEnabled() should return %t for kubernetes version %s when the container-monitoring addon has been specified, instead returned %t", true, v, enabled)
 	}
 
@@ -1033,8 +1037,9 @@ func TestIsDashboardEnabled(t *testing.T) {
 		},
 	}
 	enabled := c.IsDashboardEnabled()
-	if enabled != DefaultDashboardAddonEnabled {
-		t.Fatalf("KubernetesConfig.IsDashboardEnabled() should return %t when no kubernetes-dashboard addon has been specified, instead returned %t", DefaultDashboardAddonEnabled, enabled)
+	enabledDefault := DefaultDashboardAddonEnabled
+	if enabled != enabledDefault {
+		t.Fatalf("KubernetesConfig.IsDashboardEnabled() should return %t when no kubernetes-dashboard addon has been specified, instead returned %t", enabledDefault, enabled)
 	}
 	c.Addons = append(c.Addons, getMockAddon(DefaultDashboardAddonName))
 	enabled = c.IsDashboardEnabled()
@@ -1063,8 +1068,9 @@ func TestIsReschedulerEnabled(t *testing.T) {
 		},
 	}
 	enabled := c.IsReschedulerEnabled()
-	if enabled != DefaultReschedulerAddonEnabled {
-		t.Fatalf("KubernetesConfig.IsReschedulerEnabled() should return %t when no rescheduler addon has been specified, instead returned %t", DefaultReschedulerAddonEnabled, enabled)
+	enabledDefault := DefaultReschedulerAddonEnabled
+	if enabled != enabledDefault {
+		t.Fatalf("KubernetesConfig.IsReschedulerEnabled() should return %t when no rescheduler addon has been specified, instead returned %t", enabledDefault, enabled)
 	}
 	c.Addons = append(c.Addons, getMockAddon(DefaultReschedulerAddonName))
 	enabled = c.IsReschedulerEnabled()
@@ -1097,14 +1103,16 @@ func TestIsMetricsServerEnabled(t *testing.T) {
 		},
 	}
 	enabled := o.IsMetricsServerEnabled()
-	if enabled != DefaultMetricsServerAddonEnabled {
-		t.Fatalf("KubernetesConfig.IsMetricsServerEnabled() should return %t for kubernetes version %s when no metrics-server addon has been specified, instead returned %t", DefaultMetricsServerAddonEnabled, v, enabled)
+	enabledDefault := DefaultMetricsServerAddonEnabled
+	if enabled != enabledDefault {
+		t.Fatalf("KubernetesConfig.IsMetricsServerEnabled() should return %t for kubernetes version %s when no metrics-server addon has been specified, instead returned %t", enabledDefault, v, enabled)
 	}
 
 	o.KubernetesConfig.Addons = append(o.KubernetesConfig.Addons, getMockAddon(DefaultMetricsServerAddonName))
 	enabled = o.IsMetricsServerEnabled()
-	if enabled != DefaultMetricsServerAddonEnabled {
-		t.Fatalf("KubernetesConfig.IsMetricsServerEnabled() should return %t for kubernetes version %s when the metrics-server addon has been specified, instead returned %t", DefaultMetricsServerAddonEnabled, v, enabled)
+	enabledDefault = DefaultMetricsServerAddonEnabled
+	if enabled != enabledDefault {
+		t.Fatalf("KubernetesConfig.IsMetricsServerEnabled() should return %t for kubernetes version %s when the metrics-server addon has been specified, instead returned %t", enabledDefault, v, enabled)
 	}
 
 	b := true

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -56,7 +56,7 @@ const exampleUserMSIModel = `{
 		"orchestratorType": "Kubernetes",
 		"kubernetesConfig": {
 			"useManagedIdentity": true,
-			"userAssignedID": "` + exampleUserMSI + `"	
+			"userAssignedID": "` + exampleUserMSI + `"
 		}
 	},
 	"masterProfile": { "count": 1, "dnsPrefix": "", "vmSize": "Standard_D2_v2" },
@@ -799,7 +799,7 @@ func TestUserAssignedMSI(t *testing.T) {
 	}
 	systemMSI := apiModel.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity
 	actualUserMSI := apiModel.Properties.OrchestratorProfile.KubernetesConfig.UserAssignedID
-	if systemMSI != true || actualUserMSI != "" {
+	if !systemMSI || actualUserMSI != "" {
 		t.Fatalf("found user msi: %t and usermsi: %s", systemMSI, actualUserMSI)
 	}
 
@@ -814,7 +814,7 @@ func TestUserAssignedMSI(t *testing.T) {
 	}
 	systemMSI = apiModel.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity
 	actualUserMSI = apiModel.Properties.OrchestratorProfile.KubernetesConfig.UserAssignedID
-	if systemMSI != true && actualUserMSI != exampleUserMSI {
+	if !systemMSI && actualUserMSI != exampleUserMSI {
 		t.Fatalf("found user msi: %t and usermsi: %s", systemMSI, actualUserMSI)
 	}
 }

--- a/pkg/armhelpers/graph.go
+++ b/pkg/armhelpers/graph.go
@@ -112,7 +112,7 @@ func (az *AzureClient) CreateRoleAssignmentSimple(ctx context.Context, resourceG
 		},
 	}
 
-	re := regexp.MustCompile("(?i)status=(\\d+)")
+	re := regexp.MustCompile(`(?i)status=(\d+)`)
 	for {
 		_, err := az.CreateRoleAssignment(
 			ctx,

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -174,7 +174,7 @@ EPDesL0rH+3s1CKpgkhYdbJ675GFoGoq+X21QaqsdvoXmmuJF9qq9Tq+JaWloUNq
 	pemBuffer := bytes.Buffer{}
 	pem.Encode(&pemBuffer, pemBlock)
 
-	if string(pemBuffer.Bytes()) != expectedPrivateKeyString {
+	if pemBuffer.String() != expectedPrivateKeyString {
 		t.Fatalf("Private Key did not match expected format/value")
 	}
 

--- a/scripts/validate-go.sh
+++ b/scripts/validate-go.sh
@@ -30,13 +30,14 @@ gometalinter \
   --enable deadcode \
   --enable gofmt \
   --enable goimports \
+  --enable gosimple \
   --enable ineffassign \
   --enable misspell \
   --enable unused \
   --enable vet \
   --tests \
   --vendor \
-  --deadline 60s \
+  --deadline 120s \
   --skip test/i18n \
   --skip pkg/test \
   --exclude pkg/i18n/i18n.go \

--- a/test/e2e/azure/cli.go
+++ b/test/e2e/azure/cli.go
@@ -360,8 +360,7 @@ func (a *Account) IsClusterExpired(d time.Duration) bool {
 
 // FetchActivityLog gets all the failures from the activity log for the provided resource group.
 func (a *Account) FetchActivityLog(rg string) (string, error) {
-	var cmd *exec.Cmd
-	cmd = exec.Command("az", "monitor", "activity-log", "list", "--resource-group", rg, "--status", "Failed")
+	var cmd = exec.Command("az", "monitor", "activity-log", "list", "--resource-group", rg, "--status", "Failed")
 	util.PrintCommand(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -236,11 +236,7 @@ func (e *Engine) HasAddon(name string) (bool, api.KubernetesAddon) {
 
 // HasNetworkPolicy will return true if the specified network policy is enabled
 func (e *Engine) HasNetworkPolicy(name string) bool {
-	if strings.Contains(e.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy, name) {
-		return true
-	}
-
-	return false
+	return strings.Contains(e.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.NetworkPolicy, name)
 }
 
 // HasAllZonesAgentPools will return true if all of the agent pools have zones
@@ -251,10 +247,7 @@ func (e *Engine) HasAllZonesAgentPools() bool {
 			count++
 		}
 	}
-	if count == len(e.ExpandedDefinition.Properties.AgentPoolProfiles) {
-		return true
-	}
-	return false
+	return count == len(e.ExpandedDefinition.Properties.AgentPoolProfiles)
 }
 
 // Write will write the cluster definition to disk

--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -212,7 +212,7 @@ func (d *Deployment) WaitForReplicas(n int, sleep, duration time.Duration) ([]po
 		select {
 		case err := <-errCh:
 			return pods, err
-		case _ = <-readyCh:
+		case <-readyCh:
 			return pods, nil
 		}
 	}

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -554,7 +554,7 @@ func (p *Pod) ValidateOmsAgentLogs(execCmdString string, sleep, duration time.Du
 
 // CheckWindowsOutboundConnection will keep retrying the check if an error is received until the timeout occurs or it passes. This helps us when DNS may not be available for some time after a pod starts.
 func (p *Pod) CheckWindowsOutboundConnection(sleep, duration time.Duration) (bool, error) {
-	exp, err := regexp.Compile("(StatusCode\\s*:\\s*200)")
+	exp, err := regexp.Compile(`(StatusCode\s*:\s*200)`)
 	if err != nil {
 		log.Printf("Error while trying to create regex for windows outbound check:%s\n", err)
 		return false, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Simplifies some code as suggested by the `gosimple` plugin to `gometalinter` and enables that plugin for the `make test-style` target.

~(We can't run this plugin in general for linting, however, because it suggests some incorrect changes to `pkg/api/types_test.go`.)~

**Special notes for your reviewer**:

Obviously not a critical change, but I've had this branch sitting around for a month so I freshened it up and made a PR.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
