### PR TITLE
Remove deprecated method calls in kubeclient

### DIFF
--- a/pkg/armhelpers/kubeclient.go
+++ b/pkg/armhelpers/kubeclient.go
@@ -42,23 +42,23 @@ func (az *AzureClient) GetKubernetesClient(masterURL, kubeConfig string, interva
 
 //ListPods returns all Pods running on the passed in node
 func (c *KubernetesClientSetClient) ListPods(node *v1.Node) (*v1.PodList, error) {
-	return c.clientset.Core().Pods(metav1.NamespaceAll).List(metav1.ListOptions{
+	return c.clientset.CoreV1().Pods(metav1.NamespaceAll).List(metav1.ListOptions{
 		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": node.Name}).String()})
 }
 
 //GetNode returns details about node with passed in name
 func (c *KubernetesClientSetClient) GetNode(name string) (*v1.Node, error) {
-	return c.clientset.Core().Nodes().Get(name, metav1.GetOptions{})
+	return c.clientset.CoreV1().Nodes().Get(name, metav1.GetOptions{})
 }
 
 //UpdateNode updates the node in the api server with the passed in info
 func (c *KubernetesClientSetClient) UpdateNode(node *v1.Node) (*v1.Node, error) {
-	return c.clientset.Core().Nodes().Update(node)
+	return c.clientset.CoreV1().Nodes().Update(node)
 }
 
 //DeleteNode deregisters the node in the api server
 func (c *KubernetesClientSetClient) DeleteNode(name string) error {
-	return c.clientset.Core().Nodes().Delete(name, &metav1.DeleteOptions{})
+	return c.clientset.CoreV1().Nodes().Delete(name, &metav1.DeleteOptions{})
 }
 
 //SupportEviction queries the api server to discover if it supports eviction, and returns supported type if it is supported
@@ -94,7 +94,7 @@ func (c *KubernetesClientSetClient) SupportEviction() (string, error) {
 
 //DeletePod deletes the passed in pod
 func (c *KubernetesClientSetClient) DeletePod(pod *v1.Pod) error {
-	return c.clientset.Core().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})
+	return c.clientset.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})
 }
 
 //EvictPod evicts the passed in pod using the passed in api version
@@ -114,7 +114,7 @@ func (c *KubernetesClientSetClient) EvictPod(pod *v1.Pod, policyGroupVersion str
 
 //GetPod returns the pod
 func (c *KubernetesClientSetClient) getPod(namespace, name string) (*v1.Pod, error) {
-	return c.clientset.Core().Pods(namespace).Get(name, metav1.GetOptions{})
+	return c.clientset.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
 }
 
 //WaitForDelete waits until all pods are deleted. Returns all pods not deleted and an error on failure


### PR DESCRIPTION
Removing some deprecated method calls in kubeclient. This was done after referring to k8s go client documentation