### PR TITLE
adding ablitiy to login to an external tenant in azure client stuff

### DIFF
--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -211,25 +211,7 @@ func NewAzureClientWithClientCertificate(env azure.Environment, subscriptionID, 
 		return nil, err
 	}
 
-	if certificate == nil {
-		return nil, errors.New("certificate should not be nil")
-	}
-
-	if privateKey == nil {
-		return nil, errors.New("privateKey should not be nil")
-	}
-
-	armSpt, err := adal.NewServicePrincipalTokenFromCertificate(*oauthConfig, clientID, certificate, privateKey, env.ServiceManagementEndpoint)
-	if err != nil {
-		return nil, err
-	}
-	graphSpt, err := adal.NewServicePrincipalTokenFromCertificate(*oauthConfig, clientID, certificate, privateKey, env.GraphEndpoint)
-	if err != nil {
-		return nil, err
-	}
-	graphSpt.Refresh()
-
-	return getClient(env, subscriptionID, tenantID, armSpt, graphSpt), nil
+	return internalnewAzClientWithCertificate(env, oauthConfig, subscriptionID, clientID, tenantID, certificate, privateKey)
 }
 
 // NewAzureClientWithClientCertificateExternalTenant returns an AzureClient via client_id and jwt certificate assertion against a 3rd party tenant
@@ -239,6 +221,10 @@ func NewAzureClientWithClientCertificateExternalTenant(env azure.Environment, su
 		return nil, err
 	}
 
+	return internalnewAzClientWithCertificate(env, oauthConfig, subscriptionID, clientID, tenantID, certificate, privateKey)
+}
+
+func internalnewAzClientWithCertificate(env azure.Environment, oauthConfig *adal.OAuthConfig, subscriptionID, clientID, tenantID string, certificate *x509.Certificate, privateKey *rsa.PrivateKey) (*AzureClient, error) {
 	if certificate == nil {
 		return nil, errors.New("certificate should not be nil")
 	}

--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -211,7 +211,7 @@ func NewAzureClientWithClientCertificate(env azure.Environment, subscriptionID, 
 		return nil, err
 	}
 
-	return internalnewAzClientWithCertificate(env, oauthConfig, subscriptionID, clientID, tenantID, certificate, privateKey)
+	return newAzClientWithCertificate(env, oauthConfig, subscriptionID, clientID, tenantID, certificate, privateKey)
 }
 
 // NewAzureClientWithClientCertificateExternalTenant returns an AzureClient via client_id and jwt certificate assertion against a 3rd party tenant
@@ -221,10 +221,10 @@ func NewAzureClientWithClientCertificateExternalTenant(env azure.Environment, su
 		return nil, err
 	}
 
-	return internalnewAzClientWithCertificate(env, oauthConfig, subscriptionID, clientID, tenantID, certificate, privateKey)
+	return newAzClientWithCertificate(env, oauthConfig, subscriptionID, clientID, tenantID, certificate, privateKey)
 }
 
-func internalnewAzClientWithCertificate(env azure.Environment, oauthConfig *adal.OAuthConfig, subscriptionID, clientID, tenantID string, certificate *x509.Certificate, privateKey *rsa.PrivateKey) (*AzureClient, error) {
+func newAzClientWithCertificate(env azure.Environment, oauthConfig *adal.OAuthConfig, subscriptionID, clientID, tenantID string, certificate *x509.Certificate, privateKey *rsa.PrivateKey) (*AzureClient, error) {
 	if certificate == nil {
 		return nil, errors.New("certificate should not be nil")
 	}

--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -233,7 +233,7 @@ func NewAzureClientWithClientCertificate(env azure.Environment, subscriptionID, 
 }
 
 // NewAzureClientWithClientCertificateExternalTenant returns an AzureClient via client_id and jwt certificate assertion against a 3rd party tenant
-func NewAzureClientWithClientCertificateExternalTenant(env azure.Environment, subscriptionID, clientID string, certificate *x509.Certificate, privateKey *rsa.PrivateKey) (*AzureClient, error) {
+func NewAzureClientWithClientCertificateExternalTenant(env azure.Environment, subscriptionID, tenantID, clientID string, certificate *x509.Certificate, privateKey *rsa.PrivateKey) (*AzureClient, error) {
 	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, tenantID)
 	if err != nil {
 		return nil, err

--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -211,7 +211,7 @@ func NewAzureClientWithClientCertificate(env azure.Environment, subscriptionID, 
 		return nil, err
 	}
 
-	return newAzClientWithCertificate(env, oauthConfig, subscriptionID, clientID, tenantID, certificate, privateKey)
+	return newAzureClientWithCertificate(env, oauthConfig, subscriptionID, clientID, tenantID, certificate, privateKey)
 }
 
 // NewAzureClientWithClientCertificateExternalTenant returns an AzureClient via client_id and jwt certificate assertion against a 3rd party tenant
@@ -221,10 +221,10 @@ func NewAzureClientWithClientCertificateExternalTenant(env azure.Environment, su
 		return nil, err
 	}
 
-	return newAzClientWithCertificate(env, oauthConfig, subscriptionID, clientID, tenantID, certificate, privateKey)
+	return newAzureClientWithCertificate(env, oauthConfig, subscriptionID, clientID, tenantID, certificate, privateKey)
 }
 
-func newAzClientWithCertificate(env azure.Environment, oauthConfig *adal.OAuthConfig, subscriptionID, clientID, tenantID string, certificate *x509.Certificate, privateKey *rsa.PrivateKey) (*AzureClient, error) {
+func newAzureClientWithCertificate(env azure.Environment, oauthConfig *adal.OAuthConfig, subscriptionID, clientID, tenantID string, certificate *x509.Certificate, privateKey *rsa.PrivateKey) (*AzureClient, error) {
 	if certificate == nil {
 		return nil, errors.New("certificate should not be nil")
 	}


### PR DESCRIPTION
What this PR does / why we need it:
We are using this in the RP for getting an azure client from a specific tenant.
I see other clients are used in the CLI, I can add this there as well if needed

related to an older pr only this one uses a cert to login