### PR TITLE
only enable aggregated api if rbac != disabled

### DIFF
--- a/pkg/acsengine/defaults-apiserver_test.go
+++ b/pkg/acsengine/defaults-apiserver_test.go
@@ -286,6 +286,18 @@ func TestAPIServerConfigEnableRbac(t *testing.T) {
 	}
 }
 
+func TestAPIServerConfigDisableRbac(t *testing.T) {
+	// Test EnableRbac = false
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableRbac = helpers.PointerToBool(false)
+	setAPIServerConfig(cs)
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--authorization-mode"] != "" {
+		t.Fatalf("got unexpected '--authorization-mode' API server config value for EnableRbac=false: %s",
+			a["--authorization-mode"])
+	}
+}
+
 func TestAPIServerConfigEnableSecureKubelet(t *testing.T) {
 	// Test EnableSecureKubelet = true
 	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -397,8 +397,14 @@ func setOrchestratorDefaults(cs *api.ContainerService, isUpdate bool) {
 			a.OrchestratorProfile.KubernetesConfig.PrivateCluster.JumpboxProfile.StorageProfile = api.ManagedDisks
 		}
 
-		if a.OrchestratorProfile.KubernetesConfig.EnableRbac == nil {
-			a.OrchestratorProfile.KubernetesConfig.EnableRbac = helpers.PointerToBool(api.DefaultRBACEnabled)
+		if !helpers.IsFalseBoolPointer(a.OrchestratorProfile.KubernetesConfig.EnableRbac) {
+			if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.9.0") {
+				// TODO make EnableAggregatedAPIs a pointer to bool so that a user can opt out of it
+				a.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs = true
+			}
+			if a.OrchestratorProfile.KubernetesConfig.EnableRbac == nil {
+				a.OrchestratorProfile.KubernetesConfig.EnableRbac = helpers.PointerToBool(api.DefaultRBACEnabled)
+			}
 		}
 
 		if a.OrchestratorProfile.KubernetesConfig.EnableSecureKubelet == nil {
@@ -415,11 +421,6 @@ func setOrchestratorDefaults(cs *api.ContainerService, isUpdate bool) {
 
 		if common.IsKubernetesVersionGe(a.OrchestratorProfile.OrchestratorVersion, "1.11.0") && a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku == "Standard" {
 			a.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB = helpers.PointerToBool(api.DefaultExcludeMasterFromStandardLB)
-		}
-
-		if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.9.0") {
-			// TODO make EnableAggregatedAPIs a pointer to bool so that a user can opt out of it
-			a.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs = true
 		}
 
 		if a.OrchestratorProfile.IsAzureCNI() {

--- a/pkg/acsengine/defaults_test.go
+++ b/pkg/acsengine/defaults_test.go
@@ -666,6 +666,19 @@ func TestAzureCNIVersionString(t *testing.T) {
 	}
 }
 
+func TestDefaultDisableRbac(t *testing.T) {
+	mockCS := getMockBaseContainerService("1.10.3")
+	properties := mockCS.Properties
+	properties.OrchestratorProfile.OrchestratorType = "Kubernetes"
+	properties.OrchestratorProfile.KubernetesConfig.EnableRbac = helpers.PointerToBool(false)
+	setOrchestratorDefaults(&mockCS, true)
+
+	if properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs {
+		t.Fatalf("got unexpected EnableAggregatedAPIs config value for EnableRbac=false: %t",
+			properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs)
+	}
+}
+
 func getMockAddon(name string) api.KubernetesAddon {
 	return api.KubernetesAddon{
 		Name:    name,

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -59,6 +59,14 @@ func IsTrueBoolPointer(b *bool) bool {
 	return false
 }
 
+// IsFalseBoolPointer is a simple boolean helper function for boolean pointers
+func IsFalseBoolPointer(b *bool) bool {
+	if b != nil && !*b {
+		return true
+	}
+	return false
+}
+
 // PointerToBool returns a pointer to a bool
 func PointerToBool(b bool) *bool {
 	p := b

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -703,7 +703,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should be able to autoscale", func() {
-			if eng.HasLinuxAgents() {
+			if eng.HasLinuxAgents() && eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs {
 				By("Creating a test php-apache deployment with request limit thresholds")
 				// Inspired by http://blog.kubernetes.io/2016/07/autoscaling-in-kubernetes.html
 				r := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -137,15 +137,15 @@ func (cli *CLIProvisioner) provision() error {
 
 	c, err := config.ParseConfig()
 	if err != nil {
-		return errors.New("unable to parse base config")
+		return errors.Wrap(err, "unable to parse base config")
 	}
 	engCfg, err := engine.ParseConfig(cli.Config.CurrentWorkingDir, c.ClusterDefinition, c.Name)
 	if err != nil {
-		return errors.New("unable to parse config")
+		return errors.Wrap(err, "unable to parse config")
 	}
 	csGenerated, err := engine.ParseOutput(engCfg.GeneratedDefinitionPath + "/apimodel.json")
 	if err != nil {
-		return errors.New("unable to parse output")
+		return errors.Wrap(err, "unable to parse output")
 	}
 	cli.Engine.ExpandedDefinition = csGenerated
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Prior to this change, default configuration for RBAC and enable aggregated APIs was distinct. These default enforcements need to happen in tandem, as aggregated API functionality depends upon RBAC. So, if RBAC is disabled, we need to ensure that aggregated API functionality is not by-default enabled.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
only enable aggregated api if rbac != disabled
```