### PR TITLE
Sync up health monitoring

### DIFF
--- a/parts/k8s/health-monitor.sh
+++ b/parts/k8s/health-monitor.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# Original source: https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/gci/health-monitor.sh
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +19,9 @@
 # in cluster/gce/gci/<master/node>.yaml. The env variables come from an env
 # file provided by the systemd service.
 
+# This script originated at https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/gci/health-monitor.sh
+# and has been modified for acs-engine.
+
 set -o nounset
 set -o pipefail
 
@@ -29,7 +30,7 @@ set -o pipefail
 function container_runtime_monitoring {
   local -r max_attempts=5
   local attempt=1
-  local -r circtl="/usr/local/bin/crictl"  #="${KUBE_HOME}/bin/crictl"
+  local -r crictl="${KUBE_HOME}/bin/crictl"
   local -r container_runtime_name="${CONTAINER_RUNTIME_NAME:-docker}"
   # We still need to use `docker ps` when container runtime is "docker". This is because
   # dockershim is still part of kubelet today. When kubelet is down, crictl pods
@@ -94,17 +95,16 @@ if [[ "$#" -ne 1 ]]; then
   exit 1
 fi
 
-# KUBE_HOME="/home/kubernetes"
-# KUBE_ENV="${KUBE_HOME}/kube-env"
-# if [[ ! -e "${KUBE_ENV}" ]]; then
-#   echo "The ${KUBE_ENV} file does not exist!! Terminate health monitoring"
-#   exit 1
-# fi
+KUBE_HOME="/usr/local/bin"
+KUBE_ENV="/etc/default/kube-env"
+if [[  -e "${KUBE_ENV}" ]]; then
+  source "${KUBE_ENV}"
+fi
 
 SLEEP_SECONDS=10
 component=$1
 echo "Start kubernetes health monitoring for ${component}"
-# source "${KUBE_ENV}"
+
 if [[ "${component}" == "container-runtime" ]]; then
   container_runtime_monitoring
 elif [[ "${component}" == "kubelet" ]]; then

--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -66,14 +66,14 @@ write_files:
       }{{end}}{{end}}
     }
 
-- path: "/opt/azure/containers/health-monitor.sh"
-  permissions: "0744"
+- path: "/usr/local/bin/health-monitor.sh"
+  permissions: "0544"
   encoding: gzip
   owner: "root"
   content: !!binary |
     {{WrapAsVariable "healthMonitorScript"}}
 
-- path: "/etc/systemd/system/docker-health-monitor.service"
+- path: "/etc/systemd/system/docker-monitor.service"
   permissions: "0644"
   owner: "root"
   content: |
@@ -81,12 +81,14 @@ write_files:
     Description=a script that checks docker health and restarts if needed
     After=docker.service
     [Service]
-    ExecStart=/bin/bash -c "/opt/azure/containers/health-monitor.sh container-runtime"
     Restart=always
+    RestartSec=10
+    RemainAfterExit=yes
+    ExecStart=/usr/local/bin/health-monitor.sh container-runtime
     [Install]
     WantedBy=multi-user.target
 
-- path: "/etc/systemd/system/kubelet-health-monitor.service"
+- path: "/etc/systemd/system/kubelet-monitor.service"
   permissions: "0644"
   owner: "root"
   content: |
@@ -94,8 +96,10 @@ write_files:
     Description=a script that checks kubelet health and restarts if needed
     After=kubelet.service
     [Service]
-    ExecStart=/bin/bash -c "/opt/azure/containers/health-monitor.sh kubelet"
     Restart=always
+    RestartSec=10
+    RemainAfterExit=yes
+    ExecStart=/usr/local/bin/health-monitor.sh kubelet
     [Install]
     WantedBy=multi-user.target
 {{end}}

--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -242,9 +242,9 @@ function ensureDocker() {
     DOCKER_JSON_FILE=/etc/docker/daemon.json
     wait_for_file 1200 1 $DOCKER_JSON_FILE || exit $ERR_FILE_WATCH_TIMEOUT
     systemctlEnableAndStart docker
-    DOCKER_HEALTH_MONITOR_SYSTEMD_FILE=/etc/systemd/system/docker-health-monitor.service
+    DOCKER_HEALTH_MONITOR_SYSTEMD_FILE=/etc/systemd/system/docker-monitor.service
     wait_for_file 1200 1 $DOCKER_HEALTH_MONITOR_SYSTEMD_FILE || exit $ERR_FILE_WATCH_TIMEOUT
-    systemctlEnableAndStart docker-health-monitor
+    systemctlEnableAndStart docker-monitor
 }
 function ensureKMS() {
     systemctlEnableAndStart kms
@@ -258,9 +258,9 @@ function ensureKubelet() {
     KUBELET_RUNTIME_CONFIG_SCRIPT_FILE=/opt/azure/containers/kubelet.sh
     wait_for_file 1200 1 $KUBELET_RUNTIME_CONFIG_SCRIPT_FILE || exit $ERR_FILE_WATCH_TIMEOUT
     systemctlEnableAndStart kubelet
-    KUBELET_HEALTH_MONITOR_SYSTEMD_FILE=/etc/systemd/system/kubelet-health-monitor.service
+    KUBELET_HEALTH_MONITOR_SYSTEMD_FILE=/etc/systemd/system/kubelet-monitor.service
     wait_for_file 1200 1 $KUBELET_HEALTH_MONITOR_SYSTEMD_FILE || exit $ERR_FILE_WATCH_TIMEOUT
-    systemctlEnableAndStart kubelet-health-monitor
+    systemctlEnableAndStart kubelet-monitor
 }
 
 function ensureJournal(){

--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -258,10 +258,9 @@ function ensureKubelet() {
     KUBELET_RUNTIME_CONFIG_SCRIPT_FILE=/opt/azure/containers/kubelet.sh
     wait_for_file 1200 1 $KUBELET_RUNTIME_CONFIG_SCRIPT_FILE || exit $ERR_FILE_WATCH_TIMEOUT
     systemctlEnableAndStart kubelet
-    # Don't start the kubelet-health-monitor systemd unit (yet).
-    # KUBELET_HEALTH_MONITOR_SYSTEMD_FILE=/etc/systemd/system/kubelet-health-monitor.service
-    # wait_for_file 1200 1 $KUBELET_HEALTH_MONITOR_SYSTEMD_FILE || exit $ERR_FILE_WATCH_TIMEOUT
-    # systemctlEnableAndStart kubelet-health-monitor
+    KUBELET_HEALTH_MONITOR_SYSTEMD_FILE=/etc/systemd/system/kubelet-health-monitor.service
+    wait_for_file 1200 1 $KUBELET_HEALTH_MONITOR_SYSTEMD_FILE || exit $ERR_FILE_WATCH_TIMEOUT
+    systemctlEnableAndStart kubelet-health-monitor
 }
 
 function ensureJournal(){

--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -242,8 +242,8 @@ function ensureDocker() {
     DOCKER_JSON_FILE=/etc/docker/daemon.json
     wait_for_file 1200 1 $DOCKER_JSON_FILE || exit $ERR_FILE_WATCH_TIMEOUT
     systemctlEnableAndStart docker
-    DOCKER_HEALTH_MONITOR_SYSTEMD_FILE=/etc/systemd/system/docker-monitor.service
-    wait_for_file 1200 1 $DOCKER_HEALTH_MONITOR_SYSTEMD_FILE || exit $ERR_FILE_WATCH_TIMEOUT
+    DOCKER_MONITOR_SYSTEMD_FILE=/etc/systemd/system/docker-monitor.service
+    wait_for_file 1200 1 $DOCKER_MONITOR_SYSTEMD_FILE || exit $ERR_FILE_WATCH_TIMEOUT
     systemctlEnableAndStart docker-monitor
 }
 function ensureKMS() {
@@ -258,9 +258,9 @@ function ensureKubelet() {
     KUBELET_RUNTIME_CONFIG_SCRIPT_FILE=/opt/azure/containers/kubelet.sh
     wait_for_file 1200 1 $KUBELET_RUNTIME_CONFIG_SCRIPT_FILE || exit $ERR_FILE_WATCH_TIMEOUT
     systemctlEnableAndStart kubelet
-    KUBELET_HEALTH_MONITOR_SYSTEMD_FILE=/etc/systemd/system/kubelet-monitor.service
-    wait_for_file 1200 1 $KUBELET_HEALTH_MONITOR_SYSTEMD_FILE || exit $ERR_FILE_WATCH_TIMEOUT
-    systemctlEnableAndStart kubelet-monitor
+    # KUBELET_MONITOR_SYSTEMD_FILE=/etc/systemd/system/kubelet-monitor.service
+    # wait_for_file 1200 1 $KUBELET_MONITOR_SYSTEMD_FILE || exit $ERR_FILE_WATCH_TIMEOUT
+    # systemctlEnableAndStart kubelet-monitor
 }
 
 function ensureJournal(){

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -69,14 +69,14 @@ write_files:
       }
     }
 
-- path: "/opt/azure/containers/health-monitor.sh"
-  permissions: "0744"
+- path: "/usr/local/bin/health-monitor.sh"
+  permissions: "0544"
   encoding: gzip
   owner: "root"
   content: !!binary |
     {{WrapAsVariable "healthMonitorScript"}}
 
-- path: "/etc/systemd/system/docker-health-monitor.service"
+- path: "/etc/systemd/system/docker-monitor.service"
   permissions: "0644"
   owner: "root"
   content: |
@@ -84,12 +84,14 @@ write_files:
     Description=a script that checks docker health and restarts if needed
     After=docker.service
     [Service]
-    ExecStart=/bin/bash -c "/opt/azure/containers/health-monitor.sh container-runtime"
     Restart=always
+    RestartSec=10
+    RemainAfterExit=yes
+    ExecStart=/usr/local/bin/health-monitor.sh container-runtime
     [Install]
     WantedBy=multi-user.target
 
-- path: "/etc/systemd/system/kubelet-health-monitor.service"
+- path: "/etc/systemd/system/kubelet-monitor.service"
   permissions: "0644"
   owner: "root"
   content: |
@@ -97,8 +99,10 @@ write_files:
     Description=a script that checks kubelet health and restarts if needed
     After=kubelet.service
     [Service]
-    ExecStart=/bin/bash -c "/opt/azure/containers/health-monitor.sh kubelet"
     Restart=always
+    RestartSec=10
+    RemainAfterExit=yes
+    ExecStart=/usr/local/bin/health-monitor.sh kubelet
     [Install]
     WantedBy=multi-user.target
 {{end}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

~Enables kubelet monitoring and restarting with Kubernetes' `health-monitor.sh` script.~ Syncs up the acs-engine implementation with that being used on AKS infrastructure.

We saw some CSE 30 (Kubernetes can't start) errors in CI for this PR, so let's disable the kubelet-monitor again and leave the other changes intact while we do more testing.

cc: @juan-lee @jwilder

**Special notes for your reviewer**:

I tested this with a new acs-engine cluster to make sure units landed in the right places and everything starts up correctly.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Kubernetes: add kubelet health monitoring
```
