### PR TITLE
AKS uses VHD + outbound inet test

### DIFF
--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -41,12 +41,13 @@ function holdWALinuxAgent() {
     fi
 }
 
+testOutboundConnection
+
 if [[ ! -z "${MASTER_NODE}" ]]; then
     installEtcd
 fi
 
 if $FULL_INSTALL_REQUIRED; then
-    testOutboundConnection
     holdWALinuxAgent
     installDeps
 else 

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -618,7 +618,11 @@ func setAgentProfileDefaults(a *api.Properties, isUpgrade, isScale bool) {
 		// don't default Distro for OpenShift
 		if !a.OrchestratorProfile.IsOpenShift() {
 			if profile.Distro == "" {
-				profile.Distro = api.AKS
+				if profile.OSDiskSizeGB < api.VHDDiskSizeAKS {
+					profile.Distro = api.Ubuntu
+				} else {
+					profile.Distro = api.AKS
+				}
 			}
 		}
 

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -618,7 +618,7 @@ func setAgentProfileDefaults(a *api.Properties, isUpgrade, isScale bool) {
 		// don't default Distro for OpenShift
 		if !a.OrchestratorProfile.IsOpenShift() {
 			if profile.Distro == "" {
-				if profile.OSDiskSizeGB < api.VHDDiskSizeAKS {
+				if profile.OSDiskSizeGB != 0 && profile.OSDiskSizeGB < api.VHDDiskSizeAKS {
 					profile.Distro = api.Ubuntu
 				} else {
 					profile.Distro = api.AKS

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -618,11 +618,7 @@ func setAgentProfileDefaults(a *api.Properties, isUpgrade, isScale bool) {
 		// don't default Distro for OpenShift
 		if !a.OrchestratorProfile.IsOpenShift() {
 			if profile.Distro == "" {
-				if a.HostedMasterProfile != nil {
-					profile.Distro = api.Ubuntu
-				} else {
-					profile.Distro = api.AKS
-				}
+				profile.Distro = api.AKS
 			}
 		}
 

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -172,3 +172,8 @@ const (
 	// AgentPoolProfileRoleMaster is the master role
 	AgentPoolProfileRoleMaster AgentPoolProfileRole = "master"
 )
+
+const (
+	// VHDDiskSizeAKS maps to the OSDiskSizeGB for AKS VHD image
+	VHDDiskSizeAKS = 100
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Enable VHD image for AKS node provisioning. Restores CSE 50 exit code for VHDs to accommodate AKS req's until all external i/o dependencies are implemented as local to VHD image.

Also ensures that OS disk size configurations < 30 GB will not attempt to use AKD VHD image, which requires 100 GB.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
AKS uses VHD + outbound inet test
```
