### PR TITLE
user docker to pre-pull images during VHD CI

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -37,85 +37,85 @@ installImg
 
 DASHBOARD_VERSIONS="1.8.3 1.6.3"
 for DASHBOARD_VERSION in ${DASHBOARD_VERSIONS}; do
-    pullImg "k8s.gcr.io/kubernetes-dashboard-amd64:v${DASHBOARD_VERSION}"
+    pullContainerImage "docker" "k8s.gcr.io/kubernetes-dashboard-amd64:v${DASHBOARD_VERSION}"
 done
 
 EXECHEALTHZ_VERSIONS="1.2"
 for EXECHEALTHZ_VERSION in ${EXECHEALTHZ_VERSIONS}; do
-    pullImg "k8s.gcr.io/exechealthz-amd64:${EXECHEALTHZ_VERSION}"
+    pullContainerImage "docker" "k8s.gcr.io/exechealthz-amd64:${EXECHEALTHZ_VERSION}"
 done
 
 ADDON_RESIZER_VERSIONS="1.8.1 1.7"
 for ADDON_RESIZER_VERSION in ${ADDON_RESIZER_VERSIONS}; do
-    pullImg "k8s.gcr.io/addon-resizer:${ADDON_RESIZER_VERSION}"
+    pullContainerImage "docker" "k8s.gcr.io/addon-resizer:${ADDON_RESIZER_VERSION}"
 done
 
 HEAPSTER_VERSIONS="1.5.3 1.5.1"
 for HEAPSTER_VERSION in ${HEAPSTER_VERSIONS}; do
-    pullImg "k8s.gcr.io/heapster-amd64:v${HEAPSTER_VERSION}"
+    pullContainerImage "docker" "k8s.gcr.io/heapster-amd64:v${HEAPSTER_VERSION}"
 done
 
 METRICS_SERVER_VERSIONS="0.2.1"
 for METRICS_SERVER_VERSION in ${METRICS_SERVER_VERSIONS}; do
-    pullImg "k8s.gcr.io/metrics-server-amd64:v${METRICS_SERVER_VERSION}"
+    pullContainerImage "docker" "k8s.gcr.io/metrics-server-amd64:v${METRICS_SERVER_VERSION}"
 done
 
 KUBE_DNS_VERSIONS="1.14.10 1.14.8 1.14.5"
 for KUBE_DNS_VERSION in ${KUBE_DNS_VERSIONS}; do
-    pullImg "k8s.gcr.io/k8s-dns-kube-dns-amd64:${KUBE_DNS_VERSION}"
+    pullContainerImage "docker" "k8s.gcr.io/k8s-dns-kube-dns-amd64:${KUBE_DNS_VERSION}"
 done
 
 KUBE_ADDON_MANAGER_VERSIONS="8.6"
 for KUBE_ADDON_MANAGER_VERSION in ${KUBE_ADDON_MANAGER_VERSIONS}; do
-    pullImg "k8s.gcr.io/kube-addon-manager-amd64:v${KUBE_ADDON_MANAGER_VERSION}"
+    pullContainerImage "docker" "k8s.gcr.io/kube-addon-manager-amd64:v${KUBE_ADDON_MANAGER_VERSION}"
 done
 
 KUBE_DNS_MASQ_VERSIONS="1.14.10 1.14.8 1.14.5"
 for KUBE_DNS_MASQ_VERSION in ${KUBE_DNS_MASQ_VERSIONS}; do
-    pullImg "k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:${KUBE_DNS_MASQ_VERSION}"
+    pullContainerImage "docker" "k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:${KUBE_DNS_MASQ_VERSION}"
 done
 
 PAUSE_VERSIONS="3.1"
 for PAUSE_VERSION in ${PAUSE_VERSIONS}; do
-    pullImg "k8s.gcr.io/pause-amd64:${PAUSE_VERSION}"
+    pullContainerImage "docker" "k8s.gcr.io/pause-amd64:${PAUSE_VERSION}"
 done
 
 TILLER_VERSIONS="2.8.1"
 for TILLER_VERSION in ${TILLER_VERSIONS}; do
-    pullImg "gcr.io/kubernetes-helm/tiller:v${TILLER_VERSION}"
+    pullContainerImage "docker" "gcr.io/kubernetes-helm/tiller:v${TILLER_VERSION}"
 done
 
 RESCHEDULER_VERSIONS="0.4.0 0.3.1"
 for RESCHEDULER_VERSION in ${RESCHEDULER_VERSIONS}; do
-    pullImg "k8s.gcr.io/rescheduler:v${RESCHEDULER_VERSION}"
+    pullContainerImage "docker" "k8s.gcr.io/rescheduler:v${RESCHEDULER_VERSION}"
 done
 
 VIRTUAL_KUBELET_VERSIONS="latest"
 for VIRTUAL_KUBELET_VERSION in ${VIRTUAL_KUBELET_VERSIONS}; do
-    pullImg "microsoft/virtual-kubelet:${VIRTUAL_KUBELET_VERSION}"
+    pullContainerImage "docker" "microsoft/virtual-kubelet:${VIRTUAL_KUBELET_VERSION}"
 done
 
 AZURE_CNI_NETWORKMONITOR_VERSIONS="0.0.4"
 for AZURE_CNI_NETWORKMONITOR_VERSION in ${AZURE_CNI_NETWORKMONITOR_VERSIONS}; do
-    pullImg "containernetworking/networkmonitor:v${AZURE_CNI_NETWORKMONITOR_VERSION}"
+    pullContainerImage "docker" "containernetworking/networkmonitor:v${AZURE_CNI_NETWORKMONITOR_VERSION}"
 done
 
 CLUSTER_AUTOSCALER_VERSIONS="1.3.1 1.3.0 1.2.2 1.1.2"
 for CLUSTER_AUTOSCALER_VERSION in ${CLUSTER_AUTOSCALER_VERSIONS}; do
-    pullImg "k8s.gcr.io/cluster-autoscaler:v${CLUSTER_AUTOSCALER_VERSION}"
+    pullContainerImage "docker" "k8s.gcr.io/cluster-autoscaler:v${CLUSTER_AUTOSCALER_VERSION}"
 done
 
 K8S_DNS_SIDECAR_VERSIONS="1.14.10 1.14.8 1.14.7"
 for K8S_DNS_SIDECAR_VERSION in ${K8S_DNS_SIDECAR_VERSIONS}; do
-    pullImg "k8s.gcr.io/k8s-dns-sidecar-amd64:${K8S_DNS_SIDECAR_VERSION}"
+    pullContainerImage "docker" "k8s.gcr.io/k8s-dns-sidecar-amd64:${K8S_DNS_SIDECAR_VERSION}"
 done
 
 NVIDIA_DEVICE_PLUGIN_VERSIONS="1.11 1.10"
 for NVIDIA_DEVICE_PLUGIN_VERSION in ${NVIDIA_DEVICE_PLUGIN_VERSIONS}; do
-    pullImg "nvidia/k8s-device-plugin:${NVIDIA_DEVICE_PLUGIN_VERSION}"
+    pullContainerImage "docker" "nvidia/k8s-device-plugin:${NVIDIA_DEVICE_PLUGIN_VERSION}"
 done
 
-pullImg "busybox"
+pullContainerImage "docker" "busybox"
 
 # TODO: fetch supported k8s versions from an acs-engine command instead of hardcoding them here
 K8S_VERSIONS="1.7.7 1.7.9 1.7.12 1.7.15 1.7.16 1.8.0 1.8.1 1.8.2 1.8.4 1.8.5 1.8.6 1.8.7 1.8.8 1.8.9 1.8.10 1.8.11 1.8.12 1.8.13 1.8.14 1.8.15 1.9.0 1.9.1 1.9.2 1.9.3 1.9.4 1.9.5 1.9.6 1.9.7 1.9.8 1.9.9 1.9.10 1.10.0 1.10.1 1.10.2 1.10.3 1.10.4 1.10.5 1.10.6 1.10.7 1.11.0 1.11.1 1.11.2 1.11.3"

--- a/parts/k8s/kubernetesinstalls.sh
+++ b/parts/k8s/kubernetesinstalls.sh
@@ -215,7 +215,8 @@ function extractHyperkube() {
     rm -rf /usr/local/bin/kubelet-* /usr/local/bin/kubectl-*
 }
 
-function pullImg() {
-    DOCKER_IMAGE_URL=$1
-    retrycmd_if_failure 75 1 60 img pull $DOCKER_IMAGE_URL || exit $ERR_IMG_DOWNLOAD_TIMEOUT
+function pullContainerImage() {
+    CLI_TOOL=$1
+    DOCKER_IMAGE_URL=$2
+    retrycmd_if_failure 75 1 60 $CLI_TOOL pull $DOCKER_IMAGE_URL || exit $ERR_IMG_DOWNLOAD_TIMEOUT
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Use `docker` instead of `img` to pre-pull images because observation suggests kubernetes does not share a local image cache w/ our currently configured `img` installation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
user docker to pre-pull images during VHD CI
```
