### PR TITLE
Add support to add a list of auxiliary tokens in request header

### DIFF
--- a/pkg/armhelpers/azureclient.go
+++ b/pkg/armhelpers/azureclient.go
@@ -46,6 +46,7 @@ var (
 // This client is backed by real Azure clients talking to an ARM endpoint.
 type AzureClient struct {
 	acceptLanguages []string
+	auxiliaryTokens []string
 	environment     azure.Environment
 	subscriptionID  string
 
@@ -461,4 +462,46 @@ func (az *AzureClient) addAcceptLanguages() autorest.PrepareDecorator {
 			return r, nil
 		})
 	}
+}
+
+func (az *AzureClient) addAuxiliaryTokens() autorest.PrepareDecorator {
+	return func(p autorest.Preparer) autorest.Preparer {
+		return autorest.PreparerFunc(func(r *http.Request) (*http.Request, error) {
+			r, err := p.Prepare(r)
+			if err != nil {
+				return r, err
+			}
+			if az.auxiliaryTokens != nil {
+				for _, token := range az.auxiliaryTokens {
+					if token == "" {
+						continue
+					}
+
+					r.Header.Set("x-ms-authorization-auxiliary", fmt.Sprintf("Bearer %s", token))
+				}
+			}
+			return r, nil
+		})
+	}
+}
+
+// AddAuxillaryTokens sets the list of aux tokens to accept on this request
+func (az *AzureClient) AddAuxillaryTokens(tokens []string) {
+	az.auxiliaryTokens = tokens
+	az.authorizationClient.Client.RequestInspector = az.addAuxiliaryTokens()
+	az.deploymentOperationsClient.Client.RequestInspector = az.addAuxiliaryTokens()
+	az.deploymentsClient.Client.RequestInspector = az.addAuxiliaryTokens()
+	az.deploymentsClient.Client.RequestInspector = az.addAuxiliaryTokens()
+	az.deploymentOperationsClient.Client.RequestInspector = az.addAuxiliaryTokens()
+	az.resourcesClient.Client.RequestInspector = az.addAuxiliaryTokens()
+	az.storageAccountsClient.Client.RequestInspector = az.addAuxiliaryTokens()
+	az.interfacesClient.Client.RequestInspector = az.addAuxiliaryTokens()
+	az.groupsClient.Client.RequestInspector = az.addAuxiliaryTokens()
+	az.providersClient.Client.RequestInspector = az.addAuxiliaryTokens()
+	az.virtualMachinesClient.Client.RequestInspector = az.addAuxiliaryTokens()
+	az.virtualMachineScaleSetsClient.Client.RequestInspector = az.addAuxiliaryTokens()
+	az.disksClient.Client.RequestInspector = az.addAuxiliaryTokens()
+
+	az.applicationsClient.Client.RequestInspector = az.addAuxiliaryTokens()
+	az.servicePrincipalsClient.Client.RequestInspector = az.addAuxiliaryTokens()
 }

--- a/pkg/armhelpers/interfaces.go
+++ b/pkg/armhelpers/interfaces.go
@@ -44,7 +44,10 @@ type ACSEngineClient interface {
 
 	//AddAcceptLanguages sets the list of languages to accept on this request
 	AddAcceptLanguages(languages []string)
-	//
+
+	// AddAuxillaryTokens sets the list of aux tokens to accept on this request
+	AddAuxillaryTokens(tokens []string)
+
 	// RESOURCES
 
 	// DeployTemplate can deploy a template into Azure ARM

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -248,6 +248,9 @@ func (msc *MockStorageClient) DeleteBlob(container, blob string) error {
 //AddAcceptLanguages mock
 func (mc *MockACSEngineClient) AddAcceptLanguages(languages []string) {}
 
+// AddAuxillaryTokens mock
+func (mc *MockACSEngineClient) AddAuxillaryTokens(tokens []string) {}
+
 //DeployTemplate mock
 func (mc *MockACSEngineClient) DeployTemplate(ctx context.Context, resourceGroup, name string, template, parameters map[string]interface{}) (de resources.DeploymentExtended, err error) {
 	switch {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support to add a list of auxiliary tokens in request header. Aux tokens enables ARM to support requests which may require authentication across multiple tenants.

Primary token will always be extracted from the “Authorization” header. Auxiliary tokens will be extracted from the header “Authorization-Auxiliary”

**Special notes for your reviewer**:
Example in Azure Python CLI: https://github.com/Azure/azure-cli/pull/6423/commits/0217c4b8c8737940c0c92226347c423f0f8ec413