### PR TITLE
Update go prerequisite to 1.11 and add links

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -5,9 +5,9 @@ acs-engine.
 
 ## Prerequisites
 
-- Go 1.7.0 or later
-- Golang dep 0.5.0 or later
-- kubectl 1.7 or later
+- [Go](https://golang.org/dl) 1.11 or later
+- Golang [dep](https://github.com/golang/dep) 0.5.0 or later
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 1.7 or later
 - An Azure account (needed for deploying VMs and Azure infrastructure)
 - Git
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

#3763 made go 1.11 an effective requirement for running `make test-style` and likely for vendoring as well. `make build` will probably continue to work with earlier versions of go, but developers should really be synced up with these prereqs to avoid problems.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Docs: developers and contributors should use go 1.11 and dep 0.5.0, or later.
```
