### PR TITLE
Aesthetics: remove extra \n's in vhd metadata

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -128,6 +128,6 @@ done
 df -h
 
 echo "Install completed successfully on " `date` > /var/log/azure/golden-image-install.complete
-echo "\nVSTS Build NUMBER: ${BUILD_NUMBER}" >> /var/log/azure/golden-image-install.complete
-echo "\nVSTS Build ID: ${BUILD_ID}" >> /var/log/azure/golden-image-install.complete
-echo "\nCommit: ${COMMIT}" >> /var/log/azure/golden-image-install.complete
+echo "VSTS Build NUMBER: ${BUILD_NUMBER}" >> /var/log/azure/golden-image-install.complete
+echo "VSTS Build ID: ${BUILD_ID}" >> /var/log/azure/golden-image-install.complete
+echo "Commit: ${COMMIT}" >> /var/log/azure/golden-image-install.complete


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: remove extra \n's in vhd metadata

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
