### PR TITLE
Enforce windows password complexity requirements in acs-engine client…

### DIFF
--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -895,7 +895,7 @@ func (w *WindowsProfile) Validate(orchestratorType string) error {
 		return errors.New("WindowsProfile.AdminPassword is required, when agent pool specifies windows")
 	}
 	if validatePasswordComplexity(w.AdminUsername, w.AdminPassword) == false {
-		return errors.New("WindowsProfile.AdminPassword complexity not met. Check https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements for requirements")
+		return errors.New("WindowsProfile.AdminPassword complexity not met. Windows password should contain 3 of the following categories - uppercase letters(A-Z), lowercase(a-z) letters, digits(0-9), special characters (~!@#$%^&*_-+=`|\\(){}[]:;<>,.?/')")
 	}
 	return validateKeyVaultSecrets(w.Secrets, true)
 }

--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -894,7 +894,36 @@ func (w *WindowsProfile) Validate(orchestratorType string) error {
 	if e := validate.Var(w.AdminPassword, "required"); e != nil {
 		return errors.New("WindowsProfile.AdminPassword is required, when agent pool specifies windows")
 	}
+	if validatePasswordComplexity(w.AdminUsername, w.AdminPassword) == false {
+		return errors.New("WindowsProfile.AdminPassword complexity not met. Check https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements for requirements")
+	}
 	return validateKeyVaultSecrets(w.Secrets, true)
+}
+
+func validatePasswordComplexity(name string, password string) (out bool) {
+
+	if strings.EqualFold(name, password) {
+		return false
+	}
+
+	if len(password) == 0 {
+		return false
+	}
+
+	hits := 0
+	if regexp.MustCompile(`[0-9]+`).MatchString(password) {
+		hits++
+	}
+	if regexp.MustCompile(`[A-Z]+`).MatchString(password) {
+		hits++
+	}
+	if regexp.MustCompile(`[a-z]`).MatchString(password) {
+		hits++
+	}
+	if regexp.MustCompile(`[~!@#\$%\^&\*_\-\+=\x60\|\(\){}\[\]:;"'<>,\.\?/]+`).MatchString(password) {
+		hits++
+	}
+	return hits > 2
 }
 
 // Validate validates the KubernetesConfig

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -1279,6 +1279,21 @@ func TestWindowsVersions(t *testing.T) {
 				"should error on windows password complexity not match because uppercase and lowercase letters found in the password",
 			)
 		}
+		p = getK8sDefaultProperties(true)
+		p.WindowsProfile.AdminPassword = ""
+		if err := p.Validate(false); err == nil {
+			t.Errorf(
+				"should error on windows password length is zero",
+			)
+		}
+		p = getK8sDefaultProperties(true)
+		p.WindowsProfile.AdminUsername = "User@123"
+		p.WindowsProfile.AdminPassword = "User@123"
+		if err := p.Validate(false); err == nil {
+			t.Errorf(
+				"should error on windows password complexity not match because username and password are  same",
+			)
+		}
 		sv, _ := semver.Make(version)
 		p = getK8sDefaultProperties(true)
 		p.OrchestratorProfile.OrchestratorRelease = fmt.Sprintf("%d.%d", sv.Major, sv.Minor)

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -1265,6 +1265,20 @@ func TestWindowsVersions(t *testing.T) {
 				"should not error on valid Windows version: %v", err,
 			)
 		}
+		p = getK8sDefaultProperties(true)
+		p.WindowsProfile.AdminPassword = "Password"
+		if err := p.Validate(false); err == nil {
+			t.Errorf(
+				"should error on windows password complexity not match because no digits and special characters found in the password ",
+			)
+		}
+		p = getK8sDefaultProperties(true)
+		p.WindowsProfile.AdminPassword = "123!@#"
+		if err := p.Validate(false); err == nil {
+			t.Errorf(
+				"should error on windows password complexity not match because uppercase and lowercase letters found in the password",
+			)
+		}
 		sv, _ := semver.Make(version)
 		p = getK8sDefaultProperties(true)
 		p.OrchestratorProfile.OrchestratorRelease = fmt.Sprintf("%d.%d", sv.Major, sv.Minor)

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -1077,7 +1077,7 @@ func getK8sDefaultProperties(hasWindows bool) *Properties {
 		}
 		p.WindowsProfile = &WindowsProfile{
 			AdminUsername: "azureuser",
-			AdminPassword: "password",
+			AdminPassword: "replacepassword1234$",
 		}
 	}
 


### PR DESCRIPTION
…. #2407

Added Windows Agent password complexity check as per guidelines in  https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements.

This will prevent generation of arm templates if password complexity for windows vm does not meet the complexity requirements.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
