### PR TITLE
[WIP] netfilter AAAA race condition workaround

### DIFF
--- a/parts/k8s/addons/azure-cni-networkmonitor.yaml
+++ b/parts/k8s/addons/azure-cni-networkmonitor.yaml
@@ -43,6 +43,15 @@ spec:
             mountPath: /var/run
           - name: log
             mountPath: /var/log
+        - name: cni-tc
+          image: 'qmachu/weave-tc:0.0.1'
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
+            - name: lib-tc
+              mountPath: /lib/tc
       hostNetwork: true
       volumes:
       - name: log

--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -49,6 +49,7 @@ fi
 
 if $FULL_INSTALL_REQUIRED; then
     holdWALinuxAgent
+    netfilterFix
     installDeps
 else 
     echo "Golden image; skipping dependencies installation"

--- a/parts/k8s/kubernetesinstalls.sh
+++ b/parts/k8s/kubernetesinstalls.sh
@@ -21,6 +21,47 @@ function installEtcd() {
     fi
 }
 
+function netfilterFix() {
+    # Force the kernel to re-create the dummy mq scheduler on the default interface,
+    # - as the child qdiscs may have been set to pfifo_fast at boot even if the default
+    # appear to be ‘fq_codel’ (we also set the default to fq_codel regardless, for older
+    # systems)
+    # - as the qdiscs are using a quantum based on the boot MTU, which may have changed
+    # after DHCP has gotten the proper MTU.
+    #
+    # Setting mq will only work if the NIC supports multiple TX/RX queues, therefore
+    # creating and grafting each class/qdiscs to specific CPU cores. In case the NIC
+    # does not support that, we simply ignore the error.
+    sysctl -w net.core.default_qdisc=fq_codel
+    tc qdisc del dev $(route | grep '^default' | grep -o '[^ ]*$') root 2>/dev/null || true
+    tc qdisc add dev $(route | grep '^default' | grep -o '[^ ]*$') root handle 0: mq || true
+
+    # Traffic leaving the weave interface onto the default interface will be encapsulated
+    # and encrypted in IPSec (ESP), therefore, we may only do traffic shaping work on this
+    # interface.
+    #
+    # The weave interface is a virtual interface, which is set to noqueue by default and does
+    # not support mq nor multiq. Therefore, we go directly to the point and create a a 2-bands
+    # priomap, that sends all traffic (regardless of the TOS octet) to the 2nd band, a simple
+    # fq_codel. We then define the 1st band as a netem with the a small delay, that appears to
+    # be avoid the race in a statistically satisfying manner, and that is controlled by a pareto
+    # distribution (k=4ms, a=1ms) and route traffic marked by 0x100/0x100 to it.
+    #
+    # Using iptables, we mark 0x100/0x100 the UDP traffic destined to port 5353, that have the
+    # DNS query bits set (fast check) and then that contain at least one question with QTYPE=AAAA.
+    while ! ip link | grep "weave:" > /dev/null; do sleep 1; done
+    tc qdisc del dev weave root 2>/dev/null || true
+    tc qdisc add dev weave root handle 1: prio bands 2 priomap 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+
+    tc qdisc add dev weave parent 1:2 handle 12: fq_codel
+
+    tc qdisc add dev weave parent 1:1 handle 11: netem delay 4ms 1ms distribution pareto
+    tc filter add dev weave protocol all parent 1: prio 1 handle 0x100/0x100 fw flowid 1:1
+    iptables -A POSTROUTING -t mangle -p udp --dport 5353 -m string -m u32 --u32 "28 & 0xF8 = 0" --hex-string "|00001C0001|" --algo bm --from 40 -j MARK --set-mark 0x100/0x100
+
+    while sleep 3600; do :; done
+}
+
 function installDeps() {
     retrycmd_if_failure_no_stats 20 1 5 curl -fsSL https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb > /tmp/packages-microsoft-prod.deb || exit $ERR_MS_PROD_DEB_DOWNLOAD_TIMEOUT
     retrycmd_if_failure 60 5 10 dpkg -i /tmp/packages-microsoft-prod.deb || exit $ERR_MS_PROD_DEB_PKG_ADD_FAIL


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Implements https://blog.quentin-machu.fr/2018/06/24/5-15s-dns-lookups-on-kubernetes/ w/ Azure CNI networkmonitor daemonset

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
netfilter AAAA race condition workaround
```