### PR TITLE
Adding DeleteApp func to AzureClient and returning appObjectID in CreateApp

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -365,7 +365,7 @@ func autofillApimodel(dc *deployCmd) error {
 					},
 				}
 			}
-			applicationID, servicePrincipalObjectID, secret, err := dc.client.CreateApp(ctx, appName, appURL, replyURLs, requiredResourceAccess)
+			_, applicationID, servicePrincipalObjectID, secret, err := dc.client.CreateApp(ctx, appName, appURL, replyURLs, requiredResourceAccess)
 			if err != nil {
 				return errors.Wrap(err, "apimodel invalid: ServicePrincipalProfile was empty, and we failed to create valid credentials")
 			}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -365,10 +365,11 @@ func autofillApimodel(dc *deployCmd) error {
 					},
 				}
 			}
-			_, applicationID, servicePrincipalObjectID, secret, err := dc.client.CreateApp(ctx, appName, appURL, replyURLs, requiredResourceAccess)
+			applicationResp, servicePrincipalObjectID, secret, err := dc.client.CreateApp(ctx, appName, appURL, replyURLs, requiredResourceAccess)
 			if err != nil {
 				return errors.Wrap(err, "apimodel invalid: ServicePrincipalProfile was empty, and we failed to create valid credentials")
 			}
+			applicationID := to.String(applicationResp.AppID)
 			log.Warnf("created application with applicationID (%s) and servicePrincipalObjectID (%s).", applicationID, servicePrincipalObjectID)
 
 			log.Warnln("apimodel: ServicePrincipalProfile was empty, assigning role to application...")

--- a/pkg/armhelpers/graph.go
+++ b/pkg/armhelpers/graph.go
@@ -29,7 +29,7 @@ func (az *AzureClient) CreateGraphApplication(ctx context.Context, applicationCr
 	return az.applicationsClient.Create(ctx, applicationCreateParameters)
 }
 
-// DeleteGraphApplication creates an application via the graphrbac client
+// DeleteGraphApplication deletes an application via the graphrbac client
 func (az *AzureClient) DeleteGraphApplication(ctx context.Context, applicationObjectID string) (result autorest.Response, err error) {
 	return az.applicationsClient.Delete(ctx, applicationObjectID)
 }
@@ -106,8 +106,8 @@ func (az *AzureClient) CreateApp(ctx context.Context, appName, appURL string, re
 }
 
 // DeleteApp is a simpler method for deleting an application and the associated spn
-func (az *AzureClient) DeleteApp(ctx context.Context, appName, applicationObjectID string) (autorest.Response, error) {
-	log.Debugf("ad: deleting application with name=%q", appName)
+func (az *AzureClient) DeleteApp(ctx context.Context, applicationName, applicationObjectID string) (autorest.Response, error) {
+	log.Debugf("ad: deleting application with name=%q", applicationName)
 	applicationResp, err := az.DeleteGraphApplication(ctx, applicationObjectID)
 	if err != nil {
 		return applicationResp, err

--- a/pkg/armhelpers/graph.go
+++ b/pkg/armhelpers/graph.go
@@ -56,7 +56,7 @@ func (az *AzureClient) ListRoleAssignmentsForPrincipal(ctx context.Context, scop
 }
 
 // CreateApp is a simpler method for creating an application
-func (az *AzureClient) CreateApp(ctx context.Context, appName, appURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (applicationRes autorest.Response, servicePrincipalObjectID, servicePrincipalClientSecret string, err error) {
+func (az *AzureClient) CreateApp(ctx context.Context, appName, appURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (applicationRes graphrbac.Application, servicePrincipalObjectID, servicePrincipalClientSecret string, err error) {
 	notBefore := time.Now()
 	notAfter := time.Now().Add(10000 * 24 * time.Hour)
 
@@ -84,7 +84,7 @@ func (az *AzureClient) CreateApp(ctx context.Context, appName, appURL string, re
 	}
 	applicationResp, err := az.CreateGraphApplication(ctx, applicationReq)
 	if err != nil {
-		return applicationResp.Response, "", "", err
+		return applicationResp, "", "", err
 	}
 	applicationID := to.String(applicationResp.AppID)
 
@@ -96,12 +96,12 @@ func (az *AzureClient) CreateApp(ctx context.Context, appName, appURL string, re
 	}
 	servicePrincipalResp, err := az.servicePrincipalsClient.Create(ctx, servicePrincipalReq)
 	if err != nil {
-		return applicationResp.Response, "", "", err
+		return applicationResp, "", "", err
 	}
 
 	servicePrincipalObjectID = to.String(servicePrincipalResp.ObjectID)
 
-	return applicationResp.Response, servicePrincipalObjectID, servicePrincipalClientSecret, nil
+	return applicationResp, servicePrincipalObjectID, servicePrincipalClientSecret, nil
 }
 
 // DeleteApp is a simpler method for deleting an application and the associated spn

--- a/pkg/armhelpers/graph.go
+++ b/pkg/armhelpers/graph.go
@@ -56,7 +56,7 @@ func (az *AzureClient) ListRoleAssignmentsForPrincipal(ctx context.Context, scop
 }
 
 // CreateApp is a simpler method for creating an application
-func (az *AzureClient) CreateApp(ctx context.Context, appName, appURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (applicationRes graphrbac.Application, servicePrincipalObjectID, servicePrincipalClientSecret string, err error) {
+func (az *AzureClient) CreateApp(ctx context.Context, appName, appURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (applicationResp graphrbac.Application, servicePrincipalObjectID, servicePrincipalClientSecret string, err error) {
 	notBefore := time.Now()
 	notAfter := time.Now().Add(10000 * 24 * time.Hour)
 
@@ -82,7 +82,7 @@ func (az *AzureClient) CreateApp(ctx context.Context, appName, appURL string, re
 		},
 		RequiredResourceAccess: requiredResourceAccess,
 	}
-	applicationResp, err := az.CreateGraphApplication(ctx, applicationReq)
+	applicationResp, err = az.CreateGraphApplication(ctx, applicationReq)
 	if err != nil {
 		return applicationResp, "", "", err
 	}

--- a/pkg/armhelpers/interfaces.go
+++ b/pkg/armhelpers/interfaces.go
@@ -103,7 +103,7 @@ type ACSEngineClient interface {
 
 	// CreateGraphPrincipal creates a service principal via the graphrbac client
 	CreateGraphPrincipal(ctx context.Context, servicePrincipalCreateParameters graphrbac.ServicePrincipalCreateParameters) (graphrbac.ServicePrincipal, error)
-	CreateApp(ctx context.Context, applicationName, applicationURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (applicationObjectID, applicationID, servicePrincipalObjectID, secret string, err error)
+	CreateApp(ctx context.Context, applicationName, applicationURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (response autorest.Response, servicePrincipalObjectID, secret string, err error)
 	DeleteApp(ctx context.Context, applicationName, applicationObjectID string) (autorest.Response, error)
 
 	// User Assigned MSI

--- a/pkg/armhelpers/interfaces.go
+++ b/pkg/armhelpers/interfaces.go
@@ -103,7 +103,7 @@ type ACSEngineClient interface {
 
 	// CreateGraphPrincipal creates a service principal via the graphrbac client
 	CreateGraphPrincipal(ctx context.Context, servicePrincipalCreateParameters graphrbac.ServicePrincipalCreateParameters) (graphrbac.ServicePrincipal, error)
-	CreateApp(ctx context.Context, applicationName, applicationURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (response autorest.Response, servicePrincipalObjectID, secret string, err error)
+	CreateApp(ctx context.Context, applicationName, applicationURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (result graphrbac.Application, servicePrincipalObjectID, secret string, err error)
 	DeleteApp(ctx context.Context, applicationName, applicationObjectID string) (autorest.Response, error)
 
 	// User Assigned MSI

--- a/pkg/armhelpers/interfaces.go
+++ b/pkg/armhelpers/interfaces.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/msi/mgmt/2015-08-31-preview/msi"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	azStorage "github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/Azure/go-autorest/autorest"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 )
@@ -102,7 +103,8 @@ type ACSEngineClient interface {
 
 	// CreateGraphPrincipal creates a service principal via the graphrbac client
 	CreateGraphPrincipal(ctx context.Context, servicePrincipalCreateParameters graphrbac.ServicePrincipalCreateParameters) (graphrbac.ServicePrincipal, error)
-	CreateApp(ctx context.Context, applicationName, applicationURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (applicationID, servicePrincipalObjectID, secret string, err error)
+	CreateApp(ctx context.Context, applicationName, applicationURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (applicationObjectID, applicationID, servicePrincipalObjectID, secret string, err error)
+	DeleteApp(ctx context.Context, appName, applicationObjectID string) (autorest.Response, error)
 
 	// User Assigned MSI
 	//CreateUserAssignedID - Creates a user assigned msi.

--- a/pkg/armhelpers/interfaces.go
+++ b/pkg/armhelpers/interfaces.go
@@ -104,7 +104,7 @@ type ACSEngineClient interface {
 	// CreateGraphPrincipal creates a service principal via the graphrbac client
 	CreateGraphPrincipal(ctx context.Context, servicePrincipalCreateParameters graphrbac.ServicePrincipalCreateParameters) (graphrbac.ServicePrincipal, error)
 	CreateApp(ctx context.Context, applicationName, applicationURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (applicationObjectID, applicationID, servicePrincipalObjectID, secret string, err error)
-	DeleteApp(ctx context.Context, appName, applicationObjectID string) (autorest.Response, error)
+	DeleteApp(ctx context.Context, applicationName, applicationObjectID string) (autorest.Response, error)
 
 	// User Assigned MSI
 	//CreateUserAssignedID - Creates a user assigned msi.

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -550,8 +550,8 @@ func (mc *MockACSEngineClient) CreateGraphPrincipal(ctx context.Context, service
 }
 
 // CreateApp is a simpler method for creating an application
-func (mc *MockACSEngineClient) CreateApp(ctx context.Context, applicationName, applicationURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (response autorest.Response, servicePrincipalObjectID, secret string, err error) {
-	return response, "client-id", "client-secret", nil
+func (mc *MockACSEngineClient) CreateApp(ctx context.Context, applicationName, applicationURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (result graphrbac.Application, servicePrincipalObjectID, secret string, err error) {
+	return result, "client-id", "client-secret", nil
 }
 
 // DeleteApp is a simpler method for deleting an application

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Azure/acs-engine/pkg/helpers"
+
 	"github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
@@ -551,7 +553,9 @@ func (mc *MockACSEngineClient) CreateGraphPrincipal(ctx context.Context, service
 
 // CreateApp is a simpler method for creating an application
 func (mc *MockACSEngineClient) CreateApp(ctx context.Context, applicationName, applicationURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (result graphrbac.Application, servicePrincipalObjectID, secret string, err error) {
-	return result, "client-id", "client-secret", nil
+	return graphrbac.Application{
+		AppID: helpers.PointerToString("app-id"),
+	}, "client-id", "client-secret", nil
 }
 
 // DeleteApp is a simpler method for deleting an application

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -550,8 +550,13 @@ func (mc *MockACSEngineClient) CreateGraphPrincipal(ctx context.Context, service
 }
 
 // CreateApp is a simpler method for creating an application
-func (mc *MockACSEngineClient) CreateApp(ctx context.Context, applicationName, applicationURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (applicationID, servicePrincipalObjectID, secret string, err error) {
-	return "app-id", "client-id", "client-secret", nil
+func (mc *MockACSEngineClient) CreateApp(ctx context.Context, applicationName, applicationURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (applicationObjectID, applicationID, servicePrincipalObjectID, secret string, err error) {
+	return "app-object-id", "app-id", "client-id", "client-secret", nil
+}
+
+// DeleteApp is a simpler method for deleting an application
+func (mc *MockACSEngineClient) DeleteApp(ctx context.Context, appName, applicationObjectID string) (response autorest.Response, err error) {
+	return response, nil
 }
 
 // User Assigned MSI

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -550,8 +550,8 @@ func (mc *MockACSEngineClient) CreateGraphPrincipal(ctx context.Context, service
 }
 
 // CreateApp is a simpler method for creating an application
-func (mc *MockACSEngineClient) CreateApp(ctx context.Context, applicationName, applicationURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (applicationObjectID, applicationID, servicePrincipalObjectID, secret string, err error) {
-	return "app-object-id", "app-id", "client-id", "client-secret", nil
+func (mc *MockACSEngineClient) CreateApp(ctx context.Context, applicationName, applicationURL string, replyURLs *[]string, requiredResourceAccess *[]graphrbac.RequiredResourceAccess) (response autorest.Response, servicePrincipalObjectID, secret string, err error) {
+	return response, "client-id", "client-secret", nil
 }
 
 // DeleteApp is a simpler method for deleting an application

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -73,7 +73,7 @@ func PointerToBool(b bool) *bool {
 	return &p
 }
 
-// PointerToString returns a pointer to a bool
+// PointerToString returns a pointer to a string
 func PointerToString(s string) *string {
 	p := s
 	return &p

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -73,6 +73,12 @@ func PointerToBool(b bool) *bool {
 	return &p
 }
 
+// PointerToString returns a pointer to a bool
+func PointerToString(s string) *string {
+	p := s
+	return &p
+}
+
 // PointerToInt returns a pointer to a int
 func PointerToInt(i int) *int {
 	p := i


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR adds functionality to delete an AAD App. An AAD App can be deleted by providing in the application Object ID. Currently, the `CreateApp` function does not retrieve or return this parameter. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [x] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
