### PR TITLE
Replace deprecated Azure SDK method calls

### DIFF
--- a/pkg/armhelpers/compute.go
+++ b/pkg/armhelpers/compute.go
@@ -24,7 +24,7 @@ func (az *AzureClient) DeleteVirtualMachine(ctx context.Context, resourceGroup, 
 		return err
 	}
 
-	if err = future.WaitForCompletion(ctx, az.virtualMachinesClient.Client); err != nil {
+	if err = future.WaitForCompletionRef(ctx, az.virtualMachinesClient.Client); err != nil {
 		return err
 	}
 
@@ -49,7 +49,7 @@ func (az *AzureClient) DeleteVirtualMachineScaleSetVM(ctx context.Context, resou
 		return err
 	}
 
-	if err = future.WaitForCompletion(ctx, az.virtualMachineScaleSetVMsClient.Client); err != nil {
+	if err = future.WaitForCompletionRef(ctx, az.virtualMachineScaleSetVMsClient.Client); err != nil {
 		return err
 	}
 
@@ -71,7 +71,7 @@ func (az *AzureClient) SetVirtualMachineScaleSetCapacity(ctx context.Context, re
 		return err
 	}
 
-	if err = future.WaitForCompletion(ctx, az.virtualMachineScaleSetsClient.Client); err != nil {
+	if err = future.WaitForCompletionRef(ctx, az.virtualMachineScaleSetsClient.Client); err != nil {
 		return err
 	}
 

--- a/pkg/armhelpers/deployments.go
+++ b/pkg/armhelpers/deployments.go
@@ -26,7 +26,7 @@ func (az *AzureClient) DeployTemplate(ctx context.Context, resourceGroupName, de
 	}
 
 	outcomeText := "Succeeded"
-	err = future.WaitForCompletion(ctx, az.deploymentsClient.Client)
+	err = future.WaitForCompletionRef(ctx, az.deploymentsClient.Client)
 	if err != nil {
 		outcomeText = fmt.Sprintf("Error: %v", err)
 		log.Infof("Finished ARM Deployment (%s). %s", deploymentName, outcomeText)

--- a/pkg/armhelpers/disk.go
+++ b/pkg/armhelpers/disk.go
@@ -13,7 +13,7 @@ func (az *AzureClient) DeleteManagedDisk(ctx context.Context, resourceGroupName 
 		return err
 	}
 
-	if err = future.WaitForCompletion(ctx, az.disksClient.Client); err != nil {
+	if err = future.WaitForCompletionRef(ctx, az.disksClient.Client); err != nil {
 		return err
 	}
 

--- a/pkg/armhelpers/groupsclient.go
+++ b/pkg/armhelpers/groupsclient.go
@@ -40,7 +40,7 @@ func (az *AzureClient) DeleteResourceGroup(ctx context.Context, name string) err
 		return err
 	}
 
-	if err = future.WaitForCompletion(ctx, az.groupsClient.Client); err != nil {
+	if err = future.WaitForCompletionRef(ctx, az.groupsClient.Client); err != nil {
 		return err
 	}
 

--- a/pkg/armhelpers/network.go
+++ b/pkg/armhelpers/network.go
@@ -11,7 +11,7 @@ func (az *AzureClient) DeleteNetworkInterface(ctx context.Context, resourceGroup
 		return err
 	}
 
-	if err = future.WaitForCompletion(ctx, az.interfacesClient.Client); err != nil {
+	if err = future.WaitForCompletionRef(ctx, az.interfacesClient.Client); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Replacing WaitForCompletion method calls with WaitForCompletion as the former is deprecated as per the Azure Go SDK godoc