### PR TITLE
Re-enable outbound internet check

### DIFF
--- a/parts/k8s/kubernetescustomscript.sh
+++ b/parts/k8s/kubernetescustomscript.sh
@@ -30,12 +30,18 @@ else
     FULL_INSTALL_REQUIRED=true
 fi
 
+function testOutboundConnection() {
+    retrycmd_if_failure 40 1 3 nc -vz www.google.com 443 || retrycmd_if_failure 40 1 3 nc -vz www.1688.com 443 || exit $ERR_OUTBOUND_CONN_FAIL
+}
+
 function holdWALinuxAgent() {
     if [[ $OS == $UBUNTU_OS_NAME ]]; then
         # make sure walinuxagent doesn't get updated in the middle of running this script
         retrycmd_if_failure 20 5 30 apt-mark hold walinuxagent || exit $ERR_HOLD_WALINUXAGENT
     fi
 }
+
+testOutboundConnection
 
 if [[ ! -z "${MASTER_NODE}" ]]; then
     installEtcd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: The merry-go-round continues.

Following recent incidents where CSE 50 aided in identifying persistent network i/o failures on vms, let's put this back. I'm advocating we increase the tolerance, so there are 40 attempts each to www.google.com and www.1688.com before declaring a lack of outbound internet connectivity.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Re-enable outbound internet check
```
