### PR TITLE
add support for k8s v1.12.0-rc.2

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -81,6 +81,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.12.0-beta.0":  true,
 	"1.12.0-beta.1":  true,
 	"1.12.0-rc.1":    true,
+	"1.12.0-rc.2":    true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release


### PR DESCRIPTION
**What this PR does / why we need it**:

See https://github.com/kubernetes/kubernetes/releases/tag/v1.12.0-rc.2

TODO:

- [x] upload Windows binary

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
```release-note
add support for Kubernetes 1.12.0-rc.2
```
