### PR TITLE
Fixing unreported gosimple lints

### DIFF
--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -981,7 +981,7 @@ func (w *WindowsProfile) Validate(orchestratorType string) error {
 	if e := validate.Var(w.AdminPassword, "required"); e != nil {
 		return errors.New("WindowsProfile.AdminPassword is required, when agent pool specifies windows")
 	}
-	if validatePasswordComplexity(w.AdminUsername, w.AdminPassword) == false {
+	if !validatePasswordComplexity(w.AdminUsername, w.AdminPassword) {
 		return errors.New("WindowsProfile.AdminPassword complexity not met. Windows password should contain 3 of the following categories - uppercase letters(A-Z), lowercase(a-z) letters, digits(0-9), special characters (~!@#$%^&*_-+=`|\\(){}[]:;<>,.?/')")
 	}
 	return validateKeyVaultSecrets(w.Secrets, true)

--- a/pkg/armhelpers/graph.go
+++ b/pkg/armhelpers/graph.go
@@ -107,11 +107,7 @@ func (az *AzureClient) CreateApp(ctx context.Context, appName, appURL string, re
 // DeleteApp is a simpler method for deleting an application and the associated spn
 func (az *AzureClient) DeleteApp(ctx context.Context, applicationName, applicationObjectID string) (autorest.Response, error) {
 	log.Debugf("ad: deleting application with name=%q", applicationName)
-	applicationResp, err := az.DeleteGraphApplication(ctx, applicationObjectID)
-	if err != nil {
-		return applicationResp, err
-	}
-	return applicationResp, nil
+	return az.DeleteGraphApplication(ctx, applicationObjectID)
 }
 
 // CreateRoleAssignmentSimple is a wrapper around RoleAssignmentsClient.Create


### PR DESCRIPTION
Fixing unreported lint errors. This is because of the outdated gometalinter binaries in CircleCI