### PR TITLE
Add shortcuts for some common command-line arguments

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -93,10 +93,10 @@ func newDeployCmd() *cobra.Command {
 	}
 
 	f := deployCmd.Flags()
-	f.StringVar(&dc.apimodelPath, "api-model", "", "path to the apimodel file")
-	f.StringVar(&dc.dnsPrefix, "dns-prefix", "", "dns prefix (unique name for the cluster)")
+	f.StringVarP(&dc.apimodelPath, "api-model", "m", "", "path to the apimodel file")
+	f.StringVarP(&dc.dnsPrefix, "dns-prefix", "p", "", "dns prefix (unique name for the cluster)")
 	f.BoolVar(&dc.autoSuffix, "auto-suffix", false, "automatically append a compressed timestamp to the dnsPrefix to ensure unique cluster name automatically")
-	f.StringVar(&dc.outputDirectory, "output-directory", "", "output directory (derived from FQDN if absent)")
+	f.StringVarP(&dc.outputDirectory, "output-directory", "o", "", "output directory (derived from FQDN if absent)")
 	f.StringVar(&dc.caCertificatePath, "ca-certificate-path", "", "path to the CA certificate to use for Kubernetes PKI assets")
 	f.StringVar(&dc.caPrivateKeyPath, "ca-private-key-path", "", "path to the CA private key to use for Kubernetes PKI assets")
 	f.StringVarP(&dc.resourceGroup, "resource-group", "g", "", "resource group to deploy to (will use the DNS prefix from the apimodel if not specified)")

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -62,8 +62,8 @@ func newGenerateCmd() *cobra.Command {
 	}
 
 	f := generateCmd.Flags()
-	f.StringVar(&gc.apimodelPath, "api-model", "", "path to the apimodel file")
-	f.StringVar(&gc.outputDirectory, "output-directory", "", "output directory (derived from FQDN if absent)")
+	f.StringVarP(&gc.apimodelPath, "api-model", "m", "", "path to the apimodel file")
+	f.StringVarP(&gc.outputDirectory, "output-directory", "o", "", "output directory (derived from FQDN if absent)")
 	f.StringVar(&gc.caCertificatePath, "ca-certificate-path", "", "path to the CA certificate to use for Kubernetes PKI assets")
 	f.StringVar(&gc.caPrivateKeyPath, "ca-private-key-path", "", "path to the CA private key to use for Kubernetes PKI assets")
 	f.StringArrayVar(&gc.set, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,7 +106,7 @@ type authArgs struct {
 
 func addAuthFlags(authArgs *authArgs, f *flag.FlagSet) {
 	f.StringVar(&authArgs.RawAzureEnvironment, "azure-env", "AzurePublicCloud", "the target Azure cloud")
-	f.StringVar(&authArgs.rawSubscriptionID, "subscription-id", "", "azure subscription id (required)")
+	f.StringVarP(&authArgs.rawSubscriptionID, "subscription-id", "s", "", "azure subscription id (required)")
 	f.StringVar(&authArgs.AuthMethod, "auth-method", "device", "auth method (default:`device`, `client_secret`, `client_certificate`)")
 	f.StringVar(&authArgs.rawClientID, "client-id", "", "client id (used with --auth-method=[client_secret|client_certificate])")
 	f.StringVar(&authArgs.ClientSecret, "client-secret", "", "client secret (used with --auth-mode=client_secret)")

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -75,7 +75,7 @@ func newScaleCmd() *cobra.Command {
 	f.StringVarP(&sc.location, "location", "l", "", "location the cluster is deployed in")
 	f.StringVarP(&sc.resourceGroupName, "resource-group", "g", "", "the resource group where the cluster is deployed")
 	f.StringVar(&sc.deploymentDirectory, "deployment-dir", "", "the location of the output from `generate`")
-	f.IntVar(&sc.newDesiredAgentCount, "new-node-count", 0, "desired number of nodes")
+	f.IntVarP(&sc.newDesiredAgentCount, "new-node-count", "c", 0, "desired number of nodes")
 	f.StringVar(&sc.agentPoolToScale, "node-pool", "", "node pool to scale")
 	f.StringVar(&sc.masterFQDN, "master-FQDN", "", "FQDN for the master load balancer, Needed to scale down Kubernetes agent pools")
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -65,7 +65,7 @@ func newUpgradeCmd() *cobra.Command {
 	f.StringVarP(&uc.location, "location", "l", "", "location the cluster is deployed in (required)")
 	f.StringVarP(&uc.resourceGroupName, "resource-group", "g", "", "the resource group where the cluster is deployed (required)")
 	f.StringVar(&uc.deploymentDirectory, "deployment-dir", "", "the location of the output from `generate` (required)")
-	f.StringVar(&uc.upgradeVersion, "upgrade-version", "", "desired kubernetes version (required)")
+	f.StringVarP(&uc.upgradeVersion, "upgrade-version", "k", "", "desired kubernetes version (required)")
 	f.IntVar(&uc.timeoutInMinutes, "vm-timeout", -1, "how long to wait for each vm to be upgraded in minutes")
 	addAuthFlags(&uc.authArgs, f)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Adds single-character shortcuts for some common `acsengine` command arguments. Tries to align them with similar flags in [`az aks`](https://github.com/Azure/azure-cli/blob/dev/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py#L140).

Let me know if you like this--shortcuts can be a personal preference, and I'm glad to change the reserved letters or punt on this altogether.

Example (the `-m`, `-p`, and `-s` shortcuts are new):

```
$ ./bin/acs-engine deploy -h
Deploy an Azure Resource Manager template, parameters file and other assets for a cluster

Usage:
  acs-engine deploy [flags]

Flags:
  -m, --api-model string             path to the apimodel file
      --auth-method device           auth method (default:device, `client_secret`, `client_certificate`) (default "device")
      --auto-suffix                  automatically append a compressed timestamp to the dnsPrefix to ensure unique cluster name automatically
      --azure-env string             the target Azure cloud (default "AzurePublicCloud")
      --ca-certificate-path string   path to the CA certificate to use for Kubernetes PKI assets
      --ca-private-key-path string   path to the CA private key to use for Kubernetes PKI assets
      --certificate-path string      path to client certificate (used with --auth-method=client_certificate)
      --client-id string             client id (used with --auth-method=[client_secret|client_certificate])
      --client-secret string         client secret (used with --auth-mode=client_secret)
  -p, --dns-prefix string            dns prefix (unique name for the cluster)
  -f, --force-overwrite              automatically overwrite existing files in the output directory
  -h, --help                         help for deploy
      --language string              language to return error messages in (default "en-us")
  -l, --location string              location to deploy to (required)
      --output-directory string      output directory (derived from FQDN if absent)
      --private-key-path string      path to private key (used with --auth-method=client_certificate)
  -g, --resource-group string        resource group to deploy to (will use the DNS prefix from the apimodel if not specified)
      --set stringArray              set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
  -s, --subscription-id string       azure subscription id (required)

Global Flags:
      --debug   enable verbose debug logs

```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

There is no GitHub issue for my frustration with extra typing.

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add shortcuts for some common command-line arguments
```
