### PR TITLE
set FailureActions for docker, kubelet, kubeproxy on windows

### DIFF
--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -674,6 +674,14 @@ Set-Explorer
     New-ItemProperty -Path HKLM:"\\SOFTWARE\\Policies\\Microsoft\\Internet Explorer\\Main" -Name "Start Page" -Type String -Value http://bing.com
 }
 
+function
+Update-ServiceFailureActions()
+{
+    sc.exe failure "kubelet" actions= restart/60000/restart/60000/restart/60000 reset= 900
+    sc.exe failure "kubeproxy" actions= restart/60000/restart/60000/restart/60000 reset= 900
+    sc.exe failure "docker" actions= restart/60000/restart/60000/restart/60000 reset= 900
+}
+
 try
 {
     # Set to false for debugging.  This will output the start script to
@@ -722,6 +730,9 @@ try
 
         Write-Log "Start preProvisioning script"
         PREPROVISION_EXTENSION
+
+        Write-Log "Update service failure actions"
+        Update-ServiceFailureActions
 
         Write-Log "Setup Complete, reboot computer"
         Restart-Computer


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Original `FailureActions` setting of services `docker`, `kubelet`, `kubeproxy` are not set on Windows, so once service is down, it will never started, user needs to restart VM to make service running again, this PR set `FailureActions` as:
restart after 60000ms (1 minute) for the first, second, and third failures. Reset the counter after 86400 seconds (1 day)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3888

**Special notes for your reviewer**:
With this PR, after windows node set up:
```
PS C:\Users\azureuser> get-itemproperty hklm:\system\currentcontrolset\services\kubeproxy

Type                             : 16
Start                            : 2
ErrorControl                     : 1
ImagePath                        : c:\k\nssm.exe
DisplayName                      : Kubeproxy
ObjectName                       : LocalSystem
DelayedAutostart                 : 0
FailureActionsOnNonCrashFailures : 1
DependOnService                  : {Kubelet}
Description                      : Kubeproxy
FailureActions                   : {128, 81, 1, 0...}
PSPath                           : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\system\currentcontrolset\serv
                                   ices\kubeproxy
PSParentPath                     : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\system\currentcontrolset\serv
                                   ices
PSChildName                      : kubeproxy
PSDrive                          : HKLM
PSProvider                       : Microsoft.PowerShell.Core\Registry



PS C:\Users\azureuser> get-itemproperty hklm:\system\currentcontrolset\services\kubelet

Type                             : 16
Start                            : 2
ErrorControl                     : 1
ImagePath                        : c:\k\nssm.exe
DisplayName                      : Kubelet
ObjectName                       : LocalSystem
DelayedAutostart                 : 0
FailureActionsOnNonCrashFailures : 1
Description                      : Kubelet
FailureActions                   : {128, 81, 1, 0...}
PSPath                           : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\system\currentcontrolset\serv
                                   ices\kubelet
PSParentPath                     : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\system\currentcontrolset\serv
                                   ices
PSChildName                      : kubelet
PSDrive                          : HKLM
PSProvider                       : Microsoft.PowerShell.Core\Registry



PS C:\Users\azureuser> get-itemproperty hklm:\system\currentcontrolset\services\docker

Type           : 16
Start          : 2
ErrorControl   : 1
ImagePath      : "C:\Program Files\Docker\dockerd.exe" --run-service
ObjectName     : LocalSystem
FailureActions : {128, 81, 1, 0...}
PSPath         : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\system\currentcontrolset\services\docker
PSParentPath   : Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\system\currentcontrolset\services
PSChildName    : docker
PSDrive        : HKLM
PSProvider     : Microsoft.PowerShell.Core\Registry
```

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
set FailureActions for docker, kubelet, kubeproxy on windows
```

@PatrickLang could you review it first, thanks.
cc @adelina-t @feiskyer 