### PR TITLE
Update apiversion to make it consistent in k8s templates

### DIFF
--- a/docs/custom-vnet.md
+++ b/docs/custom-vnet.md
@@ -32,7 +32,7 @@ The Azure Resource Manager template used to deploy this virtual network is:
   "variables": {  },
   "resources": [
     {
-      "apiVersion": "2016-03-30",
+      "apiVersion": "2018-06-01",
       "location": "[resourceGroup().location]",
       "name": "ExampleCustomVNET",
       "properties": {

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -138,7 +138,7 @@ The following is an example of the template.json file.
 				"description": "Storage API Version"
 			}
 		},
-		"apiVersionDefault": {
+		"apiVersionCompute": {
 			"type": "string",
 			"minLength": 1,
 			"metadata": {
@@ -183,7 +183,7 @@ The following is an example of the template.json file.
       }, 
       "type": "Microsoft.Storage/storageAccounts"	
 	}, {
-      "apiVersion": "[parameters('apiVersionDefault')]",
+      "apiVersion": "[parameters('apiVersionCompute')]",
       "dependsOn": [],
       "location": "[resourceGroup().location]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
@@ -222,7 +222,7 @@ Replace "**EXTENSION-NAME**" with the name of the extension.
 {
     "name": "EXTENSION-NAME",
     "type": "Microsoft.Resources/deployments",
-    "apiVersion": "[variables('apiVersionDefault')]",
+    "apiVersion": "[variables('apiVersionCompute')]",
     "dependsOn": [
         "vmLoopNode"
     ],
@@ -233,8 +233,8 @@ Replace "**EXTENSION-NAME**" with the name of the extension.
             "contentVersion": "1.0.0.0"
         },
         "parameters": {
-            "apiVersionDefault": {
-                "value": "[variables('apiVersionDefault')]"
+            "apiVersionCompute": {
+                "value": "[variables('apiVersionCompute')]"
             },
             "username": {
                 "value": "[parameters('linuxAdminUsername')]"

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -222,7 +222,7 @@ Replace "**EXTENSION-NAME**" with the name of the extension.
 {
     "name": "EXTENSION-NAME",
     "type": "Microsoft.Resources/deployments",
-    "apiVersion": "[variables('apiVersionLinkDefault')]",
+    "apiVersion": "[variables('apiVersionDefault')]",
     "dependsOn": [
         "vmLoopNode"
     ],
@@ -233,9 +233,6 @@ Replace "**EXTENSION-NAME**" with the name of the extension.
             "contentVersion": "1.0.0.0"
         },
         "parameters": {
-            "apiVersionStorage": {
-                "value": "[variables('apiVersionStorage')]"
-            },
             "apiVersionDefault": {
                 "value": "[variables('apiVersionDefault')]"
             },

--- a/extensions/choco/v1/template-link.json
+++ b/extensions/choco/v1/template-link.json
@@ -1,7 +1,7 @@
 {
 	"name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'Choco')]",
 	"type": "Microsoft.Resources/deployments",
-	"apiVersion": "[variables('apiVersionDefault')]",
+	"apiVersion": "[variables('apiVersionCompute')]",
 	"dependsOn": [
 		"[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
 	],
@@ -20,7 +20,7 @@
 				"value": "EXTENSION_URL_REPLACE"
 			},
 			"apiVersionCompute": {
-				"value": "[variables('apiVersionDefault')]"
+				"value": "[variables('apiVersionCompute')]"
 			},
 			"targetVMName": {
 				"value": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET))]"

--- a/extensions/choco/v1/template-link.json
+++ b/extensions/choco/v1/template-link.json
@@ -1,7 +1,7 @@
 {
 	"name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'Choco')]",
 	"type": "Microsoft.Resources/deployments",
-	"apiVersion": "[variables('apiVersionLinkDefault')]",
+	"apiVersion": "[variables('apiVersionDefault')]",
 	"dependsOn": [
 		"[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
 	],

--- a/extensions/hello-world-k8s/v1/template-link.json
+++ b/extensions/hello-world-k8s/v1/template-link.json
@@ -1,7 +1,7 @@
 {
     "name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'HelloWorldK8s')]",
     "type": "Microsoft.Resources/deployments",
-    "apiVersion": "[variables('apiVersionDefault')]",
+    "apiVersion": "[variables('apiVersionCompute')]",
     "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
     ],
@@ -20,7 +20,7 @@
                 "value": "EXTENSION_URL_REPLACE"
             },
             "apiVersionCompute": {
-                "value": "[variables('apiVersionDefault')]"
+                "value": "[variables('apiVersionCompute')]"
             },
             "targetVMName": {
                 "value": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET))]"

--- a/extensions/hello-world-k8s/v1/template-link.json
+++ b/extensions/hello-world-k8s/v1/template-link.json
@@ -1,7 +1,7 @@
 {
     "name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'HelloWorldK8s')]",
     "type": "Microsoft.Resources/deployments",
-    "apiVersion": "[variables('apiVersionLinkDefault')]",
+    "apiVersion": "[variables('apiVersionDefault')]",
     "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
     ],

--- a/extensions/microsoft-oms-agent-k8s/v1/template-link.json
+++ b/extensions/microsoft-oms-agent-k8s/v1/template-link.json
@@ -1,7 +1,7 @@
 {
     "name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'MicrosoftOMSAgentk8s')]",
     "type": "Microsoft.Resources/deployments",
-    "apiVersion": "[variables('apiVersionDefault')]",
+    "apiVersion": "[variables('apiVersionCompute')]",
     "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
     ],
@@ -19,8 +19,8 @@
             "artifactsLocation": {
                 "value": "EXTENSION_URL_REPLACE"
             },
-            "apiVersionDefault": {
-                "value": "[variables('apiVersionDefault')]"
+            "apiVersionCompute": {
+                "value": "[variables('apiVersionCompute')]"
             },
             "targetVMName": {
                 "value": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET))]"

--- a/extensions/microsoft-oms-agent-k8s/v1/template-link.json
+++ b/extensions/microsoft-oms-agent-k8s/v1/template-link.json
@@ -1,7 +1,7 @@
 {
     "name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'MicrosoftOMSAgentk8s')]",
     "type": "Microsoft.Resources/deployments",
-    "apiVersion": "[variables('apiVersionLinkDefault')]",
+    "apiVersion": "[variables('apiVersionDefault')]",
     "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
     ],

--- a/extensions/microsoft-oms-agent-k8s/v1/template.json
+++ b/extensions/microsoft-oms-agent-k8s/v1/template.json
@@ -9,7 +9,7 @@
 				"description": "Artifacts Location - URL"
 			}
         },
-		"apiVersionDefault": {
+		"apiVersionCompute": {
 			"type": "string",
 			"minLength": 1,
 			"metadata": {
@@ -50,7 +50,7 @@
    },
    "resources": [  
 	{
-      "apiVersion": "[parameters('apiVersionDefault')]",
+      "apiVersion": "[parameters('apiVersionCompute')]",
       "dependsOn": [],
       "location": "[resourceGroup().location]",
       "type": "Microsoft.Compute/virtualMachines/extensions",

--- a/extensions/prometheus-grafana-k8s/v1/template-link.json
+++ b/extensions/prometheus-grafana-k8s/v1/template-link.json
@@ -1,7 +1,7 @@
 {
     "name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'PrometheusGrafanaK8s')]",
     "type": "Microsoft.Resources/deployments",
-    "apiVersion": "[variables('apiVersionDefault')]",
+    "apiVersion": "[variables('apiVersionComput')]",
     "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
     ],
@@ -20,7 +20,7 @@
                 "value": "EXTENSION_URL_REPLACE"
             },
             "apiVersionCompute": {
-                "value": "[variables('apiVersionDefault')]"
+                "value": "[variables('apiVersionCompute')]"
             },
             "targetVMName": {
                 "value": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET))]"

--- a/extensions/prometheus-grafana-k8s/v1/template-link.json
+++ b/extensions/prometheus-grafana-k8s/v1/template-link.json
@@ -1,7 +1,7 @@
 {
     "name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'PrometheusGrafanaK8s')]",
     "type": "Microsoft.Resources/deployments",
-    "apiVersion": "[variables('apiVersionLinkDefault')]",
+    "apiVersion": "[variables('apiVersionDefault')]",
     "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
     ],

--- a/extensions/windows-patches/v1/template-link.json
+++ b/extensions/windows-patches/v1/template-link.json
@@ -1,7 +1,7 @@
 {
 	"name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'windows-patches')]",
 	"type": "Microsoft.Resources/deployments",
-	"apiVersion": "[variables('apiVersionLinkDefault')]",
+	"apiVersion": "[variables('apiVersionDefault')]",
 	"dependsOn": [
 		"[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
 	],

--- a/extensions/windows-patches/v1/template-link.json
+++ b/extensions/windows-patches/v1/template-link.json
@@ -1,7 +1,7 @@
 {
 	"name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'windows-patches')]",
 	"type": "Microsoft.Resources/deployments",
-	"apiVersion": "[variables('apiVersionDefault')]",
+	"apiVersion": "[variables('apiVersionCompute')]",
 	"dependsOn": [
 		"[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
 	],
@@ -20,7 +20,7 @@
 				"value": "EXTENSION_URL_REPLACE"
 			},
 			"apiVersionCompute": {
-				"value": "[variables('apiVersionDefault')]"
+				"value": "[variables('apiVersionCompute')]"
 			},
 			"targetVMName": {
 				"value": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET))]"

--- a/extensions/winrm/v1/template-link.json
+++ b/extensions/winrm/v1/template-link.json
@@ -1,7 +1,7 @@
 {
 	"name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'winrm')]",
 	"type": "Microsoft.Resources/deployments",
-	"apiVersion": "[variables('apiVersionLinkDefault')]",
+	"apiVersion": "[variables('apiVersionDefault')]",
 	"dependsOn": [
 		"[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
 	],

--- a/extensions/winrm/v1/template-link.json
+++ b/extensions/winrm/v1/template-link.json
@@ -1,7 +1,7 @@
 {
 	"name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'winrm')]",
 	"type": "Microsoft.Resources/deployments",
-	"apiVersion": "[variables('apiVersionDefault')]",
+	"apiVersion": "[variables('apiVersionCompute')]",
 	"dependsOn": [
 		"[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
 	],
@@ -20,7 +20,7 @@
 				"value": "EXTENSION_URL_REPLACE"
 			},
 			"apiVersionCompute": {
-				"value": "[variables('apiVersionDefault')]"
+				"value": "[variables('apiVersionCompute')]"
 			},
 			"targetVMName": {
 				"value": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET))]"

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -84,10 +84,11 @@
       "properties":
         {
             "platformFaultDomainCount": 2,
-            "platformUpdateDomainCount": 3,
-		"managed" : "true"
+            "platformUpdateDomainCount": 3
         },
-
+      "sku": {
+        "name": "Aligned"
+      },
       "type": "Microsoft.Compute/availabilitySets"
     },
 {{else if .IsStorageAccount}}

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -1,9 +1,5 @@
     {
-{{if .AcceleratedNetworkingEnabled}}
-      "apiVersion": "2018-04-01",
-{{else}}
       "apiVersion": "[variables('apiVersionDefault')]",
-{{end}}
       "copy": {
         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "loop"
@@ -84,7 +80,7 @@
    {
       "location": "[variables('location')]",
       "name": "[variables('{{.Name}}AvailabilitySet')]",
-      "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
+      "apiVersion": "[variables('apiVersionDefault')]",
       "properties":
         {
             "platformFaultDomainCount": 2,
@@ -96,7 +92,7 @@
     },
 {{else if .IsStorageAccount}}
     {
-      "apiVersion": "[variables('apiVersionStorage')]",
+      "apiVersion": "[variables('apiVersionDefault')]",
       "copy": {
         "count": "[variables('{{.Name}}StorageAccountsCount')]",
         "name": "loop"
@@ -117,7 +113,7 @@
     },
     {{if .HasDisks}}
     {
-      "apiVersion": "[variables('apiVersionStorage')]",
+      "apiVersion": "[variables('apiVersionDefault')]",
       "copy": {
         "count": "[variables('{{.Name}}StorageAccountsCount')]",
         "name": "datadiskLoop"
@@ -146,15 +142,7 @@
     },
 {{end}}
   {
-    {{if UserAssignedIDEnabled}}
-     "apiVersion": "[variables('apiVersionUserMSI')]",
-    {{else}}
-    {{if .IsManagedDisks}}
-      "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
-    {{else}}
       "apiVersion": "[variables('apiVersionDefault')]",
-    {{end}}
-    {{end}}
       "copy": {
         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "vmLoopNode"
@@ -257,7 +245,7 @@
           {{if .IsStorageAccount}}
             ,"name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')),'-osdisk')]"
             ,"vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-osdisk.vhd')]"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionDefault')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-osdisk.vhd')]"
             }
           {{end}}
           {{if ne .OSDiskSizeGB 0}}
@@ -271,7 +259,7 @@
     {{if UseManagedIdentity}}
     {{if (not UserAssignedIDEnabled)}}
     {
-      "apiVersion": "2014-10-01-preview",
+      "apiVersion": "[variables('apiVersionDefault')]",
       "copy": {
          "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
          "name": "vmLoopNode"
@@ -291,7 +279,7 @@
          "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
          "name": "vmLoopNode"
        },
-       "apiVersion": "2015-05-01-preview",
+       "apiVersion": "[variables('apiVersionDefault')]",
        "location": "[resourceGroup().location]",
        {{if UserAssignedIDEnabled}}
        "dependsOn": [

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -1,5 +1,5 @@
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "[variables('apiVersionNetwork')]",
       "copy": {
         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "loop"

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -107,8 +107,8 @@
       {{end}}
       "location": "[variables('location')]",
       "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
-      "properties": {
-        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+      "sku": {
+        "name": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
       },
       "type": "Microsoft.Storage/storageAccounts"
     },
@@ -128,8 +128,8 @@
       {{end}}
       "location": "[variables('location')]",
       "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
-      "properties": {
-        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+      "sku": {
+        "name": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
       },
       "type": "Microsoft.Storage/storageAccounts"
     },

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -1,5 +1,5 @@
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "loop"
@@ -80,7 +80,7 @@
    {
       "location": "[variables('location')]",
       "name": "[variables('{{.Name}}AvailabilitySet')]",
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "properties":
         {
             "platformFaultDomainCount": 2,
@@ -137,13 +137,13 @@
     {
       "location": "[variables('location')]",
       "name": "[variables('{{.Name}}AvailabilitySet')]",
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "properties": {},
       "type": "Microsoft.Compute/availabilitySets"
     },
 {{end}}
   {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "vmLoopNode"
@@ -260,7 +260,7 @@
     {{if UseManagedIdentity}}
     {{if (not UserAssignedIDEnabled)}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
          "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
          "name": "vmLoopNode"
@@ -280,7 +280,7 @@
          "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
          "name": "vmLoopNode"
        },
-       "apiVersion": "[variables('apiVersionDefault')]",
+       "apiVersion": "[variables('apiVersionCompute')]",
        "location": "[resourceGroup().location]",
        {{if UserAssignedIDEnabled}}
        "dependsOn": [
@@ -305,7 +305,7 @@
      },
      {{end}}
      {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "vmLoopNode"
@@ -339,7 +339,7 @@
     ,{
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '/computeAksLinuxBilling')]",
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "vmLoopNode"

--- a/parts/k8s/kubernetesagentresourcesvmas.t
+++ b/parts/k8s/kubernetesagentresourcesvmas.t
@@ -93,7 +93,7 @@
     },
 {{else if .IsStorageAccount}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionStorage')]",
       "copy": {
         "count": "[variables('{{.Name}}StorageAccountsCount')]",
         "name": "loop"
@@ -114,7 +114,7 @@
     },
     {{if .HasDisks}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionStorage')]",
       "copy": {
         "count": "[variables('{{.Name}}StorageAccountsCount')]",
         "name": "datadiskLoop"
@@ -246,7 +246,7 @@
           {{if .IsStorageAccount}}
             ,"name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')),'-osdisk')]"
             ,"vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionDefault')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-osdisk.vhd')]"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-osdisk.vhd')]"
             }
           {{end}}
           {{if ne .OSDiskSizeGB 0}}

--- a/parts/k8s/kubernetesagentresourcesvmss.t
+++ b/parts/k8s/kubernetesagentresourcesvmss.t
@@ -1,6 +1,6 @@
 {{if and UseManagedIdentity (not UserAssignedIDEnabled)}}
   {
-    "apiVersion": "2014-10-01-preview",
+    "apiVersion": "[variables('apiVersionDefault')]",
     "name": "[guid(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}VMNamePrefix'), 'vmidentity'))]",
     "type": "Microsoft.Authorization/roleAssignments",
     "properties": {
@@ -10,7 +10,7 @@
   },
 {{end}}
   {
-    "apiVersion": "[variables('apiVersionVirtualMachineScaleSets')]",
+    "apiVersion": "[variables('apiVersionDefault')]",
     "dependsOn": [
     {{if .IsCustomVNET}}
       "[variables('nsgID')]"

--- a/parts/k8s/kubernetesagentresourcesvmss.t
+++ b/parts/k8s/kubernetesagentresourcesvmss.t
@@ -1,6 +1,6 @@
 {{if and UseManagedIdentity (not UserAssignedIDEnabled)}}
   {
-    "apiVersion": "[variables('apiVersionDefault')]",
+    "apiVersion": "[variables('apiVersionCompute')]",
     "name": "[guid(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}VMNamePrefix'), 'vmidentity'))]",
     "type": "Microsoft.Authorization/roleAssignments",
     "properties": {
@@ -10,7 +10,7 @@
   },
 {{end}}
   {
-    "apiVersion": "[variables('apiVersionDefault')]",
+    "apiVersion": "[variables('apiVersionCompute')]",
     "dependsOn": [
     {{if .IsCustomVNET}}
       "[variables('nsgID')]"

--- a/parts/k8s/kubernetesbase.t
+++ b/parts/k8s/kubernetesbase.t
@@ -60,7 +60,7 @@
       {
         "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
         "name": "[variables('userAssignedID')]",
-        "apiVersion": "2015-08-31-PREVIEW",
+        "apiVersion": "[variables('apiVersionDefault')]",
         "location": "[variables('location')]"
       },
     {{end}}

--- a/parts/k8s/kubernetesbase.t
+++ b/parts/k8s/kubernetesbase.t
@@ -60,7 +60,7 @@
       {
         "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
         "name": "[variables('userAssignedID')]",
-        "apiVersion": "[variables('apiVersionDefault')]",
+        "apiVersion": "[variables('apiVersionCompute')]",
         "location": "[variables('location')]"
       },
     {{end}}
@@ -86,7 +86,7 @@
     {{if IsHostedMaster}}
       {{if not IsCustomVNET}}
       ,{
-        "apiVersion": "[variables('apiVersionDefault')]",
+        "apiVersion": "[variables('apiVersionCompute')]",
         "dependsOn": [
           "[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgName'))]"
       {{if not IsAzureCNI}}
@@ -125,14 +125,14 @@
     {{end}}
     {{if not IsAzureCNI}}
     ,{
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "location": "[variables('location')]",
       "name": "[variables('routeTableName')]",
       "type": "Microsoft.Network/routeTables"
     }
     {{end}}
     ,{
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "location": "[variables('location')]",
       "name": "[variables('nsgName')]",
       "properties": {

--- a/parts/k8s/kubernetesbase.t
+++ b/parts/k8s/kubernetesbase.t
@@ -86,7 +86,7 @@
     {{if IsHostedMaster}}
       {{if not IsCustomVNET}}
       ,{
-        "apiVersion": "[variables('apiVersionCompute')]",
+        "apiVersion": "[variables('apiVersionNetwork')]",
         "dependsOn": [
           "[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgName'))]"
       {{if not IsAzureCNI}}
@@ -125,14 +125,14 @@
     {{end}}
     {{if not IsAzureCNI}}
     ,{
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "[variables('apiVersionNetwork')]",
       "location": "[variables('location')]",
       "name": "[variables('routeTableName')]",
       "type": "Microsoft.Network/routeTables"
     }
     {{end}}
     ,{
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "[variables('apiVersionNetwork')]",
       "location": "[variables('location')]",
       "name": "[variables('nsgName')]",
       "properties": {

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -22,7 +22,7 @@
       "type": "Microsoft.Compute/availabilitySets"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionStorage')]",
 {{if not IsPrivateCluster}}
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
@@ -453,7 +453,7 @@
               "osDisk": {
                 "createOption": "fromImage",
                 "vhd": {
-                    "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('jumpboxStorageAccountName')),variables('apiVersionDefault')).primaryEndpoints.blob,'vhds/',parameters('jumpboxVMName'),'jumpboxdisk.vhd')]"
+                    "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('jumpboxStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/',parameters('jumpboxVMName'),'jumpboxdisk.vhd')]"
                 },
                 "name": "[variables('jumpboxOSDiskName')]"
               },
@@ -476,7 +476,7 @@
     {
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[variables('jumpboxStorageAccountName')]",
-            "apiVersion": "[variables('apiVersionDefault')]",
+            "apiVersion": "[variables('apiVersionStorage')]",
             "location": "[variables('location')]",
             "properties": {
                 "accountType": "[variables('vmSizesMap')[parameters('jumpboxVMSize')].storageAccountType]"
@@ -626,7 +626,7 @@
      {
        "type": "Microsoft.Storage/storageAccounts",
        "name": "[variables('clusterKeyVaultName')]",
-       "apiVersion": "[variables('apiVersionDefault')]",
+       "apiVersion": "[variables('apiVersionStorage')]",
        "location": "[variables('location')]",
        "properties": {
          "accountType": "Standard_LRS"
@@ -807,7 +807,7 @@
               ,"name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-etcddisk')]"
               {{if .MasterProfile.IsStorageAccount}}
               ,"vhd": {
-                "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionDefault')).primaryEndpoints.blob,'vhds/', variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')),'-etcddisk.vhd')]"
+                "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/', variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')),'-etcddisk.vhd')]"
               }
               {{end}}
             }
@@ -829,7 +829,7 @@
 {{if .MasterProfile.IsStorageAccount}}
             ,"name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-osdisk')]"
             ,"vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionDefault')).primaryEndpoints.blob,'vhds/',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')),'-osdisk.vhd')]"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')),'-osdisk.vhd')]"
             }
 {{end}}
 {{if ne .MasterProfile.OSDiskSizeGB 0}}

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -4,11 +4,13 @@
       "location": "[variables('location')]",
       "name": "[variables('masterAvailabilitySet')]",
       "properties":
-        {
-            "platformFaultDomainCount": 2,
-            "platformUpdateDomainCount": 3,
-		        "managed" : true
-        },
+      {
+        "platformFaultDomainCount": 2,
+        "platformUpdateDomainCount": 3
+      },
+      "sku": {
+        "name": "Aligned"
+      },
       "type": "Microsoft.Compute/availabilitySets"
     },
 {{else if .MasterProfile.IsStorageAccount}}

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -38,7 +38,7 @@
 {{end}}
 {{if not .MasterProfile.IsCustomVNET}}
 {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "[variables('apiVersionNetwork')]",
       "dependsOn": [
 {{if RequireRouteTable}}
         "[concat('Microsoft.Network/routeTables/', variables('routeTableName'))]"{{if not IsOpenShift}},{{end}}
@@ -80,7 +80,7 @@
     },
 {{end}}
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "[variables('apiVersionNetwork')]",
       "location": "[variables('location')]",
       "name": "[variables('nsgName')]",
       "properties": {
@@ -135,7 +135,7 @@
     },
 {{if RequireRouteTable}}
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "[variables('apiVersionNetwork')]",
       "location": "[variables('location')]",
       "name": "[variables('routeTableName')]",
       "type": "Microsoft.Network/routeTables"
@@ -143,7 +143,7 @@
 {{end}}
 {{if not IsPrivateCluster}}
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "[variables('apiVersionNetwork')]",
       "location": "[variables('location')]",
       "name": "[variables('masterPublicIPAddressName')]",
       "properties": {
@@ -155,7 +155,7 @@
       "type": "Microsoft.Network/publicIPAddresses"
     },
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "[variables('apiVersionNetwork')]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
       ],
@@ -214,7 +214,7 @@
       "type": "Microsoft.Network/loadBalancers"
     },
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "[variables('apiVersionNetwork')]",
       "copy": {
         "count": "[sub(variables('masterCount'), variables('masterOffset'))]",
         "name": "masterLbLoopNode"
@@ -236,7 +236,7 @@
       "type": "Microsoft.Network/loadBalancers/inboundNatRules"
     },
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "[variables('apiVersionNetwork')]",
       "copy": {
         "count": "[sub(variables('masterCount'), variables('masterOffset'))]",
         "name": "nicLoopNode"
@@ -486,7 +486,7 @@
     {
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('jumpboxNetworkSecurityGroupName')]",
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "[variables('apiVersionNetwork')]",
       "location": "[variables('location')]",
       "properties": {
           "securityRules": [
@@ -512,7 +512,7 @@
           "name": "Basic"
       },
       "name": "[variables('jumpboxPublicIpAddressName')]",
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "[variables('apiVersionNetwork')]",
       "location": "[variables('location')]",
       "properties": {
           "dnsSettings": {
@@ -524,7 +524,7 @@
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('jumpboxNetworkInterfaceName')]",
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "[variables('apiVersionNetwork')]",
       "location": "[variables('location')]",
       "properties": {
           "ipConfigurations": [
@@ -558,7 +558,7 @@
 {{end}}
 {{if gt .MasterProfile.Count 1}}
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "[variables('apiVersionNetwork')]",
       "dependsOn": [
 {{if .MasterProfile.IsCustomVNET}}
         "[variables('nsgID')]"

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -1,6 +1,6 @@
 {{if .MasterProfile.IsManagedDisks}}
     {
-      "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
+      "apiVersion": "[variables('apiVersionDefault')]",
       "location": "[variables('location')]",
       "name": "[variables('masterAvailabilitySet')]",
       "properties":
@@ -20,7 +20,7 @@
       "type": "Microsoft.Compute/availabilitySets"
     },
     {
-      "apiVersion": "[variables('apiVersionStorage')]",
+      "apiVersion": "[variables('apiVersionDefault')]",
 {{if not IsPrivateCluster}}
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
@@ -410,11 +410,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('jumpboxVMName')]",
-      {{if JumpboxIsManagedDisks}}
-      "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
-      {{else}}
       "apiVersion": "[variables('apiVersionDefault')]",
-      {{end}}
       "location": "[variables('location')]",
       "properties": {
           "osProfile": {
@@ -455,7 +451,7 @@
               "osDisk": {
                 "createOption": "fromImage",
                 "vhd": {
-                    "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('jumpboxStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/',parameters('jumpboxVMName'),'jumpboxdisk.vhd')]"
+                    "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('jumpboxStorageAccountName')),variables('apiVersionDefault')).primaryEndpoints.blob,'vhds/',parameters('jumpboxVMName'),'jumpboxdisk.vhd')]"
                 },
                 "name": "[variables('jumpboxOSDiskName')]"
               },
@@ -478,7 +474,7 @@
     {
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[variables('jumpboxStorageAccountName')]",
-            "apiVersion": "[variables('apiVersionStorage')]",
+            "apiVersion": "[variables('apiVersionDefault')]",
             "location": "[variables('location')]",
             "properties": {
                 "accountType": "[variables('vmSizesMap')[parameters('jumpboxVMSize')].storageAccountType]"
@@ -628,7 +624,7 @@
      {
        "type": "Microsoft.Storage/storageAccounts",
        "name": "[variables('clusterKeyVaultName')]",
-       "apiVersion": "[variables('apiVersionStorage')]",
+       "apiVersion": "[variables('apiVersionDefault')]",
        "location": "[variables('location')]",
        "properties": {
          "accountType": "Standard_LRS"
@@ -637,7 +633,7 @@
      {
        "type": "Microsoft.KeyVault/vaults",
        "name": "[variables('clusterKeyVaultName')]",
-       "apiVersion": "[variables('apiVersionKeyVault')]",
+       "apiVersion": "[variables('apiVersionDefault')]",
        "location": "[variables('location')]",
        {{ if UseManagedIdentity}}
        "dependsOn": 
@@ -720,15 +716,7 @@
      },
  {{end}}
     {
-    {{if UserAssignedIDEnabled}}
-      "apiVersion": "[variables('apiVersionUserMSI')]",
-    {{else}}
-    {{if .MasterProfile.IsManagedDisks}}
-      "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
-    {{else}}
       "apiVersion": "[variables('apiVersionDefault')]",
-    {{end}}
-    {{end}}
       "copy": {
         "count": "[sub(variables('masterCount'), variables('masterOffset'))]",
         "name": "vmLoopNode"
@@ -817,7 +805,7 @@
               ,"name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-etcddisk')]"
               {{if .MasterProfile.IsStorageAccount}}
               ,"vhd": {
-                "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/', variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')),'-etcddisk.vhd')]"
+                "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionDefault')).primaryEndpoints.blob,'vhds/', variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')),'-etcddisk.vhd')]"
               }
               {{end}}
             }
@@ -839,7 +827,7 @@
 {{if .MasterProfile.IsStorageAccount}}
             ,"name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')),'-osdisk')]"
             ,"vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'vhds/',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')),'-osdisk.vhd')]"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('masterStorageAccountName')),variables('apiVersionDefault')).primaryEndpoints.blob,'vhds/',variables('masterVMNamePrefix'),copyIndex(variables('masterOffset')),'-osdisk.vhd')]"
             }
 {{end}}
 {{if ne .MasterProfile.OSDiskSizeGB 0}}
@@ -854,7 +842,7 @@
     {{if UseManagedIdentity}}
     {{if (not UserAssignedIDEnabled)}}
     {
-      "apiVersion": "2014-10-01-preview",
+      "apiVersion": "[variables('apiVersionDefault')]",
       "copy": {
          "count": "[variables('masterCount')]",
          "name": "vmLoopNode"
@@ -874,7 +862,7 @@
          "count": "[variables('masterCount')]",
          "name": "vmLoopNode"
        },
-       "apiVersion": "2015-05-01-preview",
+       "apiVersion": "[variables('apiVersionDefault')]",
        "location": "[resourceGroup().location]",
        {{if (not UserAssignedIDEnabled)}}
        "dependsOn": [

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -1,6 +1,6 @@
 {{if .MasterProfile.IsManagedDisks}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "location": "[variables('location')]",
       "name": "[variables('masterAvailabilitySet')]",
       "properties":
@@ -15,7 +15,7 @@
     },
 {{else if .MasterProfile.IsStorageAccount}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "location": "[variables('location')]",
       "name": "[variables('masterAvailabilitySet')]",
       "properties": {},
@@ -38,7 +38,7 @@
 {{end}}
 {{if not .MasterProfile.IsCustomVNET}}
 {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "dependsOn": [
 {{if RequireRouteTable}}
         "[concat('Microsoft.Network/routeTables/', variables('routeTableName'))]"{{if not IsOpenShift}},{{end}}
@@ -80,7 +80,7 @@
     },
 {{end}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "location": "[variables('location')]",
       "name": "[variables('nsgName')]",
       "properties": {
@@ -135,7 +135,7 @@
     },
 {{if RequireRouteTable}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "location": "[variables('location')]",
       "name": "[variables('routeTableName')]",
       "type": "Microsoft.Network/routeTables"
@@ -143,7 +143,7 @@
 {{end}}
 {{if not IsPrivateCluster}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "location": "[variables('location')]",
       "name": "[variables('masterPublicIPAddressName')]",
       "properties": {
@@ -155,7 +155,7 @@
       "type": "Microsoft.Network/publicIPAddresses"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
       ],
@@ -214,7 +214,7 @@
       "type": "Microsoft.Network/loadBalancers"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
         "count": "[sub(variables('masterCount'), variables('masterOffset'))]",
         "name": "masterLbLoopNode"
@@ -236,7 +236,7 @@
       "type": "Microsoft.Network/loadBalancers/inboundNatRules"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
         "count": "[sub(variables('masterCount'), variables('masterOffset'))]",
         "name": "nicLoopNode"
@@ -327,7 +327,7 @@
     },
 {{else}}
       {
-        "apiVersion": "[variables('apiVersionDefault')]",
+        "apiVersion": "[variables('apiVersionCompute')]",
         "copy": {
           "count": "[sub(variables('masterCount'), variables('masterOffset'))]",
           "name": "nicLoopNode"
@@ -412,7 +412,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('jumpboxVMName')]",
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "location": "[variables('location')]",
       "properties": {
           "osProfile": {
@@ -486,7 +486,7 @@
     {
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('jumpboxNetworkSecurityGroupName')]",
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "location": "[variables('location')]",
       "properties": {
           "securityRules": [
@@ -512,7 +512,7 @@
           "name": "Basic"
       },
       "name": "[variables('jumpboxPublicIpAddressName')]",
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "location": "[variables('location')]",
       "properties": {
           "dnsSettings": {
@@ -524,7 +524,7 @@
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('jumpboxNetworkInterfaceName')]",
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "location": "[variables('location')]",
       "properties": {
           "ipConfigurations": [
@@ -558,7 +558,7 @@
 {{end}}
 {{if gt .MasterProfile.Count 1}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "dependsOn": [
 {{if .MasterProfile.IsCustomVNET}}
         "[variables('nsgID')]"
@@ -635,7 +635,7 @@
      {
        "type": "Microsoft.KeyVault/vaults",
        "name": "[variables('clusterKeyVaultName')]",
-       "apiVersion": "[variables('apiVersionDefault')]",
+       "apiVersion": "[variables('apiVersionKeyVault')]",
        "location": "[variables('location')]",
        {{ if UseManagedIdentity}}
        "dependsOn": 
@@ -718,7 +718,7 @@
      },
  {{end}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
         "count": "[sub(variables('masterCount'), variables('masterOffset'))]",
         "name": "vmLoopNode"
@@ -844,7 +844,7 @@
     {{if UseManagedIdentity}}
     {{if (not UserAssignedIDEnabled)}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
          "count": "[variables('masterCount')]",
          "name": "vmLoopNode"
@@ -864,7 +864,7 @@
          "count": "[variables('masterCount')]",
          "name": "vmLoopNode"
        },
-       "apiVersion": "[variables('apiVersionDefault')]",
+       "apiVersion": "[variables('apiVersionCompute')]",
        "location": "[resourceGroup().location]",
        {{if (not UserAssignedIDEnabled)}}
        "dependsOn": [
@@ -889,7 +889,7 @@
      },
      {{end}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
         "count": "[sub(variables('masterCount'), variables('masterOffset'))]",
         "name": "vmLoopNode"
@@ -923,7 +923,7 @@
     ,{
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('masterVMNamePrefix'), copyIndex(variables('masterOffset')), '/computeAksLinuxBilling')]",
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
         "count": "[sub(variables('masterCount'), variables('masterOffset'))]",
         "name": "vmLoopNode"

--- a/parts/k8s/kubernetesmasterresources.t
+++ b/parts/k8s/kubernetesmasterresources.t
@@ -30,8 +30,8 @@
 {{end}}
       "location": "[variables('location')]",
       "name": "[variables('masterStorageAccountName')]",
-      "properties": {
-        "accountType": "[variables('vmSizesMap')[parameters('masterVMSize')].storageAccountType]"
+      "sku": {
+        "name": "[variables('vmSizesMap')[parameters('masterVMSize')].storageAccountType]"
       },
       "type": "Microsoft.Storage/storageAccounts"
     },
@@ -478,8 +478,8 @@
             "name": "[variables('jumpboxStorageAccountName')]",
             "apiVersion": "[variables('apiVersionStorage')]",
             "location": "[variables('location')]",
-            "properties": {
-                "accountType": "[variables('vmSizesMap')[parameters('jumpboxVMSize')].storageAccountType]"
+            "sku": {
+              "name": "[variables('vmSizesMap')[parameters('jumpboxVMSize')].storageAccountType]"
             }
     },
     {{end}}
@@ -628,9 +628,9 @@
        "name": "[variables('clusterKeyVaultName')]",
        "apiVersion": "[variables('apiVersionStorage')]",
        "location": "[variables('location')]",
-       "properties": {
-         "accountType": "Standard_LRS"
-       }
+       "sku": {
+        "name": "Standard_LRS"
+      }
      },
      {
        "type": "Microsoft.KeyVault/vaults",

--- a/parts/k8s/kubernetesmasterresourcesvmss.t
+++ b/parts/k8s/kubernetesmasterresourcesvmss.t
@@ -1,6 +1,6 @@
 {{if and UseManagedIdentity (not UserAssignedIDEnabled)}}
   {
-    "apiVersion": "[variables('apiVersionDefault')]",
+    "apiVersion": "[variables('apiVersionCompute')]",
     "name": "[guid(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('masterVMNamePrefix'), 'vmidentity'))]",
     "type": "Microsoft.Authorization/roleAssignments",
     "properties": {
@@ -22,7 +22,7 @@
   {
     "type": "Microsoft.KeyVault/vaults",
     "name": "[variables('clusterKeyVaultName')]",
-    "apiVersion": "[variables('apiVersionDefault')]",
+    "apiVersion": "[variables('apiVersionKeyVault')]",
     "location": "[variables('location')]",
     {{ if UseManagedIdentity}}
     "dependsOn": 
@@ -73,7 +73,7 @@
   },
 {{end}}
 {
-  "apiVersion": "[variables('apiVersionDefault')]",
+  "apiVersion": "[variables('apiVersionCompute')]",
   "location": "[variables('location')]",
   "name": "[variables('nsgName')]",
   "properties": {
@@ -128,7 +128,7 @@
 },
 {{if RequireRouteTable}}
 {
-  "apiVersion": "[variables('apiVersionDefault')]",
+  "apiVersion": "[variables('apiVersionCompute')]",
   "location": "[variables('location')]",
   "name": "[variables('routeTableName')]",
   "type": "Microsoft.Network/routeTables"
@@ -136,7 +136,7 @@
 {{end}}
 {{if not .MasterProfile.IsCustomVNET}}
 {
-  "apiVersion": "[variables('apiVersionDefault')]",
+  "apiVersion": "[variables('apiVersionCompute')]",
   "dependsOn": [
     {{if RequireRouteTable}}
     "[concat('Microsoft.Network/routeTables/', variables('routeTableName'))]",
@@ -186,7 +186,7 @@
 },
 {{end}}
 {
-  "apiVersion": "[variables('apiVersionDefault')]",
+  "apiVersion": "[variables('apiVersionCompute')]",
   "location": "[variables('location')]",
   "name": "[variables('masterPublicIPAddressName')]",
   "properties": {
@@ -208,7 +208,7 @@
     "type": "Microsoft.Network/loadBalancers",
     "name": "[variables('masterLbName')]",
     "location": "[variables('location')]",
-    "apiVersion": "[variables('apiVersionDefault')]",
+    "apiVersion": "[variables('apiVersionCompute')]",
     "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
     ],
@@ -282,7 +282,7 @@
     }
 },
 {
-    "apiVersion": "[variables('apiVersionDefault')]",
+    "apiVersion": "[variables('apiVersionCompute')]",
     "dependsOn": [
     {{if .MasterProfile.IsCustomVNET}}
       "[variables('nsgID')]"

--- a/parts/k8s/kubernetesmasterresourcesvmss.t
+++ b/parts/k8s/kubernetesmasterresourcesvmss.t
@@ -15,8 +15,8 @@
     "name": "[variables('clusterKeyVaultName')]",
     "apiVersion": "[variables('apiVersionStorage')]",
     "location": "[variables('location')]",
-    "properties": {
-      "accountType": "Standard_LRS"
+    "sku": {
+      "name": "Standard_LRS"
     }
   },
   {

--- a/parts/k8s/kubernetesmasterresourcesvmss.t
+++ b/parts/k8s/kubernetesmasterresourcesvmss.t
@@ -73,7 +73,7 @@
   },
 {{end}}
 {
-  "apiVersion": "[variables('apiVersionCompute')]",
+  "apiVersion": "[variables('apiVersionNetwork')]",
   "location": "[variables('location')]",
   "name": "[variables('nsgName')]",
   "properties": {
@@ -128,7 +128,7 @@
 },
 {{if RequireRouteTable}}
 {
-  "apiVersion": "[variables('apiVersionCompute')]",
+  "apiVersion": "[variables('apiVersionNetwork')]",
   "location": "[variables('location')]",
   "name": "[variables('routeTableName')]",
   "type": "Microsoft.Network/routeTables"
@@ -136,7 +136,7 @@
 {{end}}
 {{if not .MasterProfile.IsCustomVNET}}
 {
-  "apiVersion": "[variables('apiVersionCompute')]",
+  "apiVersion": "[variables('apiVersionNetwork')]",
   "dependsOn": [
     {{if RequireRouteTable}}
     "[concat('Microsoft.Network/routeTables/', variables('routeTableName'))]",
@@ -186,7 +186,7 @@
 },
 {{end}}
 {
-  "apiVersion": "[variables('apiVersionCompute')]",
+  "apiVersion": "[variables('apiVersionNetwork')]",
   "location": "[variables('location')]",
   "name": "[variables('masterPublicIPAddressName')]",
   "properties": {
@@ -208,7 +208,7 @@
     "type": "Microsoft.Network/loadBalancers",
     "name": "[variables('masterLbName')]",
     "location": "[variables('location')]",
-    "apiVersion": "[variables('apiVersionCompute')]",
+    "apiVersion": "[variables('apiVersionNetwork')]",
     "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
     ],

--- a/parts/k8s/kubernetesmasterresourcesvmss.t
+++ b/parts/k8s/kubernetesmasterresourcesvmss.t
@@ -13,7 +13,7 @@
   {
     "type": "Microsoft.Storage/storageAccounts",
     "name": "[variables('clusterKeyVaultName')]",
-    "apiVersion": "[variables('apiVersionDefault')]",
+    "apiVersion": "[variables('apiVersionStorage')]",
     "location": "[variables('location')]",
     "properties": {
       "accountType": "Standard_LRS"

--- a/parts/k8s/kubernetesmasterresourcesvmss.t
+++ b/parts/k8s/kubernetesmasterresourcesvmss.t
@@ -1,6 +1,6 @@
 {{if and UseManagedIdentity (not UserAssignedIDEnabled)}}
   {
-    "apiVersion": "2014-10-01-preview",
+    "apiVersion": "[variables('apiVersionDefault')]",
     "name": "[guid(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('masterVMNamePrefix'), 'vmidentity'))]",
     "type": "Microsoft.Authorization/roleAssignments",
     "properties": {
@@ -13,7 +13,7 @@
   {
     "type": "Microsoft.Storage/storageAccounts",
     "name": "[variables('clusterKeyVaultName')]",
-    "apiVersion": "[variables('apiVersionStorage')]",
+    "apiVersion": "[variables('apiVersionDefault')]",
     "location": "[variables('location')]",
     "properties": {
       "accountType": "Standard_LRS"
@@ -22,7 +22,7 @@
   {
     "type": "Microsoft.KeyVault/vaults",
     "name": "[variables('clusterKeyVaultName')]",
-    "apiVersion": "[variables('apiVersionKeyVault')]",
+    "apiVersion": "[variables('apiVersionDefault')]",
     "location": "[variables('location')]",
     {{ if UseManagedIdentity}}
     "dependsOn": 
@@ -186,7 +186,7 @@
 },
 {{end}}
 {
-  "apiVersion": "2018-04-01",
+  "apiVersion": "[variables('apiVersionDefault')]",
   "location": "[variables('location')]",
   "name": "[variables('masterPublicIPAddressName')]",
   "properties": {
@@ -208,7 +208,7 @@
     "type": "Microsoft.Network/loadBalancers",
     "name": "[variables('masterLbName')]",
     "location": "[variables('location')]",
-    "apiVersion": "2018-04-01",
+    "apiVersion": "[variables('apiVersionDefault')]",
     "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
     ],
@@ -282,7 +282,7 @@
     }
 },
 {
-    "apiVersion": "[variables('apiVersionVirtualMachineScaleSets')]",
+    "apiVersion": "[variables('apiVersionDefault')]",
     "dependsOn": [
     {{if .MasterProfile.IsCustomVNET}}
       "[variables('nsgID')]"

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -84,6 +84,7 @@
     "masterOffset": "[parameters('masterOffset')]",
 {{end}}
     "apiVersionDefault": "2018-06-01",
+    "apiVersionStorage": "2018-07-01",
     "locations": [
          "[resourceGroup().location]",
          "[parameters('location')]"
@@ -295,7 +296,7 @@
       ]
 {{end}}
 {{if .HasWindows}}
-    , "windowsCustomScriptSuffix": " $inputFile = '%SYSTEMDRIVE%\\AzureData\\CustomData.bin' ; $outputFile = '%SYSTEMDRIVE%\\AzureData\\CustomDataSetupScript.ps1' ; Copy-Item $inputFile $outputFile ; Invoke-Expression('{0} {1}' -f $outputFile, $arguments) ; "
+    ,"windowsCustomScriptSuffix": " $inputFile = '%SYSTEMDRIVE%\\AzureData\\CustomData.bin' ; $outputFile = '%SYSTEMDRIVE%\\AzureData\\CustomDataSetupScript.ps1' ; Copy-Item $inputFile $outputFile ; Invoke-Expression('{0} {1}' -f $outputFile, $arguments) ; "
 {{end}}
 {{if EnableEncryptionWithExternalKms}}
      ,"clusterKeyVaultName": "[take(concat('kv', tolower(uniqueString(concat(variables('masterFqdnPrefix'),variables('location'),parameters('nameSuffix'))))), 22)]"

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -86,6 +86,7 @@
     "apiVersionCompute": "2018-06-01",
     "apiVersionStorage": "2018-07-01",
     "apiVersionKeyVault": "2018-02-14",
+    "apiVersionNetwork": "2018-08-01",
     "locations": [
          "[resourceGroup().location]",
          "[parameters('location')]"

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -298,7 +298,7 @@
     , "windowsCustomScriptSuffix": " $inputFile = '%SYSTEMDRIVE%\\AzureData\\CustomData.bin' ; $outputFile = '%SYSTEMDRIVE%\\AzureData\\CustomDataSetupScript.ps1' ; Copy-Item $inputFile $outputFile ; Invoke-Expression('{0} {1}' -f $outputFile, $arguments) ; "
 {{end}}
 {{if EnableEncryptionWithExternalKms}}
-     "clusterKeyVaultName": "[take(concat('kv', tolower(uniqueString(concat(variables('masterFqdnPrefix'),variables('location'),parameters('nameSuffix'))))), 22)]"
+     ,"clusterKeyVaultName": "[take(concat('kv', tolower(uniqueString(concat(variables('masterFqdnPrefix'),variables('location'),parameters('nameSuffix'))))), 22)]"
 {{else}}
     ,"clusterKeyVaultName": ""
 {{end}}

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -83,8 +83,7 @@
     "masterCount": {{.MasterProfile.Count}},
     "masterOffset": "[parameters('masterOffset')]",
 {{end}}
-    "apiVersionDefault": "2016-03-30",
-    "apiVersionLinkDefault": "2015-01-01",
+    "apiVersionDefault": "2018-06-01",
     "locations": [
          "[resourceGroup().location]",
          "[parameters('location')]"
@@ -104,7 +103,6 @@
     "sshKeyPath": "[concat('/home/',parameters('linuxAdminUsername'),'/.ssh/authorized_keys')]",
 
 {{if .HasStorageAccountDisks}}
-    "apiVersionStorage": "2015-06-15",
     "maxVMsPerStorageAccount": 20,
     "maxStorageAccountsPerAgent": "[div(variables('maxVMsPerPool'),variables('maxVMsPerStorageAccount'))]",
     "dataStorageAccountPrefixSeed": 97,
@@ -116,15 +114,6 @@
 {{else}}
     "storageAccountPrefixes": [],
     "storageAccountBaseName": "",
-{{end}}
-{{if UserAssignedIDEnabled}}
-    "apiVersionUserMSI": "2018-06-01",
-{{end}}
-{{if .HasManagedDisks}}
-    "apiVersionStorageManagedDisks": "2016-04-30-preview",
-{{end}}
-{{if .HasVMSSAgentPool}}
-    "apiVersionVirtualMachineScaleSets": "2017-12-01",
 {{end}}
 {{if not IsHostedMaster}}
   {{if .MasterProfile.IsStorageAccount}}
@@ -309,10 +298,6 @@
     , "windowsCustomScriptSuffix": " $inputFile = '%SYSTEMDRIVE%\\AzureData\\CustomData.bin' ; $outputFile = '%SYSTEMDRIVE%\\AzureData\\CustomDataSetupScript.ps1' ; Copy-Item $inputFile $outputFile ; Invoke-Expression('{0} {1}' -f $outputFile, $arguments) ; "
 {{end}}
 {{if EnableEncryptionWithExternalKms}}
-     ,"apiVersionKeyVault": "2016-10-01",
-     {{if not .HasStorageAccountDisks}}
-     "apiVersionStorage": "2015-06-15",
-     {{end}}
      "clusterKeyVaultName": "[take(concat('kv', tolower(uniqueString(concat(variables('masterFqdnPrefix'),variables('location'),parameters('nameSuffix'))))), 22)]"
 {{else}}
     ,"clusterKeyVaultName": ""

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -83,8 +83,9 @@
     "masterCount": {{.MasterProfile.Count}},
     "masterOffset": "[parameters('masterOffset')]",
 {{end}}
-    "apiVersionDefault": "2018-06-01",
+    "apiVersionCompute": "2018-06-01",
     "apiVersionStorage": "2018-07-01",
+    "apiVersionKeyVault": "2018-02-14",
     "locations": [
          "[resourceGroup().location]",
          "[parameters('location')]"

--- a/parts/k8s/kubernetesmastervarsvmss.t
+++ b/parts/k8s/kubernetesmastervarsvmss.t
@@ -76,6 +76,7 @@
     "masterIpAddressCount": {{.MasterProfile.IPAddressCount}},
 {{end}}
     "apiVersionDefault": "2018-06-01",
+    "apiVersionStorage": "2018-07-01",
     "locations": [
          "[resourceGroup().location]",
          "[parameters('location')]"
@@ -263,7 +264,7 @@
       ]
 {{end}}
 {{if .HasWindows}}
-    , "windowsCustomScriptSuffix": " $inputFile = '%SYSTEMDRIVE%\\AzureData\\CustomData.bin' ; $outputFile = '%SYSTEMDRIVE%\\AzureData\\CustomDataSetupScript.ps1' ; Copy-Item $inputFile $outputFile ; Invoke-Expression('{0} {1}' -f $outputFile, $arguments) ; "
+    ,"windowsCustomScriptSuffix": " $inputFile = '%SYSTEMDRIVE%\\AzureData\\CustomData.bin' ; $outputFile = '%SYSTEMDRIVE%\\AzureData\\CustomDataSetupScript.ps1' ; Copy-Item $inputFile $outputFile ; Invoke-Expression('{0} {1}' -f $outputFile, $arguments) ; "
 {{end}}
 {{if EnableEncryptionWithExternalKms}}
     ,"clusterKeyVaultName": "[take(concat('kv', tolower(uniqueString(concat(variables('masterFqdnPrefix'),variables('location'),parameters('nameSuffix'))))), 22)]"

--- a/parts/k8s/kubernetesmastervarsvmss.t
+++ b/parts/k8s/kubernetesmastervarsvmss.t
@@ -266,7 +266,7 @@
     , "windowsCustomScriptSuffix": " $inputFile = '%SYSTEMDRIVE%\\AzureData\\CustomData.bin' ; $outputFile = '%SYSTEMDRIVE%\\AzureData\\CustomDataSetupScript.ps1' ; Copy-Item $inputFile $outputFile ; Invoke-Expression('{0} {1}' -f $outputFile, $arguments) ; "
 {{end}}
 {{if EnableEncryptionWithExternalKms}}
-     "clusterKeyVaultName": "[take(concat('kv', tolower(uniqueString(concat(variables('masterFqdnPrefix'),variables('location'),parameters('nameSuffix'))))), 22)]"
+    ,"clusterKeyVaultName": "[take(concat('kv', tolower(uniqueString(concat(variables('masterFqdnPrefix'),variables('location'),parameters('nameSuffix'))))), 22)]"
 {{else}}
     ,"clusterKeyVaultName": ""
 {{end}}

--- a/parts/k8s/kubernetesmastervarsvmss.t
+++ b/parts/k8s/kubernetesmastervarsvmss.t
@@ -75,8 +75,9 @@
     "masterOffset": "",
     "masterIpAddressCount": {{.MasterProfile.IPAddressCount}},
 {{end}}
-    "apiVersionDefault": "2018-06-01",
+    "apiVersionCompute": "2018-06-01",
     "apiVersionStorage": "2018-07-01",
+    "apiVersionKeyVault": "2018-02-14",
     "locations": [
          "[resourceGroup().location]",
          "[parameters('location')]"

--- a/parts/k8s/kubernetesmastervarsvmss.t
+++ b/parts/k8s/kubernetesmastervarsvmss.t
@@ -75,8 +75,7 @@
     "masterOffset": "",
     "masterIpAddressCount": {{.MasterProfile.IPAddressCount}},
 {{end}}
-    "apiVersionDefault": "2016-03-30",
-    "apiVersionLinkDefault": "2015-01-01",
+    "apiVersionDefault": "2018-06-01",
     "locations": [
          "[resourceGroup().location]",
          "[parameters('location')]"
@@ -95,7 +94,6 @@
     "sshKeyPath": "[concat('/home/',parameters('linuxAdminUsername'),'/.ssh/authorized_keys')]",
 
 {{if .HasStorageAccountDisks}}
-    "apiVersionStorage": "2015-06-15",
     "maxVMsPerStorageAccount": 20,
     "maxStorageAccountsPerAgent": "[div(variables('maxVMsPerPool'),variables('maxVMsPerStorageAccount'))]",
     "dataStorageAccountPrefixSeed": 97,
@@ -108,13 +106,6 @@
     "storageAccountPrefixes": [],
     "storageAccountBaseName": "",
 {{end}}
-{{if UserAssignedIDEnabled}}
-    "apiVersionUserMSI": "2018-06-01",
-{{end}}
-{{if .HasManagedDisks}}
-    "apiVersionStorageManagedDisks": "2016-04-30-preview",
-{{end}}
-    "apiVersionVirtualMachineScaleSets": "2017-12-01",
 {{if not IsHostedMaster}}
   {{if .MasterProfile.IsStorageAccount}}
     "masterStorageAccountName": "[concat(variables('storageAccountBaseName'), 'mstr0')]",
@@ -275,10 +266,6 @@
     , "windowsCustomScriptSuffix": " $inputFile = '%SYSTEMDRIVE%\\AzureData\\CustomData.bin' ; $outputFile = '%SYSTEMDRIVE%\\AzureData\\CustomDataSetupScript.ps1' ; Copy-Item $inputFile $outputFile ; Invoke-Expression('{0} {1}' -f $outputFile, $arguments) ; "
 {{end}}
 {{if EnableEncryptionWithExternalKms}}
-     ,"apiVersionKeyVault": "2016-10-01",
-     {{if not .HasStorageAccountDisks}}
-     "apiVersionStorage": "2015-06-15",
-     {{end}}
      "clusterKeyVaultName": "[take(concat('kv', tolower(uniqueString(concat(variables('masterFqdnPrefix'),variables('location'),parameters('nameSuffix'))))), 22)]"
 {{else}}
     ,"clusterKeyVaultName": ""

--- a/parts/k8s/kubernetesmastervarsvmss.t
+++ b/parts/k8s/kubernetesmastervarsvmss.t
@@ -78,6 +78,7 @@
     "apiVersionCompute": "2018-06-01",
     "apiVersionStorage": "2018-07-01",
     "apiVersionKeyVault": "2018-02-14",
+    "apiVersionNetwork": "2018-08-01",
     "locations": [
          "[resourceGroup().location]",
          "[parameters('location')]"

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -91,8 +91,8 @@
       {{end}}
       "location": "[variables('location')]",
       "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName'))]",
-      "properties": {
-        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+      "sku": {
+        "name": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
       },
       "type": "Microsoft.Storage/storageAccounts"
     },
@@ -112,8 +112,8 @@
       {{end}}
       "location": "[variables('location')]",
       "name": "[concat(variables('storageAccountPrefixes')[mod(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(copyIndex(variables('dataStorageAccountPrefixSeed')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}DataAccountName'))]",
-      "properties": {
-        "accountType": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
+      "sku": {
+        "name": "[variables('vmSizesMap')[variables('{{.Name}}VMSize')].storageAccountType]"
       },
       "type": "Microsoft.Storage/storageAccounts"
     },

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -1,6 +1,6 @@
 {{if HasWindowsCustomImage}}
     {"type": "Microsoft.Compute/images",
-      "apiVersion": "2017-12-01",
+      "apiVersion": "[variables('apiVersionDefault')]",
       "name": "{{.Name}}CustomWindowsImage",
       "location": "[variables('location')]",
       "properties": {
@@ -69,7 +69,7 @@
    {
       "location": "[variables('location')]",
       "name": "[variables('{{.Name}}AvailabilitySet')]",
-      "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
+      "apiVersion": "[variables('apiVersionDefault')]",
       "properties":
         {
             "platformFaultDomainCount": 2,
@@ -81,7 +81,7 @@
     },
 {{else if .IsStorageAccount}}
     {
-      "apiVersion": "[variables('apiVersionStorage')]",
+      "apiVersion": "[variables('apiVersionDefault')]",
       "copy": {
         "count": "[variables('{{.Name}}StorageAccountsCount')]",
         "name": "loop"
@@ -102,7 +102,7 @@
     },
     {{if .HasDisks}}
     {
-      "apiVersion": "[variables('apiVersionStorage')]",
+      "apiVersion": "[variables('apiVersionDefault')]",
       "copy": {
         "count": "[variables('{{.Name}}StorageAccountsCount')]",
         "name": "datadiskLoop"
@@ -131,11 +131,7 @@
     },
 {{end}}
     {
-      {{if .IsManagedDisks}}
-        "apiVersion": "[variables('apiVersionStorageManagedDisks')]",
-      {{else}}
-        "apiVersion": "[variables('apiVersionDefault')]",
-      {{end}}
+      "apiVersion": "[variables('apiVersionDefault')]",
       "copy": {
         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "vmLoopNode"
@@ -203,7 +199,7 @@
 {{if .IsStorageAccount}}
             ,"name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')),'-osdisk')]"
             ,"vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-osdisk.vhd')]"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionDefault')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-osdisk.vhd')]"
             }
 {{end}}
 {{if ne .OSDiskSizeGB 0}}
@@ -216,7 +212,7 @@
     },
     {{if UseManagedIdentity}}
     {
-      "apiVersion": "2014-10-01-preview",
+      "apiVersion": "[variables('apiVersionDefault')]",
       "copy": {
          "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
          "name": "vmLoopNode"
@@ -235,7 +231,7 @@
           "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
           "name": "vmLoopNode"
         },
-        "apiVersion": "2015-05-01-preview",
+        "apiVersion": "[variables('apiVersionDefault')]",
         "location": "[resourceGroup().location]",
         "dependsOn": [
           "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -81,7 +81,7 @@
     },
 {{else if .IsStorageAccount}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionStorage')]",
       "copy": {
         "count": "[variables('{{.Name}}StorageAccountsCount')]",
         "name": "loop"
@@ -102,7 +102,7 @@
     },
     {{if .HasDisks}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionStorage')]",
       "copy": {
         "count": "[variables('{{.Name}}StorageAccountsCount')]",
         "name": "datadiskLoop"
@@ -199,7 +199,7 @@
 {{if .IsStorageAccount}}
             ,"name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')),'-osdisk')]"
             ,"vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionDefault')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-osdisk.vhd')]"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/',variables('storageAccountPrefixes')[mod(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(div(copyIndex(variables('{{.Name}}Offset')),variables('maxVMsPerStorageAccount')),variables('{{.Name}}StorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('{{.Name}}AccountName')),variables('apiVersionStorage')).primaryEndpoints.blob,'osdisk/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '-osdisk.vhd')]"
             }
 {{end}}
 {{if ne .OSDiskSizeGB 0}}

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -1,6 +1,6 @@
 {{if HasWindowsCustomImage}}
     {"type": "Microsoft.Compute/images",
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "name": "{{.Name}}CustomWindowsImage",
       "location": "[variables('location')]",
       "properties": {
@@ -16,11 +16,7 @@
     },
 {{end}}
     {
-      {{if .AcceleratedNetworkingEnabled}}
-      "apiVersion": "2018-04-01",
-      {{else}}
-      "apiVersion": "[variables('apiVersionDefault')]",
-      {{end}}
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "loop"
@@ -69,7 +65,7 @@
    {
       "location": "[variables('location')]",
       "name": "[variables('{{.Name}}AvailabilitySet')]",
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "properties":
         {
             "platformFaultDomainCount": 2,
@@ -125,13 +121,13 @@
     {
       "location": "[variables('location')]",
       "name": "[variables('{{.Name}}AvailabilitySet')]",
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "properties": {},
       "type": "Microsoft.Compute/availabilitySets"
     },
 {{end}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "vmLoopNode"
@@ -212,7 +208,7 @@
     },
     {{if UseManagedIdentity}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
          "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
          "name": "vmLoopNode"
@@ -231,7 +227,7 @@
           "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
           "name": "vmLoopNode"
         },
-        "apiVersion": "[variables('apiVersionDefault')]",
+        "apiVersion": "[variables('apiVersionCompute')]",
         "location": "[resourceGroup().location]",
         "dependsOn": [
           "[concat('Microsoft.Compute/virtualMachines/', variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')))]",
@@ -250,7 +246,7 @@
       },
      {{end}}
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "vmLoopNode"
@@ -280,7 +276,7 @@
     ,{
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('{{.Name}}VMNamePrefix'), copyIndex(variables('{{.Name}}Offset')), '/computeAksLinuxBilling')]",
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "[variables('apiVersionCompute')]",
       "copy": {
         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "vmLoopNode"

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -16,7 +16,7 @@
     },
 {{end}}
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "[variables('apiVersionNetwork')]",
       "copy": {
         "count": "[sub(variables('{{.Name}}Count'), variables('{{.Name}}Offset'))]",
         "name": "loop"

--- a/parts/k8s/kuberneteswinagentresourcesvmas.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmas.t
@@ -69,10 +69,11 @@
       "properties":
         {
             "platformFaultDomainCount": 2,
-            "platformUpdateDomainCount": 3,
-		        "managed" : "true"
+            "platformUpdateDomainCount": 3
         },
-
+      "sku": {
+        "name": "Aligned"
+      },
       "type": "Microsoft.Compute/availabilitySets"
     },
 {{else if .IsStorageAccount}}

--- a/parts/k8s/kuberneteswinagentresourcesvmss.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmss.t
@@ -1,6 +1,6 @@
 {{if UseManagedIdentity}}
   {
-    "apiVersion": "[variables('apiVersionDefault')]",
+    "apiVersion": "[variables('apiVersionCompute')]",
     "name": "[guid(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}VMNamePrefix'), 'vmidentity'))]",
     "type": "Microsoft.Authorization/roleAssignments",
     "properties": {
@@ -10,7 +10,7 @@
   },
 {{end}}
   {
-    "apiVersion": "[variables('apiVersionDefault')]",
+    "apiVersion": "[variables('apiVersionCompute')]",
     "dependsOn": [
     {{if .IsCustomVNET}}
       "[variables('nsgID')]"

--- a/parts/k8s/kuberneteswinagentresourcesvmss.t
+++ b/parts/k8s/kuberneteswinagentresourcesvmss.t
@@ -1,6 +1,6 @@
 {{if UseManagedIdentity}}
   {
-    "apiVersion": "2014-10-01-preview",
+    "apiVersion": "[variables('apiVersionDefault')]",
     "name": "[guid(concat('Microsoft.Compute/virtualMachineScaleSets/', variables('{{.Name}}VMNamePrefix'), 'vmidentity'))]",
     "type": "Microsoft.Authorization/roleAssignments",
     "properties": {
@@ -10,7 +10,7 @@
   },
 {{end}}
   {
-    "apiVersion": "[variables('apiVersionVirtualMachineScaleSets')]",
+    "apiVersion": "[variables('apiVersionDefault')]",
     "dependsOn": [
     {{if .IsCustomVNET}}
       "[variables('nsgID')]"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Update the default api version to 2018-06-01 (the most recent one used in the code, for managed identity) and use the default in k8s templates instead of having different hardcoded versions for each feature that needs a more recent api version. This change will need to be tested carefully to make sure that we don't regress any features. However, I expect that it won't be as big of an api version jump as it seems since most resources were already using a 2018 api version (2018-04-01) for accelerated networking (on by default).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3835 

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
