### PR TITLE
Search domain improvements

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -540,6 +540,7 @@ A cluster can have 0 to 12 agent pool profiles. Agent Pool Profiles are used for
 | customSearchDomain.name          | no       | describes the search domain to be used on all linux clusters                                                                                                                     |
 | customSearchDomain.realmUser     | no       | describes the realm user with permissions to update dns registries on Windows Server DNS                                                                                         |
 | customSearchDomain.realmPassword | no       | describes the realm user password to update dns registries on Windows Server DNS                                                                                                 |
+| customSearchDomain.computerOU | no       | optional OU path to register acs-engine machines into Windows Server DNS                                                                                                 |
 | customNodesDNS.dnsServer         | no       | describes the IP address of the DNS Server                                                                                                                                       |
 
 #### secrets

--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -207,6 +207,7 @@ AGENT_ARTIFACTS_CONFIG_PLACEHOLDER
     sed -i "s|<searchDomainName>|{{WrapAsParameter "searchDomainName"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
     sed -i "s|<searchDomainRealmUser>|{{WrapAsParameter "searchDomainRealmUser"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
     sed -i "s|<searchDomainRealmPassword>|{{WrapAsParameter "searchDomainRealmPassword"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
+    sed -i "s|<searchDomainComputerOU>|{{WrapAsParameter "searchDomainComputerOU"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"    
 {{end}}
 
 - path: "/opt/azure/containers/provision.sh"

--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -207,7 +207,7 @@ AGENT_ARTIFACTS_CONFIG_PLACEHOLDER
     sed -i "s|<searchDomainName>|{{WrapAsParameter "searchDomainName"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
     sed -i "s|<searchDomainRealmUser>|{{WrapAsParameter "searchDomainRealmUser"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
     sed -i "s|<searchDomainRealmPassword>|{{WrapAsParameter "searchDomainRealmPassword"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
-    sed -i "s|<searchDomainComputerOU>|{{WrapAsParameter "searchDomainComputerOU"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"    
+    sed -i "s|<searchDomainComputerOU>|{{WrapAsParameter "searchDomainComputerOU"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
 {{end}}
 
 - path: "/opt/azure/containers/provision.sh"

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -380,6 +380,7 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
     sed -i "s|<searchDomainName>|{{WrapAsParameter "searchDomainName"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
     sed -i "s|<searchDomainRealmUser>|{{WrapAsParameter "searchDomainRealmUser"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
     sed -i "s|<searchDomainRealmPassword>|{{WrapAsParameter "searchDomainRealmPassword"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
+    sed -i "s|<searchDomainComputerOU>|{{WrapAsParameter "searchDomainComputerOU"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"    
 {{end}}
 {{if .OrchestratorProfile.KubernetesConfig.IsContainerMonitoringEnabled}}
     sed -i "s|<omsAgentVersion>|{{WrapAsParameter "omsAgentVersion"}}|g" "/etc/kubernetes/addons/omsagent-daemonset.yaml"

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -380,7 +380,7 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
     sed -i "s|<searchDomainName>|{{WrapAsParameter "searchDomainName"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
     sed -i "s|<searchDomainRealmUser>|{{WrapAsParameter "searchDomainRealmUser"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
     sed -i "s|<searchDomainRealmPassword>|{{WrapAsParameter "searchDomainRealmPassword"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
-    sed -i "s|<searchDomainComputerOU>|{{WrapAsParameter "searchDomainComputerOU"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"    
+    sed -i "s|<searchDomainComputerOU>|{{WrapAsParameter "searchDomainComputerOU"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
 {{end}}
 {{if .OrchestratorProfile.KubernetesConfig.IsContainerMonitoringEnabled}}
     sed -i "s|<omsAgentVersion>|{{WrapAsParameter "omsAgentVersion"}}|g" "/etc/kubernetes/addons/omsagent-daemonset.yaml"

--- a/parts/k8s/kubernetesmastercustomdatavmss.yml
+++ b/parts/k8s/kubernetesmastercustomdatavmss.yml
@@ -382,6 +382,7 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
     sed -i "s|<searchDomainName>|{{WrapAsParameter "searchDomainName"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
     sed -i "s|<searchDomainRealmUser>|{{WrapAsParameter "searchDomainRealmUser"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
     sed -i "s|<searchDomainRealmPassword>|{{WrapAsParameter "searchDomainRealmPassword"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
+    sed -i "s|<searchDomainComputerOU>|{{WrapAsParameter "searchDomainComputerOU"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
 {{end}}
 {{if .OrchestratorProfile.KubernetesConfig.IsContainerMonitoringEnabled}}
     sed -i "s|<omsAgentVersion>|{{WrapAsParameter "omsAgentVersion"}}|g" "/etc/kubernetes/addons/omsagent-daemonset.yaml"

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -928,6 +928,13 @@
         "description": "Windows server AD user password to join the Linux Machines with active directory and be able to change dns registries."
       },
       "type": "securestring"
+    },
+    "searchDomainComputerOU": {
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional OU path to register acs-engine machines into Windows Server DNS"
+      },
+      "type": "string"
     }
 {{end}}
 {{if HasCustomNodesDNS}}

--- a/parts/k8s/setup-custom-search-domains.sh
+++ b/parts/k8s/setup-custom-search-domains.sh
@@ -23,7 +23,6 @@ retrycmd_if_failure 10 5 120 apt-get -y install \
   sssd-tools \
   samba-common \
   samba \
-  samba-common \
   python2.7 \
   samba-libs \
   packagekit

--- a/parts/k8s/setup-custom-search-domains.sh
+++ b/parts/k8s/setup-custom-search-domains.sh
@@ -2,7 +2,31 @@
 set -x
 source /opt/azure/containers/provision_source.sh
 
-sudo echo "  dns-search <searchDomainName>" >> /etc/network/interfaces.d/50-cloud-init.cfg
+sdName="<searchDomainName>"
+sdRealmUser=$"<searchDomainRealmUser>"
+sdRealmPassword=$"<searchDomainRealmPassword>"
+sdComputerOU=$"<searchDomainComputerOU>"
+ucDomainName=$(echo "${sdName}" | tr /a-z/ /A-Z/)
+
+computerOUSwitch=""
+if [[ ! -z "${sdComputerOU}" ]]; then
+  computerOUSwitch="--computer-ou ${sdComputerOU}"
+fi
+
+echo "  dns-search ${sdName}" >> /etc/network/interfaces.d/50-cloud-init.cfg
 systemctl_restart 20 5 10 restart networking
-retrycmd_if_failure 10 5 120 apt-get -y install realmd sssd sssd-tools samba-common samba samba-common python2.7 samba-libs packagekit
-echo "<searchDomainRealmPassword>" | realm join -U <searchDomainRealmUser>@`echo "<searchDomainName>" | tr /a-z/ /A-Z/` `echo "<searchDomainName>" | tr /a-z/ /A-Z/`
+
+retrycmd_if_failure 10 5 120 apt-get update
+retrycmd_if_failure 10 5 120 apt-get -y install \
+  realmd \
+  sssd \
+  sssd-tools \
+  samba-common \
+  samba \
+  samba-common \
+  python2.7 \
+  samba-libs \
+  packagekit
+
+echo "${sdRealmPassword}" | \
+  realm join -U "${sdRealmUser}@${ucDomainName}" ${ucDomainName} ${computerOUSwitch}

--- a/parts/k8s/setup-custom-search-domains.sh
+++ b/parts/k8s/setup-custom-search-domains.sh
@@ -10,7 +10,7 @@ ucDomainName=$(echo "${sdName}" | tr /a-z/ /A-Z/)
 
 computerOUSwitch=""
 if [[ ! -z "${sdComputerOU}" ]]; then
-  computerOUSwitch="--computer-ou ${sdComputerOU}"
+  computerOUSwitch="--computer-ou='${sdComputerOU}'"
 fi
 
 echo "  dns-search ${sdName}" >> /etc/network/interfaces.d/50-cloud-init.cfg

--- a/parts/k8s/setup-custom-search-domains.sh
+++ b/parts/k8s/setup-custom-search-domains.sh
@@ -5,7 +5,7 @@ source /opt/azure/containers/provision_source.sh
 sdName="<searchDomainName>"
 sdRealmUser=$"<searchDomainRealmUser>"
 sdRealmPassword=$"<searchDomainRealmPassword>"
-sdComputerOU=$"<searchDomainComputerOU>"
+sdComputerOU="<searchDomainComputerOU>"
 ucDomainName=$(echo "${sdName}" | tr /a-z/ /A-Z/)
 
 computerOUSwitch=""
@@ -14,7 +14,7 @@ if [[ ! -z "${sdComputerOU}" ]]; then
 fi
 
 echo "  dns-search ${sdName}" >> /etc/network/interfaces.d/50-cloud-init.cfg
-systemctl_restart 20 5 10 restart networking
+systemctl_restart 20 5 10 networking
 
 retrycmd_if_failure 10 5 120 apt-get update
 retrycmd_if_failure 10 5 120 apt-get -y install \
@@ -27,5 +27,5 @@ retrycmd_if_failure 10 5 120 apt-get -y install \
   samba-libs \
   packagekit
 
-echo "${sdRealmPassword}" | \
-  realm join -U "${sdRealmUser}@${ucDomainName}" ${ucDomainName} ${computerOUSwitch}
+  realmCommand="realm join -U ${sdRealmUser}@${ucDomainName} ${ucDomainName} ${computerOUSwitch}"
+  eval "echo \"${sdRealmPassword}\" | ${realmCommand}"

--- a/pkg/acsengine/params.go
+++ b/pkg/acsengine/params.go
@@ -43,6 +43,7 @@ func getParameters(cs *api.ContainerService, generatorCode string, acsengineVers
 		addValue(parametersMap, "searchDomainName", properties.LinuxProfile.CustomSearchDomain.Name)
 		addValue(parametersMap, "searchDomainRealmUser", properties.LinuxProfile.CustomSearchDomain.RealmUser)
 		addValue(parametersMap, "searchDomainRealmPassword", properties.LinuxProfile.CustomSearchDomain.RealmPassword)
+		addValue(parametersMap, "searchDomainComputerOU", properties.LinuxProfile.CustomSearchDomain.ComputerOU)
 	}
 	if properties.LinuxProfile.CustomNodesDNS != nil {
 		addValue(parametersMap, "dnsServer", properties.LinuxProfile.CustomNodesDNS.DNSServer)

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -560,6 +560,7 @@ func convertLinuxProfileToVLabs(obj *LinuxProfile, vlabsProfile *vlabs.LinuxProf
 		vlabsProfile.CustomSearchDomain.Name = obj.CustomSearchDomain.Name
 		vlabsProfile.CustomSearchDomain.RealmUser = obj.CustomSearchDomain.RealmUser
 		vlabsProfile.CustomSearchDomain.RealmPassword = obj.CustomSearchDomain.RealmPassword
+		vlabsProfile.CustomSearchDomain.ComputerOU = obj.CustomSearchDomain.ComputerOU
 	}
 
 	if obj.CustomNodesDNS != nil {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -484,6 +484,7 @@ func convertVLabsLinuxProfile(vlabs *vlabs.LinuxProfile, api *LinuxProfile) {
 		api.CustomSearchDomain.Name = vlabs.CustomSearchDomain.Name
 		api.CustomSearchDomain.RealmUser = vlabs.CustomSearchDomain.RealmUser
 		api.CustomSearchDomain.RealmPassword = vlabs.CustomSearchDomain.RealmPassword
+		api.CustomSearchDomain.ComputerOU = vlabs.CustomSearchDomain.ComputerOU
 	}
 
 	if vlabs.CustomNodesDNS != nil {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -169,6 +169,7 @@ type CustomSearchDomain struct {
 	Name          string `json:"name,omitempty"`
 	RealmUser     string `json:"realmUser,omitempty"`
 	RealmPassword string `json:"realmPassword,omitempty"`
+	ComputerOU    string `json:"computerOU,omitempty"`
 }
 
 // CustomNodesDNS represents the Search Domain when the custom vnet for a custom DNS as a nameserver.

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -141,6 +141,7 @@ type CustomSearchDomain struct {
 	Name          string `json:"name,omitempty"`
 	RealmUser     string `json:"realmUser,omitempty"`
 	RealmPassword string `json:"realmPassword,omitempty"`
+	ComputerOU    string `json:"computerOU,omitempty"`
 }
 
 // CustomNodesDNS represents the Search Domain


### PR DESCRIPTION
**What this PR does / why we need it**:

As noted in #3737, I was unable to get this feature working out of the box without:

- FEATURE: addition of computerOU switch to the realm command so that machines can join into a specific OU path in Active Directory
- BUGFIX: addition of `apt-get update` before custom search domain packages are installed
- BUGFIX: fix custom search domain sed replacement in acs-engine/parts/k8s/kubernetesagentcustomdata.yml (not yet working)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes #3737

**Special notes for your reviewer**:

**If applicable**:
- [x] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- FEATURE: addition of computerOU switch to the realm command so that machines can join into a specific OU path in Active Directory
- BUGFIX: addition of `apt-get update` before custom search domain packages are installed
- BUGFIX: fix custom search domain sed replacement in acs-engine/parts/k8s/kubernetesagentcustomdata.yml (not yet working)
```