### PR TITLE
[WIP]Helper method to escape special characters in bash

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -156,3 +156,34 @@ func GetHomeDir() string {
 	}
 	return os.Getenv("HOME")
 }
+
+// BashEscapeString safely escapes strings with bash-specific special characters.
+func BashEscapeString(s string) string {
+	if runtime.GOOS == "windows" || s == "" {
+		return s
+	}
+
+	// If no single quotes, just wrap the entire string within single quotes
+	if strings.Index(s, "'") < 0 {
+		return "'" + s + "'"
+	}
+
+	// If string has single quotes, we would need to do some magic escaping
+	temp := s
+	var arr []string
+	for {
+		idx := strings.Index(temp, "'")
+		if idx < 0 {
+			break
+		}
+		arr = append(arr, `'`+temp[:idx]+`'`)
+		arr = append(arr, `"'"`)
+		temp = temp[idx+1:]
+	}
+
+	if len(temp) > 0 {
+		arr = append(arr, temp)
+	}
+
+	return strings.Join(arr, "")
+}


### PR DESCRIPTION
This PR adds a utility method to escape special chars in bash. Normally we'd get around this by wrapping the string in single quotes. The utility method handles the edge cases where we need to single-quote-wrap strings with single quotes.