### PR TITLE
Stop ginkgo tests after first failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ ifneq ($(GIT_BASEDIR),)
 endif
 
 test: generate
-	ginkgo -skipPackage test/e2e/dcos,test/e2e/kubernetes,test/e2e/openshift -r .
+	ginkgo -skipPackage test/e2e/dcos,test/e2e/kubernetes,test/e2e/openshift -failFast -r .
 
 .PHONY: test-style
 test-style:

--- a/scripts/ginkgo.coverage.sh
+++ b/scripts/ginkgo.coverage.sh
@@ -25,8 +25,8 @@ hash goveralls 2>/dev/null || go get github.com/mattn/goveralls
 hash godir 2>/dev/null || go get github.com/Masterminds/godir
 
 generate_cover_data() {
-  ginkgo -skipPackage test/e2e/dcos,test/e2e/kubernetes,test/e2e/openshift -cover -r .
-  echo "" > ${coveragetxt}  
+  ginkgo -skipPackage test/e2e/dcos,test/e2e/kubernetes,test/e2e/openshift -failFast -cover -r .
+  echo "" > ${coveragetxt}
   find . -type f -name "*.coverprofile" | while read -r file;  do cat $file >> ${coveragetxt} && mv $file ${coverdir}; done
   echo "mode: $covermode" >"$profile"
   grep -h -v "^mode:" "$coverdir"/*.coverprofile >>"$profile"

--- a/test/e2e/runner/ginkgo.go
+++ b/test/e2e/runner/ginkgo.go
@@ -36,9 +36,9 @@ func (g *Ginkgo) Run() error {
 	testDir := fmt.Sprintf("test/e2e/%s", g.Config.Orchestrator)
 	var cmd *exec.Cmd
 	if g.Config.GinkgoFocus != "" {
-		cmd = exec.Command("ginkgo", "-slowSpecThreshold", "180", "-r", "-v", "--focus", g.Config.GinkgoFocus, testDir)
+		cmd = exec.Command("ginkgo", "-slowSpecThreshold", "180", "-failFast", "-r", "-v", "--focus", g.Config.GinkgoFocus, testDir)
 	} else {
-		cmd = exec.Command("ginkgo", "-slowSpecThreshold", "180", "-r", "-v", testDir)
+		cmd = exec.Command("ginkgo", "-slowSpecThreshold", "180", "-failFast", "-r", "-v", testDir)
 	}
 	util.PrintCommand(cmd)
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
In some environments, each e2e spec can wait for a timeout before failing, which can make the overall test suite take a long time before it returns an overall failure. This tells `ginkgo` to bail after the first red flag instead.

The tradeoff here is speed versus potentially gaining more knowledge about the overall set of failed test cases. That's usually been the right tradeoff IMHO, but I'm curious what others think.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Stop ginkgo tests after first failure
```
