### PR TITLE
Refactor VM prefix to template functions

### DIFF
--- a/parts/k8s/kubernetesagentvars.t
+++ b/parts/k8s/kubernetesagentvars.t
@@ -4,6 +4,9 @@
 {{end}}
     "{{.Name}}Count": "[parameters('{{.Name}}Count')]",
     "{{.Name}}VMNamePrefix": "{{GetAgentVMPrefix .}}",
+{{if .IsWindows}}
+    "winResourceNamePrefix" : "[substring(parameters('nameSuffix'), 0, 5)]",
+{{end}}
 {{if .IsAvailabilitySets}}
     "{{.Name}}Offset": "[parameters('{{.Name}}Offset')]",
     "{{.Name}}AvailabilitySet": "[concat('{{.Name}}-availabilitySet-', parameters('nameSuffix'))]",

--- a/parts/k8s/kubernetesagentvars.t
+++ b/parts/k8s/kubernetesagentvars.t
@@ -3,16 +3,15 @@
     "{{.Name}}StorageAccountsCount": "[add(div(variables('{{.Name}}Count'), variables('maxVMsPerStorageAccount')), mod(add(mod(variables('{{.Name}}Count'), variables('maxVMsPerStorageAccount')),2), add(mod(variables('{{.Name}}Count'), variables('maxVMsPerStorageAccount')),1)))]",
 {{end}}
     "{{.Name}}Count": "[parameters('{{.Name}}Count')]",
+    "{{.Name}}VMNamePrefix": "{{GetAgentVMPrefix .}}",
 {{if .IsAvailabilitySets}}
     "{{.Name}}Offset": "[parameters('{{.Name}}Offset')]",
     "{{.Name}}AvailabilitySet": "[concat('{{.Name}}-availabilitySet-', parameters('nameSuffix'))]",
-{{end}}
-    "{{.Name}}VMNamePrefix": "{{GetAgentVMPrefix variables('{{.Name}}Index')}}",
+{{else}}
     {{if .IsLowPriorityScaleSet}}
     "{{.Name}}ScaleSetPriority": "[parameters('{{.Name}}ScaleSetPriority')]",
     "{{.Name}}ScaleSetEvictionPolicy": "[parameters('{{.Name}}ScaleSetEvictionPolicy')]",
     {{end}}
-{{end}}
 {{end}}
     "{{.Name}}VMSize": "[parameters('{{.Name}}VMSize')]",
 {{if .IsCustomVNET}}

--- a/parts/k8s/kubernetesagentvars.t
+++ b/parts/k8s/kubernetesagentvars.t
@@ -7,14 +7,7 @@
     "{{.Name}}Offset": "[parameters('{{.Name}}Offset')]",
     "{{.Name}}AvailabilitySet": "[concat('{{.Name}}-availabilitySet-', parameters('nameSuffix'))]",
 {{end}}
-{{if .IsWindows}}
-    "winResourceNamePrefix" : "[substring(parameters('nameSuffix'), 0, 5)]",
-    "{{.Name}}VMNamePrefix": "[concat(variables('winResourceNamePrefix'), parameters('orchestratorName'), add(900,variables('{{.Name}}Index')))]",
-{{else}}
-{{if .IsAvailabilitySets}}
-    "{{.Name}}VMNamePrefix": "[concat(parameters('orchestratorName'), '-{{.Name}}-', parameters('nameSuffix'), '-')]",
-{{else}}
-    "{{.Name}}VMNamePrefix": "[concat(parameters('orchestratorName'), '-{{.Name}}-', parameters('nameSuffix'), '-vmss')]",
+    "{{.Name}}VMNamePrefix": "{{GetAgentVMPrefix variables('{{.Name}}Index')}}",
     {{if .IsLowPriorityScaleSet}}
     "{{.Name}}ScaleSetPriority": "[parameters('{{.Name}}ScaleSetPriority')]",
     "{{.Name}}ScaleSetEvictionPolicy": "[parameters('{{.Name}}ScaleSetEvictionPolicy')]",

--- a/parts/k8s/kubernetesmastervars.t
+++ b/parts/k8s/kubernetesmastervars.t
@@ -240,7 +240,7 @@
     "masterFirstAddrOctets": "[split(parameters('firstConsecutiveStaticIP'),'.')]",
     "masterFirstAddrOctet4": "[variables('masterFirstAddrOctets')[3]]",
     "masterFirstAddrPrefix": "[concat(variables('masterFirstAddrOctets')[0],'.',variables('masterFirstAddrOctets')[1],'.',variables('masterFirstAddrOctets')[2],'.')]",
-    "masterVMNamePrefix": "[concat(parameters('orchestratorName'), '-master-', parameters('nameSuffix'), '-')]",
+    "masterVMNamePrefix": "{{GetMasterVMPrefix}}",
     "masterVMNames": [
       "[concat(variables('masterVMNamePrefix'), '0')]",
       "[concat(variables('masterVMNamePrefix'), '1')]",

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -802,11 +802,11 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			imageRef := cs.Properties.MasterProfile.ImageRef
 			return imageRef != nil && len(imageRef.Name) > 0 && len(imageRef.ResourceGroup) > 0
 		},
-		"GetAgentVMPrefix": func(index int) string {
-			return cs.Properties.GetAgentVMPrefix(index)
+		"GetAgentVMPrefix": func(profile *api.AgentPoolProfile) string {
+			return cs.Properties.GetAgentVMPrefix(profile)
 		},
 		"GetMasterVMPrefix": func() string {
-			return cs.Properties.GetMasterPrefix()
+			return cs.Properties.GetMasterVMPrefix()
 		},
 		"GetRouteTableName": func() string {
 			return cs.Properties.GetRouteTableName()

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -802,6 +802,12 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			imageRef := cs.Properties.MasterProfile.ImageRef
 			return imageRef != nil && len(imageRef.Name) > 0 && len(imageRef.ResourceGroup) > 0
 		},
+		"GetAgentVMPrefix": func(index int) string {
+			return cs.Properties.GetAgentVMPrefix(index)
+		},
+		"GetMasterVMPrefix": func() string {
+			return cs.Properties.GetMasterPrefix()
+		},
 		"GetRouteTableName": func() string {
 			return cs.Properties.GetRouteTableName()
 		},

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -748,9 +748,21 @@ func (p *Properties) K8sOrchestratorName() string {
 	return ""
 }
 
+// GetAgentPoolIndex returns the prefix of agentpool VMs given the pool index1
+func (p *Properties) GetAgentPoolIndex(a *AgentPoolProfile) int {
+	var index int
+	for i, profile := range p.AgentPoolProfiles {
+		if profile.Name == a.Name {
+			index = i
+			break
+		}
+	}
+	return index
+}
+
 // GetAgentVMPrefix returns the prefix of agentpool VMs given the pool index
-func (p *Properties) GetAgentVMPrefix(index int) string {
-	a := p.AgentPoolProfiles[index]
+func (p *Properties) GetAgentVMPrefix(a *AgentPoolProfile) string {
+	index := p.GetAgentPoolIndex(a)
 	nameSuffix := p.GetClusterID()
 	var vmPrefix string
 	if a.IsWindows() {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -750,7 +750,7 @@ func (p *Properties) K8sOrchestratorName() string {
 
 // GetAgentPoolIndex returns the prefix of agentpool VMs given the pool index1
 func (p *Properties) GetAgentPoolIndex(a *AgentPoolProfile) int {
-	var index int
+	index := -1
 	for i, profile := range p.AgentPoolProfiles {
 		if profile.Name == a.Name {
 			index = i

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -759,7 +759,7 @@ func (p *Properties) getAgentPoolIndexByName(name string) int {
 	return index
 }
 
-// GetAgentVMPrefix returns the prefix of agentpool VMs given the pool index
+// GetAgentVMPrefix returns the VM prefix for an agentpool
 func (p *Properties) GetAgentVMPrefix(a *AgentPoolProfile) string {
 	index := p.getAgentPoolIndexByName(a.Name)
 	nameSuffix := p.GetClusterID()

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -748,11 +748,10 @@ func (p *Properties) K8sOrchestratorName() string {
 	return ""
 }
 
-// GetAgentPoolIndex returns the prefix of agentpool VMs given the pool index1
-func (p *Properties) GetAgentPoolIndex(a *AgentPoolProfile) int {
+func (p *Properties) getAgentPoolIndex(name string) int {
 	index := -1
 	for i, profile := range p.AgentPoolProfiles {
-		if profile.Name == a.Name {
+		if profile.Name == name {
 			index = i
 			break
 		}
@@ -762,7 +761,7 @@ func (p *Properties) GetAgentPoolIndex(a *AgentPoolProfile) int {
 
 // GetAgentVMPrefix returns the prefix of agentpool VMs given the pool index
 func (p *Properties) GetAgentVMPrefix(a *AgentPoolProfile) string {
-	index := p.GetAgentPoolIndex(a)
+	index := p.getAgentPoolIndex(a.Name)
 	nameSuffix := p.GetClusterID()
 	var vmPrefix string
 	if a.IsWindows() {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -748,7 +748,8 @@ func (p *Properties) K8sOrchestratorName() string {
 	return ""
 }
 
-func (p *Properties) getAgentVMPrefix(index int) string {
+// GetAgentVMPrefix returns the prefix of agentpool VMs given the pool index
+func (p *Properties) GetAgentVMPrefix(index int) string {
 	a := p.AgentPoolProfiles[index]
 	nameSuffix := p.GetClusterID()
 	var vmPrefix string
@@ -763,7 +764,8 @@ func (p *Properties) getAgentVMPrefix(index int) string {
 	return vmPrefix
 }
 
-func (p *Properties) getMasterVMPrefix() string {
+// GetMasterVMPrefix returns the prefix of master VMs
+func (p *Properties) GetMasterVMPrefix() string {
 	return p.K8sOrchestratorName() + "-master-" + p.GetClusterID() + "-"
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -748,7 +748,7 @@ func (p *Properties) K8sOrchestratorName() string {
 	return ""
 }
 
-func (p *Properties) getAgentPoolIndex(name string) int {
+func (p *Properties) getAgentPoolIndexByName(name string) int {
 	index := -1
 	for i, profile := range p.AgentPoolProfiles {
 		if profile.Name == name {
@@ -761,7 +761,7 @@ func (p *Properties) getAgentPoolIndex(name string) int {
 
 // GetAgentVMPrefix returns the prefix of agentpool VMs given the pool index
 func (p *Properties) GetAgentVMPrefix(a *AgentPoolProfile) string {
-	index := p.getAgentPoolIndex(a.Name)
+	index := p.getAgentPoolIndexByName(a.Name)
 	nameSuffix := p.GetClusterID()
 	var vmPrefix string
 	if a.IsWindows() {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -783,7 +783,11 @@ func (p *Properties) GetMasterVMPrefix() string {
 
 // GetResourcePrefix returns the prefix to use for naming cluster resources
 func (p *Properties) GetResourcePrefix() string {
-	return p.K8sOrchestratorName() + "-" + p.GetClusterID() + "-"
+	if p.IsHostedMasterProfile() { 
+		return p.K8sOrchestratorName() + "-agentpool-" + p.GetClusterID() + "-"
+	} 
+	return p.K8sOrchestratorName() + "-master-" + p.GetClusterID() + "-"
+
 }
 
 // GetRouteTableName returns the route table name of the cluster.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -763,13 +763,15 @@ func (p *Properties) getAgentPoolIndexByName(name string) int {
 func (p *Properties) GetAgentVMPrefix(a *AgentPoolProfile) string {
 	index := p.getAgentPoolIndexByName(a.Name)
 	nameSuffix := p.GetClusterID()
-	var vmPrefix string
-	if a.IsWindows() {
-		vmPrefix = nameSuffix[:5] + p.K8sOrchestratorName() + strconv.Itoa(900+index)
-	} else {
-		vmPrefix = p.K8sOrchestratorName() + "-" + a.Name + "-" + nameSuffix + "-"
-		if a.IsVirtualMachineScaleSets() {
-			vmPrefix += "vmss"
+	vmPrefix := ""
+	if index != -1 {
+		if a.IsWindows() {
+			vmPrefix = nameSuffix[:5] + p.K8sOrchestratorName() + strconv.Itoa(900+index)
+		} else {
+			vmPrefix = p.K8sOrchestratorName() + "-" + a.Name + "-" + nameSuffix + "-"
+			if a.IsVirtualMachineScaleSets() {
+				vmPrefix += "vmss"
+			}
 		}
 	}
 	return vmPrefix

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -783,9 +783,9 @@ func (p *Properties) GetMasterVMPrefix() string {
 
 // GetResourcePrefix returns the prefix to use for naming cluster resources
 func (p *Properties) GetResourcePrefix() string {
-	if p.IsHostedMasterProfile() { 
+	if p.IsHostedMasterProfile() {
 		return p.K8sOrchestratorName() + "-agentpool-" + p.GetClusterID() + "-"
-	} 
+	}
 	return p.K8sOrchestratorName() + "-master-" + p.GetClusterID() + "-"
 
 }

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -2052,11 +2052,12 @@ func TestGetAgentVMPrefix(t *testing.T) {
 		expectedVMPrefix string
 	}{
 		{
+			name: "Linux VMAS agent pool profile",
 			profile: &AgentPoolProfile{
 				Name:   "agentpool",
 				VMSize: "Standard_D2_v2",
 				Count:  1,
-				OsType: "Linux",
+				OSType: "Linux",
 			},
 			properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
@@ -2075,7 +2076,61 @@ func TestGetAgentVMPrefix(t *testing.T) {
 					},
 				},
 			},
-			expectedVMPrefix: "bbb",
+			expectedVMPrefix: "k8s-agentpool-42378941-",
+		},
+		{
+			name: "Linux VMSS agent pool profile",
+			profile: &AgentPoolProfile{
+				Name:                "agentpool",
+				VMSize:              "Standard_D2_v2",
+				Count:               1,
+				OSType:              "Linux",
+			},
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					Count:     1,
+					DNSPrefix: "myprefix1",
+					VMSize:    "Standard_DS2_v2",
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Name:   "agentpool",
+						VMSize: "Standard_D2_v2",
+						Count:  1,
+					},
+				},
+			},
+			expectedVMPrefix: "k8s-agentpool-42378941-vmss",
+		},
+		{
+			name: "Windows agent pool profile",
+			profile: &AgentPoolProfile{
+				Name:   "agentpool",
+				VMSize: "Standard_D2_v2",
+				Count:  1,
+				OSType: "Windows",
+			},
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					Count:     1,
+					DNSPrefix: "myprefix2",
+					VMSize:    "Standard_DS2_v2",
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Name:   "agentpool",
+						VMSize: "Standard_D2_v2",
+						Count:  1,
+					},
+				},
+			},
+			expectedVMPrefix: "44196k8s900",
 		},
 	}
 

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -2173,6 +2173,7 @@ func TestGetAgentVMPrefix(t *testing.T) {
 						Name:   "agentpool",
 						VMSize: "Standard_D2_v2",
 						Count:  1,
+						OSType: "Linux",
 					},
 				},
 			},
@@ -2198,9 +2199,11 @@ func TestGetAgentVMPrefix(t *testing.T) {
 				},
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
-						Name:   "agentpool",
-						VMSize: "Standard_D2_v2",
-						Count:  1,
+						Name:                "agentpool",
+						VMSize:              "Standard_D2_v2",
+						Count:               1,
+						AvailabilityProfile: "VirtualMachineScaleSets",
+						OSType:              "Linux",
 					},
 				},
 			},
@@ -2228,10 +2231,38 @@ func TestGetAgentVMPrefix(t *testing.T) {
 						Name:   "agentpool",
 						VMSize: "Standard_D2_v2",
 						Count:  1,
+						OSType: "Windows",
 					},
 				},
 			},
 			expectedVMPrefix: "24789k8s900",
+		},
+		{
+			name: "agent profile doesn't exist",
+			profile: &AgentPoolProfile{
+				Name:   "something",
+				VMSize: "Standard_D2_v2",
+				Count:  1,
+				OSType: "Windows",
+			},
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					Count:     1,
+					DNSPrefix: "myprefix2",
+					VMSize:    "Standard_DS2_v2",
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Name:   "agentpool",
+						VMSize: "Standard_D2_v2",
+						Count:  1,
+					},
+				},
+			},
+			expectedVMPrefix: "",
 		},
 	}
 

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -1733,10 +1733,10 @@ func TestGetRouteTableName(t *testing.T) {
 	}
 
 	actualRTName := p.GetRouteTableName()
-	expectedRTName := "aks-28513887-routetable"
+	expectedRTName := "aks-agentpool-28513887-routetable"
 
 	actualNSGName := p.GetNSGName()
-	expectedNSGName := "aks-28513887-nsg"
+	expectedNSGName := "aks-agentpool-28513887-nsg"
 
 	if actualRTName != expectedRTName {
 		t.Errorf("expected route table name %s, but got %s", expectedRTName, actualRTName)
@@ -1766,10 +1766,10 @@ func TestGetRouteTableName(t *testing.T) {
 	}
 
 	actualRTName = p.GetRouteTableName()
-	expectedRTName = "k8s-28513887-routetable"
+	expectedRTName = "k8s-master-28513887-routetable"
 
 	actualNSGName = p.GetNSGName()
-	expectedNSGName = "k8s-28513887-nsg"
+	expectedNSGName = "k8s-master-28513887-nsg"
 
 	if actualRTName != expectedRTName {
 		t.Errorf("expected route table name %s, but got %s", actualRTName, expectedRTName)

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -1733,10 +1733,10 @@ func TestGetRouteTableName(t *testing.T) {
 	}
 
 	actualRTName := p.GetRouteTableName()
-	expectedRTName := "aks-agentpool-28513887-routetable"
+	expectedRTName := "aks-28513887-routetable"
 
 	actualNSGName := p.GetNSGName()
-	expectedNSGName := "aks-agentpool-28513887-nsg"
+	expectedNSGName := "aks-28513887-nsg"
 
 	if actualRTName != expectedRTName {
 		t.Errorf("expected route table name %s, but got %s", expectedRTName, actualRTName)
@@ -1766,10 +1766,10 @@ func TestGetRouteTableName(t *testing.T) {
 	}
 
 	actualRTName = p.GetRouteTableName()
-	expectedRTName = "k8s-master-28513887-routetable"
+	expectedRTName = "k8s-28513887-routetable"
 
 	actualNSGName = p.GetNSGName()
-	expectedNSGName = "k8s-master-28513887-nsg"
+	expectedNSGName = "k8s-28513887-nsg"
 
 	if actualRTName != expectedRTName {
 		t.Errorf("expected route table name %s, but got %s", actualRTName, expectedRTName)

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -2044,6 +2044,118 @@ func TestProperties_GetClusterMetadata(t *testing.T) {
 
 }
 
+func TestGetAgentPoolIndexByName(t *testing.T) {
+	tests := []struct {
+		name          string
+		profile       *AgentPoolProfile
+		properties    *Properties
+		expectedIndex int
+	}{
+		{
+			name: "index 0",
+			profile: &AgentPoolProfile{
+				Name:   "myagentpool",
+				VMSize: "Standard_D2_v2",
+				Count:  3,
+			},
+			properties: &Properties{
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Name:   "myagentpool",
+						VMSize: "Standard_D2_v2",
+						Count:  3,
+					},
+					{
+						Name:   "agentpool1",
+						VMSize: "Standard_D2_v2",
+						Count:  1,
+					},
+				},
+			},
+			expectedIndex: 0,
+		},
+		{
+			name: "index 3",
+			profile: &AgentPoolProfile{
+				Name:   "myagentpool",
+				VMSize: "Standard_D2_v2",
+				Count:  2,
+			},
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					Count:     1,
+					DNSPrefix: "myprefix1",
+					VMSize:    "Standard_DS2_v2",
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Name:   "agentpool1",
+						VMSize: "Standard_D2_v2",
+						Count:  2,
+					},
+					{
+						Name:   "agentpool2",
+						VMSize: "Standard_D2_v2",
+						Count:  2,
+					},
+					{
+						Name:   "agentpool3",
+						VMSize: "Standard_D2_v2",
+						Count:  2,
+					},
+					{
+						Name:   "myagentpool",
+						VMSize: "Standard_D2_v2",
+						Count:  2,
+					},
+				},
+			},
+			expectedIndex: 3,
+		},
+		{
+			name: "not found",
+			profile: &AgentPoolProfile{
+				Name:   "myagentpool",
+				VMSize: "Standard_D2_v2",
+				Count:  1,
+			},
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					Count:     1,
+					DNSPrefix: "myprefix2",
+					VMSize:    "Standard_DS2_v2",
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Name:   "agent1",
+						VMSize: "Standard_D2_v2",
+						Count:  1,
+					},
+				},
+			},
+			expectedIndex: -1,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			actual := test.properties.getAgentPoolIndexByName(test.profile)
+
+			if actual != test.expectedIndex {
+				t.Errorf("expected agent pool index %d, but got %d", test.expectedIndex, actual)
+			}
+		})
+	}
+}
+
 func TestGetAgentVMPrefix(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -2084,6 +2084,7 @@ func TestGetAgentVMPrefix(t *testing.T) {
 				Name:                "agentpool",
 				VMSize:              "Standard_D2_v2",
 				Count:               1,
+				AvailabilityProfile: "VirtualMachineScaleSets",
 				OSType:              "Linux",
 			},
 			properties: &Properties{
@@ -2103,7 +2104,7 @@ func TestGetAgentVMPrefix(t *testing.T) {
 					},
 				},
 			},
-			expectedVMPrefix: "k8s-agentpool-42378941-vmss",
+			expectedVMPrefix: "k8s-agentpool-30819786-vmss",
 		},
 		{
 			name: "Windows agent pool profile",

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -2047,17 +2047,13 @@ func TestProperties_GetClusterMetadata(t *testing.T) {
 func TestGetAgentPoolIndexByName(t *testing.T) {
 	tests := []struct {
 		name          string
-		profile       *AgentPoolProfile
+		profileName   string
 		properties    *Properties
 		expectedIndex int
 	}{
 		{
-			name: "index 0",
-			profile: &AgentPoolProfile{
-				Name:   "myagentpool",
-				VMSize: "Standard_D2_v2",
-				Count:  3,
-			},
+			name:        "index 0",
+			profileName: "myagentpool",
 			properties: &Properties{
 				AgentPoolProfiles: []*AgentPoolProfile{
 					{
@@ -2075,12 +2071,8 @@ func TestGetAgentPoolIndexByName(t *testing.T) {
 			expectedIndex: 0,
 		},
 		{
-			name: "index 3",
-			profile: &AgentPoolProfile{
-				Name:   "myagentpool",
-				VMSize: "Standard_D2_v2",
-				Count:  2,
-			},
+			name:        "index 3",
+			profileName: "myagentpool",
 			properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorType: Kubernetes,
@@ -2116,12 +2108,8 @@ func TestGetAgentPoolIndexByName(t *testing.T) {
 			expectedIndex: 3,
 		},
 		{
-			name: "not found",
-			profile: &AgentPoolProfile{
-				Name:   "myagentpool",
-				VMSize: "Standard_D2_v2",
-				Count:  1,
-			},
+			name:        "not found",
+			profileName: "myagentpool",
 			properties: &Properties{
 				OrchestratorProfile: &OrchestratorProfile{
 					OrchestratorType: Kubernetes,
@@ -2147,7 +2135,7 @@ func TestGetAgentPoolIndexByName(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			actual := test.properties.getAgentPoolIndexByName(test.profile)
+			actual := test.properties.getAgentPoolIndexByName(test.profileName)
 
 			if actual != test.expectedIndex {
 				t.Errorf("expected agent pool index %d, but got %d", test.expectedIndex, actual)

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -2243,7 +2243,7 @@ func TestGetAgentVMPrefix(t *testing.T) {
 					},
 				},
 			},
-			expectedVMPrefix: "44196k8s900",
+			expectedVMPrefix: "24789k8s900",
 		},
 	}
 

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -2043,3 +2043,51 @@ func TestProperties_GetClusterMetadata(t *testing.T) {
 	}
 
 }
+
+func TestGetAgentVMPrefix(t *testing.T) {
+	tests := []struct {
+		name             string
+		profile          *AgentPoolProfile
+		properties       *Properties
+		expectedVMPrefix string
+	}{
+		{
+			profile: &AgentPoolProfile{
+				Name:   "agentpool",
+				VMSize: "Standard_D2_v2",
+				Count:  1,
+				OsType: "Linux",
+			},
+			properties: &Properties{
+				OrchestratorProfile: &OrchestratorProfile{
+					OrchestratorType: Kubernetes,
+				},
+				MasterProfile: &MasterProfile{
+					Count:     1,
+					DNSPrefix: "myprefix",
+					VMSize:    "Standard_DS2_v2",
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Name:   "agentpool",
+						VMSize: "Standard_D2_v2",
+						Count:  1,
+					},
+				},
+			},
+			expectedVMPrefix: "bbb",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			actual := test.properties.GetAgentVMPrefix(test.profile)
+
+			if actual != test.expectedVMPrefix {
+				t.Errorf("expected agent VM name %s, but got %s", test.expectedVMPrefix, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: instead of hardcoding VM name prefixes in several places, centralize in one common function. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
