### PR TITLE
Change 'windowsVersion' to 'imageVersion' in docs

### DIFF
--- a/docs/kubernetes/windows-details.md
+++ b/docs/kubernetes/windows-details.md
@@ -36,7 +36,7 @@ WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1709-wit
 WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1803-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1803-with-Containers-smalldisk:1803.0.20180504  1803.0.20180504
 ```
 
-You can use the Offer, Publisher and Sku to pick a specific version by adding `windowsOffer`, `windowsPublisher`, `windowsSku` and (optionally) `windowsVersion` to the `windowsProfile` section. In this example, the latest Windows Server version 1803 image would be deployed.
+You can use the Offer, Publisher and Sku to pick a specific version by adding `windowsOffer`, `windowsPublisher`, `windowsSku` and (optionally) `imageVersion` to the `windowsProfile` section. In this example, the latest Windows Server version 1803 image would be deployed.
 
 ```json
 "windowsProfile": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: 
This pull request fixes difference between the documentation and implementation of windowsProfile in section of [deploying specific version](https://github.com/Azure/acs-engine/blob/master/docs/kubernetes/windows-details.md#choosing-the-windows-server-version).
That's the only one place I could find the `windowsProfile` and `windowsVersion` in documentation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3883 

