### PR TITLE
Use `echo -n` to skip adding newline to external command output

### DIFF
--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -301,15 +301,13 @@ func TestShellQuote(t *testing.T) {
 		}
 
 		if runtime.GOOS != "windows" {
-			out, err := exec.Command("/bin/bash", "-c", "testvar="+actual+"; echo $testvar").Output()
+			out, err := exec.Command("/bin/bash", "-c", "testvar="+actual+"; echo -n $testvar").Output()
 			if err != nil {
 				t.Errorf("unexpected error : %s", err.Error())
 			}
 
-			o := string(out[:len(out)-1]) //dropping last character as echo prints out a new line as the last character
-
-			if o != test.input {
-				t.Errorf("failed in Bash output test. Expected %s but got %s", test, o)
+			if string(out) != test.input {
+				t.Errorf("failed in Bash output test. Expected %s but got %s", test, out)
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Harsh Vardhan <harsh59v@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Earlier, the ShellQuote helper method's test runs the `echo` command, gets the output(with the last character as a newline)
Now, the helper method uses the `echo` command with the `-n` flag.

Ref:
---

From the help option of `echo`
```
...
Echo the STRING(s) to standard output.

  -n             do not output the trailing newline
...
```

**If applicable**:
- [ ] documentation
- [x] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)