### PR TITLE
Fix accidentally shadowed variable in upgrade cluster.

### DIFF
--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -117,8 +117,9 @@ func (uc *UpgradeCluster) UpgradeCluster(subscriptionID uuid.UUID, kubeConfig, r
 	case strings.HasPrefix(upgradeVersion, "1.9."),
 		strings.HasPrefix(upgradeVersion, "1.10."),
 		strings.HasPrefix(upgradeVersion, "1.11."):
-		upgrader := &Upgrader{}
-		upgrader.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout, acsengineVersion)
+		u := &Upgrader{}
+		u.Init(uc.Translator, uc.Logger, uc.ClusterTopology, uc.Client, kubeConfig, uc.StepTimeout, acsengineVersion)
+		upgrader = u
 
 	default:
 		return uc.Translator.Errorf("Upgrade to Kubernetes version %s is not supported", upgradeVersion)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Upgrade in master is inadvertently broken because we failed to run upgrade tests before merging #3924.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
