### PR TITLE
Change default value for osImageVersion parameter

### DIFF
--- a/parts/masterparams.t
+++ b/parts/masterparams.t
@@ -145,7 +145,7 @@
       "type": "string"
     },
     "osImageVersion": {
-      "defaultValue": "16.04.201804050",
+      "defaultValue": "latest",
       "metadata": {
         "description": "OS image version."
       },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This is a no-op, the default value is not used since we set the value in code but this does show in the ARM template so might be confusing for users that the default is an old version.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: follow up for https://github.com/Azure/acs-engine/issues/3933#issuecomment-426384810

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
