### PR TITLE
Update go-dev tools image for go 1.11.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: /go/src/github.com/Azure/acs-engine
   docker:
-    - image: quay.io/deis/go-dev:v1.17.0
+    - image: quay.io/deis/go-dev:v1.17.2
   environment:
     GOPATH: /go
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GITTAG := $(VERSION_SHORT)
 endif
 
 REPO_PATH := github.com/Azure/acs-engine
-DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.17.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.17.2
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_OPTS := --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_VARS}
 DEV_ENV_CMD := docker run ${DEV_ENV_OPTS} ${DEV_ENV_IMAGE}

--- a/makedev.ps1
+++ b/makedev.ps1
@@ -1,5 +1,5 @@
 $REPO_PATH = "github.com/Azure/acs-engine"
-$DEV_ENV_IMAGE = "quay.io/deis/go-dev:v1.17.0"
+$DEV_ENV_IMAGE = "quay.io/deis/go-dev:v1.17.2"
 $DEV_ENV_WORK_DIR = "/go/src/$REPO_PATH"
 
 docker.exe run -it --rm -w $DEV_ENV_WORK_DIR -v `"$($PWD)`":$DEV_ENV_WORK_DIR $DEV_ENV_IMAGE bash


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the go compiler with several bug fixes.
See https://golang.org/doc/devel/release.html#go1.11.minor
and https://github.com/deis/docker-go-dev/releases/tag/v1.17.2

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update go-dev tools image for go 1.11.1
```
