### PR TITLE
Update AKS base image to 0.17.0

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -113,7 +113,7 @@ var (
 		ImageOffer:     "aks",
 		ImageSku:       "aksbase",
 		ImagePublisher: "microsoft-aks",
-		ImageVersion:   "0.16.0",
+		ImageVersion:   "0.17.0",
 	}
 
 	//DefaultOpenShift39RHELImageConfig is the OpenShift on RHEL distribution.


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support binaries for Kubernetes 12.0.0 and 1.9.11 to the AKS Base Image VHD. See bec4fef015947f0b859217a9e6f3ee74d1493e6e and 3db00808286f0fe254b78fa8d55d87a8ebd0e27e.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update AKS base image to 0.17.0
```
