### PR TITLE
retain existing AKS SNAT implementation

### DIFF
--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -191,6 +191,12 @@ AGENT_ARTIFACTS_CONFIG_PLACEHOLDER
 {{if not EnablePodSecurityPolicy}}
     sed -i "s|apparmor_parser|d|g" "/etc/systemd/system/kubelet.service"
 {{end}}
+{{if IsHostedMaster}}
+    {{if IsAzureCNI}}
+    # SNAT outbound traffic from pods to destinations outside of VNET.
+    iptables -t nat -A POSTROUTING -m iprange ! --dst-range 168.63.129.16 -m addrtype ! --dst-type local ! -d {{WrapAsParameter "vnetCidr"}} -j MASQUERADE
+    {{end}}
+{{end}}
 {{if HasCustomSearchDomain}}
     sed -i "s|<searchDomainName>|{{WrapAsParameter "searchDomainName"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"
     sed -i "s|<searchDomainRealmUser>|{{WrapAsParameter "searchDomainRealmUser"}}|g" "/opt/azure/containers/setup-custom-search-domains.sh"

--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -201,6 +201,7 @@
       },
       "type": "string"
     },
+{{if not IsHostedMaster}}
     "kubernetesNonMasqueradeCidr": {
       "metadata": {
         "description": "kubernetesNonMasqueradeCidr cluster subnet"
@@ -208,6 +209,7 @@
       "defaultValue": "{{GetDefaultVNETCIDR}}",
       "type": "string"
     },
+{{end}}
     "kubernetesKubeletClusterDomain": {
       "metadata": {
         "description": "--cluster-domain Kubelet config"

--- a/pkg/acsengine/defaults-kubelet.go
+++ b/pkg/acsengine/defaults-kubelet.go
@@ -65,6 +65,11 @@ func setKubeletConfig(cs *api.ContainerService) {
 		"--image-pull-progress-deadline":    "30m",
 	}
 
+	// AKS overrides
+	if cs.Properties.IsHostedMasterProfile() {
+		defaultKubeletConfig["--non-masquerade-cidr"] = cs.Properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet
+	}
+
 	// Apply Azure CNI-specific --max-pods value
 	if o.KubernetesConfig.NetworkPlugin == NetworkPluginAzure {
 		defaultKubeletConfig["--max-pods"] = strconv.Itoa(DefaultKubernetesMaxPodsVNETIntegrated)

--- a/pkg/acsengine/params_k8s.go
+++ b/pkg/acsengine/params_k8s.go
@@ -269,8 +269,6 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 				} else {
 					addValue(parametersMap, "kubernetesNonMasqueradeCidr", properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet)
 				}
-			} else {
-				addValue(parametersMap, "kubernetesNonMasqueradeCidr", kubernetesConfig.KubeletConfig["--non-masquerade-cidr"])
 			}
 			addValue(parametersMap, "kubernetesKubeletClusterDomain", kubernetesConfig.KubeletConfig["--cluster-domain"])
 			addValue(parametersMap, "dockerBridgeCidr", kubernetesConfig.DockerBridgeSubnet)

--- a/pkg/acsengine/params_k8s.go
+++ b/pkg/acsengine/params_k8s.go
@@ -259,14 +259,18 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 				CloudProviderRateLimitBucket: kubernetesConfig.CloudProviderRateLimitBucket,
 			})
 			addValue(parametersMap, "kubeClusterCidr", kubernetesConfig.ClusterSubnet)
-			if properties.OrchestratorProfile.IsAzureCNI() {
-				if properties.MasterProfile != nil && properties.MasterProfile.IsCustomVNET() {
-					addValue(parametersMap, "kubernetesNonMasqueradeCidr", properties.MasterProfile.VnetCidr)
+			if !properties.IsHostedMasterProfile() {
+				if properties.OrchestratorProfile.IsAzureCNI() {
+					if properties.MasterProfile != nil && properties.MasterProfile.IsCustomVNET() {
+						addValue(parametersMap, "kubernetesNonMasqueradeCidr", properties.MasterProfile.VnetCidr)
+					} else {
+						addValue(parametersMap, "kubernetesNonMasqueradeCidr", DefaultVNETCIDR)
+					}
 				} else {
-					addValue(parametersMap, "kubernetesNonMasqueradeCidr", DefaultVNETCIDR)
+					addValue(parametersMap, "kubernetesNonMasqueradeCidr", properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet)
 				}
 			} else {
-				addValue(parametersMap, "kubernetesNonMasqueradeCidr", properties.OrchestratorProfile.KubernetesConfig.ClusterSubnet)
+				addValue(parametersMap, "kubernetesNonMasqueradeCidr", kubernetesConfig.KubeletConfig["--non-masquerade-cidr"])
 			}
 			addValue(parametersMap, "kubernetesKubeletClusterDomain", kubernetesConfig.KubeletConfig["--cluster-domain"])
 			addValue(parametersMap, "dockerBridgeCidr", kubernetesConfig.DockerBridgeSubnet)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: A follow-up to 
https://github.com/Azure/acs-engine/pull/3916

Allows acs-engine to bake ip-masq-agent SNAT implementation before merging into AKS.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
retain existing AKS SNAT implementation
```