### PR TITLE
Enable upgrade to next supported Kubernetes version

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -383,6 +383,11 @@ func GetLatestPatchVersion(majorMinor string, versionsList []string) (version st
 	return version
 }
 
+// GetNextAvailableMinorVersion returns the next supported minor version
+func GetNextAvailableMinorVersion(versions []string, version string) {
+	// TODO
+}
+
 // IsSupportedKubernetesVersion return true if the provided Kubernetes version is supported
 func IsSupportedKubernetesVersion(version string, isUpdate, hasWindows bool) bool {
 	for _, ver := range GetAllSupportedKubernetesVersions(isUpdate, hasWindows) {

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -192,6 +192,42 @@ func GetVersionsBetween(versions []string, versionMin, versionMax string, inclus
 	return ret
 }
 
+// GetMinVersion gets the lowest semver version
+// preRelease=true means accept a pre-release version as a min value
+func GetMinVersion(versions []string, preRelease bool) string {
+	if len(versions) < 1 {
+		return ""
+	}
+	lowest, _ := semver.Make("99.99.99")
+	lowestPreRelease, _ := semver.Make("99.99.99-z.9")
+	var preReleaseVersions []semver.Version
+	for _, v := range versions {
+		sv, _ := semver.Make(v)
+		if len(sv.Pre) != 0 {
+			preReleaseVersions = append(preReleaseVersions, sv)
+		} else {
+			if sv.Compare(lowest) == -1 {
+				lowest = sv
+			}
+		}
+	}
+	if preRelease {
+		for _, sv := range preReleaseVersions {
+			if sv.Compare(lowestPreRelease) == -1 {
+				lowestPreRelease = sv
+			}
+		}
+		switch lowestPreRelease.Compare(lowest) {
+		case 1:
+			return lowestPreRelease.String()
+		default:
+			return lowest.String()
+		}
+
+	}
+	return lowest.String()
+}
+
 // GetMaxVersion gets the highest semver version
 // preRelease=true means accept a pre-release version as a max value
 func GetMaxVersion(versions []string, preRelease bool) string {
@@ -381,11 +417,6 @@ func GetLatestPatchVersion(majorMinor string, versionsList []string) (version st
 		}
 	}
 	return version
-}
-
-// GetNextAvailableMinorVersion returns the next supported minor version
-func GetNextAvailableMinorVersion(versions []string, version string) {
-	// TODO
 }
 
 // IsSupportedKubernetesVersion return true if the provided Kubernetes version is supported

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -206,24 +206,20 @@ func GetMinVersion(versions []string, preRelease bool) string {
 		if len(sv.Pre) != 0 {
 			preReleaseVersions = append(preReleaseVersions, sv)
 		} else {
-			if sv.Compare(lowest) == -1 {
+			if sv.LT(lowest) {
 				lowest = sv
 			}
 		}
 	}
 	if preRelease {
 		for _, sv := range preReleaseVersions {
-			if sv.Compare(lowestPreRelease) == -1 {
+			if sv.LT(lowestPreRelease) {
 				lowestPreRelease = sv
 			}
 		}
-		switch lowestPreRelease.Compare(lowest) {
-		case 1:
+		if lowestPreRelease.LT(lowest) {
 			return lowestPreRelease.String()
-		default:
-			return lowest.String()
 		}
-
 	}
 	return lowest.String()
 }
@@ -242,24 +238,20 @@ func GetMaxVersion(versions []string, preRelease bool) string {
 		if len(sv.Pre) != 0 {
 			preReleaseVersions = append(preReleaseVersions, sv)
 		} else {
-			if sv.Compare(highest) == 1 {
+			if sv.GT(highest) {
 				highest = sv
 			}
 		}
 	}
 	if preRelease {
 		for _, sv := range preReleaseVersions {
-			if sv.Compare(highestPreRelease) == 1 {
+			if sv.GT(highestPreRelease) {
 				highestPreRelease = sv
 			}
 		}
-		switch highestPreRelease.Compare(highest) {
-		case 1:
+		if highestPreRelease.GT(highest) {
 			return highestPreRelease.String()
-		default:
-			return highest.String()
 		}
-
 	}
 	return highest.String()
 }

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -198,30 +198,8 @@ func GetMinVersion(versions []string, preRelease bool) string {
 	if len(versions) < 1 {
 		return ""
 	}
-	lowest, _ := semver.Make("99.99.99")
-	lowestPreRelease, _ := semver.Make("99.99.99-z.9")
-	var preReleaseVersions []semver.Version
-	for _, v := range versions {
-		sv, _ := semver.Make(v)
-		if len(sv.Pre) != 0 {
-			preReleaseVersions = append(preReleaseVersions, sv)
-		} else {
-			if sv.LT(lowest) {
-				lowest = sv
-			}
-		}
-	}
-	if preRelease {
-		for _, sv := range preReleaseVersions {
-			if sv.LT(lowestPreRelease) {
-				lowestPreRelease = sv
-			}
-		}
-		if lowestPreRelease.LT(lowest) {
-			return lowestPreRelease.String()
-		}
-	}
-	return lowest.String()
+	semverVersions := getSortedSemverVersions(versions, preRelease)
+	return semverVersions[0].String()
 }
 
 // GetMaxVersion gets the highest semver version
@@ -230,30 +208,20 @@ func GetMaxVersion(versions []string, preRelease bool) string {
 	if len(versions) < 1 {
 		return ""
 	}
-	highest, _ := semver.Make("0.0.0")
-	highestPreRelease, _ := semver.Make("0.0.0-alpha.0")
-	var preReleaseVersions []semver.Version
+	semverVersions := getSortedSemverVersions(versions, preRelease)
+	return semverVersions[len(semverVersions)-1].String()
+}
+
+func getSortedSemverVersions(versions []string, preRelease bool) []semver.Version {
+	var semverVersions []semver.Version
 	for _, v := range versions {
 		sv, _ := semver.Make(v)
-		if len(sv.Pre) != 0 {
-			preReleaseVersions = append(preReleaseVersions, sv)
-		} else {
-			if sv.GT(highest) {
-				highest = sv
-			}
+		if len(sv.Pre) == 0 || preRelease {
+			semverVersions = append(semverVersions, sv)
 		}
 	}
-	if preRelease {
-		for _, sv := range preReleaseVersions {
-			if sv.GT(highestPreRelease) {
-				highestPreRelease = sv
-			}
-		}
-		if highestPreRelease.GT(highest) {
-			return highestPreRelease.String()
-		}
-	}
-	return highest.String()
+	semver.Sort(semverVersions)
+	return semverVersions
 }
 
 // AllKubernetesWindowsSupportedVersions maintain a set of available k8s Windows versions in acs-engine

--- a/pkg/api/common/versions_test.go
+++ b/pkg/api/common/versions_test.go
@@ -389,54 +389,66 @@ func TestGetLatestPatchVersion(t *testing.T) {
 	}
 }
 
-func TestGetMaxVersion(t *testing.T) {
-	expected := "1.0.3"
-	versions := []string{"1.0.1", "1.0.2", expected}
-	max := GetMaxVersion(versions, false)
-	if max != expected {
-		t.Errorf("GetMaxVersion returned the wrong max version, expected %s, got %s", expected, max)
+func TestGetMinMaxVersion(t *testing.T) {
+	cases := []struct {
+		expectedMin string
+		expectedMax string
+		versions    []string
+		preRelease  bool
+	}{
+		{
+			expectedMin: "1.0.0",
+			expectedMax: "1.0.3",
+			versions:    []string{"1.0.1", "1.0.2", "1.0.0", "1.0.3"},
+			preRelease:  false,
+		},
+		{
+			expectedMin: "0.0.20",
+			expectedMax: "1.3.1",
+			versions:    []string{"1.0.1", "1.1.2", "1.3.1", "0.0.20"},
+			preRelease:  false,
+		},
+		{
+			expectedMin: "1.0.1",
+			expectedMax: "1.1.2",
+			versions:    []string{"1.0.1", "1.1.2", "1.2.3-alpha.1"},
+			preRelease:  false,
+		},
+		{
+			expectedMin: "1.0.1",
+			expectedMax: "1.2.3-alpha.1",
+			versions:    []string{"1.0.1", "1.1.2", "1.2.3-alpha.1"},
+			preRelease:  true,
+		},
+		{
+			expectedMin: "0.1.3-beta.1",
+			expectedMax: "1.1.2",
+			versions:    []string{"1.0.1", "1.1.2", "0.1.3-beta.1", "1.0.0-alpha.1"},
+			preRelease:  true,
+		},
+		{
+			expectedMin: "",
+			expectedMax: "",
+			versions:    []string{},
+			preRelease:  false,
+		},
+		{
+			expectedMin: "",
+			expectedMax: "",
+			versions:    []string{},
+			preRelease:  true,
+		},
 	}
 
-	expected = "1.2.3"
-	versions = []string{"1.0.1", "1.1.2", expected}
-	max = GetMaxVersion(versions, false)
-	if max != expected {
-		t.Errorf("GetMaxVersion returned the wrong max version, expected %s, got %s", expected, max)
-	}
-
-	expected = "1.1.2"
-	versions = []string{"1.0.1", expected, "1.2.3-alpha.1"}
-	max = GetMaxVersion(versions, false)
-	if max != expected {
-		t.Errorf("GetMaxVersion returned the wrong max version, expected %s, got %s", expected, max)
-	}
-
-	expected = "1.2.3-alpha.1"
-	versions = []string{"1.0.1", "1.1.2", expected}
-	max = GetMaxVersion(versions, true)
-	if max != expected {
-		t.Errorf("GetMaxVersion returned the wrong max version, expected %s, got %s", expected, max)
-	}
-
-	expected = "1.1.2"
-	versions = []string{"1.1.1", "1.0.0-alpha.1", expected}
-	max = GetMaxVersion(versions, true)
-	if max != expected {
-		t.Errorf("GetMaxVersion returned the wrong max version, expected %s, got %s", expected, max)
-	}
-
-	expected = ""
-	versions = []string{}
-	max = GetMaxVersion(versions, false)
-	if max != expected {
-		t.Errorf("GetMaxVersion returned the wrong max version, expected %s, got %s", expected, max)
-	}
-
-	expected = ""
-	versions = []string{}
-	max = GetMaxVersion(versions, true)
-	if max != expected {
-		t.Errorf("GetMaxVersion returned the wrong max version, expected %s, got %s", expected, max)
+	for _, c := range cases {
+		min := GetMinVersion(c.versions, c.preRelease)
+		if min != c.expectedMin {
+			t.Errorf("GetMinVersion returned the wrong min version, expected %s, got %s", c.expectedMin, min)
+		}
+		max := GetMaxVersion(c.versions, c.preRelease)
+		if max != c.expectedMax {
+			t.Errorf("GetMaxVersion returned the wrong max version, expected %s, got %s", c.expectedMax, max)
+		}
 	}
 }
 

--- a/pkg/api/orchestrators.go
+++ b/pkg/api/orchestrators.go
@@ -1,13 +1,11 @@
 package api
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/Azure/acs-engine/pkg/api/common"
 	"github.com/Azure/acs-engine/pkg/api/v20170930"
 	"github.com/Azure/acs-engine/pkg/api/vlabs"
-	"github.com/blang/semver"
 	"github.com/pkg/errors"
 )
 
@@ -181,13 +179,7 @@ func kubernetesInfo(csOrch *OrchestratorProfile, hasWindows bool) ([]*Orchestrat
 
 func kubernetesUpgrades(csOrch *OrchestratorProfile, hasWindows bool) ([]*OrchestratorProfile, error) {
 	ret := []*OrchestratorProfile{}
-
-	currentVer, err := semver.Make(csOrch.OrchestratorVersion)
-	if err != nil {
-		return nil, err
-	}
-	nextNextMinorString := strconv.FormatUint(currentVer.Major, 10) + "." + strconv.FormatUint(currentVer.Minor+2, 10) + ".0-alpha.0"
-	upgradeableVersions := common.GetVersionsBetween(common.GetAllSupportedKubernetesVersions(false, hasWindows), csOrch.OrchestratorVersion, nextNextMinorString, false, true)
+	upgradeableVersions := common.GetVersionsGt(common.GetAllSupportedKubernetesVersions(false, hasWindows), csOrch.OrchestratorVersion, false, true)
 	for _, ver := range upgradeableVersions {
 		ret = append(ret, &OrchestratorProfile{
 			OrchestratorType:    Kubernetes,

--- a/pkg/api/orchestrators.go
+++ b/pkg/api/orchestrators.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -202,18 +203,23 @@ func getKubernetesAvailableUpgradeVersions(orchestratorVersion string, supported
 		return nil, err
 	}
 	versionsGT := common.GetVersionsGt(supportedVersions, orchestratorVersion, false, true)
-	min, err := semver.Make(common.GetMinVersion(versionsGT, true))
-	if err != nil {
-		return nil, err
-	}
+	if len(versionsGT) != 0 {
+		minVersion := common.GetMinVersion(versionsGT, true)
+		fmt.Print(minVersion)
+		min, err := semver.Make(minVersion)
+		if err != nil {
+			return nil, err
+		}
 
-	if currentVer.Major >= min.Major && currentVer.Minor < min.Minor {
-		skipUpgradeMinor = strconv.FormatUint(min.Major, 10) + "." + strconv.FormatUint(min.Minor+1, 10) + ".0-alpha.0"
-	} else {
-		skipUpgradeMinor = strconv.FormatUint(currentVer.Major, 10) + "." + strconv.FormatUint(currentVer.Minor+2, 10) + ".0-alpha.0"
-	}
+		if currentVer.Major >= min.Major && currentVer.Minor+1 < min.Minor {
+			skipUpgradeMinor = strconv.FormatUint(min.Major, 10) + "." + strconv.FormatUint(min.Minor+1, 10) + ".0-alpha.0"
+		} else {
+			skipUpgradeMinor = strconv.FormatUint(currentVer.Major, 10) + "." + strconv.FormatUint(currentVer.Minor+2, 10) + ".0-alpha.0"
+		}
 
-	return common.GetVersionsBetween(supportedVersions, orchestratorVersion, skipUpgradeMinor, false, true), nil
+		return common.GetVersionsBetween(supportedVersions, orchestratorVersion, skipUpgradeMinor, false, true), nil
+	}
+	return []string{}, nil
 
 }
 

--- a/pkg/api/orchestrators.go
+++ b/pkg/api/orchestrators.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -204,9 +203,7 @@ func getKubernetesAvailableUpgradeVersions(orchestratorVersion string, supported
 	}
 	versionsGT := common.GetVersionsGt(supportedVersions, orchestratorVersion, false, true)
 	if len(versionsGT) != 0 {
-		minVersion := common.GetMinVersion(versionsGT, true)
-		fmt.Print(minVersion)
-		min, err := semver.Make(minVersion)
+		min, err := semver.Make(common.GetMinVersion(versionsGT, true))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/api/orchestrators_test.go
+++ b/pkg/api/orchestrators_test.go
@@ -56,7 +56,8 @@ func TestOrchestratorUpgradeInfo(t *testing.T) {
 			OrchestratorType:    Kubernetes,
 			OrchestratorVersion: deployedVersion,
 		}
-		v := getKubernetesAvailableUpgradeVersions(deployedVersion, common.GetAllSupportedKubernetesVersions(false, false))
+		v, e := getKubernetesAvailableUpgradeVersions(deployedVersion, common.GetAllSupportedKubernetesVersions(false, false))
+		Expect(e).To(BeNil())
 		orch, e := GetOrchestratorVersionProfile(csOrch, false)
 		Expect(e).To(BeNil())
 		Expect(len(orch.Upgrades)).To(Equal(len(v)))

--- a/pkg/api/orchestrators_test.go
+++ b/pkg/api/orchestrators_test.go
@@ -62,6 +62,15 @@ func TestOrchestratorUpgradeInfo(t *testing.T) {
 		Expect(e).To(BeNil())
 		Expect(len(orch.Upgrades)).To(Equal(len(v)))
 	}
+
+	// The latest version is not upgradable
+	csOrch = &OrchestratorProfile{
+		OrchestratorType:    Kubernetes,
+		OrchestratorVersion: common.GetMaxVersion(common.GetAllSupportedKubernetesVersions(false, false), true),
+	}
+	orch, e = GetOrchestratorVersionProfile(csOrch, false)
+	Expect(e).To(BeNil())
+	Expect(len(orch.Upgrades)).To(Equal(0))
 }
 
 func TestGetOrchestratorVersionProfileListV20170930(t *testing.T) {

--- a/pkg/api/orchestrators_test.go
+++ b/pkg/api/orchestrators_test.go
@@ -50,7 +50,6 @@ func TestVersionCompare(t *testing.T) {
 
 func TestOrchestratorUpgradeInfo(t *testing.T) {
 	RegisterTestingT(t)
-	// Each kubernetes version is upgradable to all supported versions greater than itself
 	testVersions := []string{"1.6.9", "1.7.0", "1.7.15", "1.8.4", "1.9.6", "1.10.0-beta.2", "1.11.0", "1.12.0"}
 	for _, deployedVersion := range testVersions {
 		csOrch := &OrchestratorProfile{

--- a/pkg/api/orchestrators_test.go
+++ b/pkg/api/orchestrators_test.go
@@ -50,86 +50,18 @@ func TestVersionCompare(t *testing.T) {
 
 func TestOrchestratorUpgradeInfo(t *testing.T) {
 	RegisterTestingT(t)
-	// 1.6.9 is upgradable to 1.6.x and 1.7.x
-	deployedVersion := "1.6.9"
-	nextNextMinorVersion := "1.8.0-alpha.0"
-	csOrch := &OrchestratorProfile{
-		OrchestratorType:    Kubernetes,
-		OrchestratorVersion: deployedVersion,
+	// Each kubernetes version is upgradable to all supported versions greater than itself
+	testVersions := []string{"1.6.9", "1.7.0", "1.7.15", "1.8.4", "1.9.6", "1.10.0-beta.2", "1.11.0", "1.12.0"}
+	for _, deployedVersion := range testVersions {
+		csOrch := &OrchestratorProfile{
+			OrchestratorType:    Kubernetes,
+			OrchestratorVersion: deployedVersion,
+		}
+		v := common.GetVersionsGt(common.GetAllSupportedKubernetesVersions(false, false), deployedVersion, false, true)
+		orch, e := GetOrchestratorVersionProfile(csOrch, false)
+		Expect(e).To(BeNil())
+		Expect(len(orch.Upgrades)).To(Equal(len(v)))
 	}
-	v := common.GetVersionsBetween(common.GetAllSupportedKubernetesVersions(false, false), deployedVersion, nextNextMinorVersion, false, true)
-	orch, e := GetOrchestratorVersionProfile(csOrch, false)
-	Expect(e).To(BeNil())
-	Expect(len(orch.Upgrades)).To(Equal(len(v)))
-
-	// 1.7.0 is upgradable to 1.7.x and 1.8.x
-	deployedVersion = "1.7.0"
-	nextNextMinorVersion = "1.9.0-alpha.0"
-	csOrch = &OrchestratorProfile{
-		OrchestratorType:    Kubernetes,
-		OrchestratorVersion: deployedVersion,
-	}
-	v = common.GetVersionsBetween(common.GetAllSupportedKubernetesVersions(false, false), deployedVersion, nextNextMinorVersion, false, true)
-	orch, e = GetOrchestratorVersionProfile(csOrch, false)
-	Expect(e).To(BeNil())
-	Expect(len(orch.Upgrades)).To(Equal(len(v)))
-
-	// 1.7.15 is upgradable to 1.8.x
-	deployedVersion = "1.7.15"
-	nextNextMinorVersion = "1.9.0-alpha.0"
-	csOrch = &OrchestratorProfile{
-		OrchestratorType:    Kubernetes,
-		OrchestratorVersion: deployedVersion,
-	}
-	v = common.GetVersionsBetween(common.GetAllSupportedKubernetesVersions(false, false), deployedVersion, nextNextMinorVersion, false, true)
-	orch, e = GetOrchestratorVersionProfile(csOrch, false)
-	Expect(e).To(BeNil())
-	Expect(len(orch.Upgrades)).To(Equal(len(v)))
-
-	// 1.8.4 is upgradable to 1.8.x and 1.9.x
-	deployedVersion = "1.8.4"
-	nextNextMinorVersion = "1.10.0-alpha.0"
-	csOrch = &OrchestratorProfile{
-		OrchestratorType:    Kubernetes,
-		OrchestratorVersion: deployedVersion,
-	}
-	v = common.GetVersionsBetween(common.GetAllSupportedKubernetesVersions(false, false), deployedVersion, nextNextMinorVersion, false, true)
-	orch, e = GetOrchestratorVersionProfile(csOrch, false)
-	Expect(e).To(BeNil())
-	Expect(len(orch.Upgrades)).To(Equal(len(v)))
-
-	// 1.9.6 is upgradable to 1.10.x
-	deployedVersion = "1.9.6"
-	nextNextMinorVersion = "1.11.0-alpha.0"
-	csOrch = &OrchestratorProfile{
-		OrchestratorType:    Kubernetes,
-		OrchestratorVersion: deployedVersion,
-	}
-	v = common.GetVersionsBetween(common.GetAllSupportedKubernetesVersions(false, false), deployedVersion, nextNextMinorVersion, false, true)
-	orch, e = GetOrchestratorVersionProfile(csOrch, false)
-	Expect(e).To(BeNil())
-	Expect(len(orch.Upgrades)).To(Equal(len(v)))
-
-	// 1.10.0-beta.2 is upgradable to newer pre-release versions in 1.10.n release channel and official 1.10.n releases
-	deployedVersion = "1.10.0-beta.2"
-	nextNextMinorVersion = "1.12.0-alpha.0"
-	csOrch = &OrchestratorProfile{
-		OrchestratorType:    Kubernetes,
-		OrchestratorVersion: deployedVersion,
-	}
-	v = common.GetVersionsBetween(common.GetAllSupportedKubernetesVersions(false, false), deployedVersion, nextNextMinorVersion, false, true)
-	orch, e = GetOrchestratorVersionProfile(csOrch, false)
-	Expect(e).To(BeNil())
-	Expect(len(orch.Upgrades)).To(Equal(len(v)))
-
-	// The latest version is not upgradable
-	csOrch = &OrchestratorProfile{
-		OrchestratorType:    Kubernetes,
-		OrchestratorVersion: common.GetMaxVersion(common.GetAllSupportedKubernetesVersions(false, false), true),
-	}
-	orch, e = GetOrchestratorVersionProfile(csOrch, false)
-	Expect(e).To(BeNil())
-	Expect(len(orch.Upgrades)).To(Equal(0))
 }
 
 func TestGetOrchestratorVersionProfileListV20170930(t *testing.T) {

--- a/pkg/api/orchestrators_test.go
+++ b/pkg/api/orchestrators_test.go
@@ -254,8 +254,13 @@ func TestGetKubernetesAvailableUpgradeVersions(t *testing.T) {
 		},
 		{
 			version:          "1.8.14",
-			versions:         []string{"1.7.15", "1.8.14", "1.8.15"},
+			versions:         []string{"1.7.15", "1.8.14", "1.8.15", "1.9.10", "1.9.11", "1.10.3", "1.10.4"},
 			expectedUpgrades: []string{"1.8.15"},
+		},
+		{
+			version:          "1.8.14",
+			versions:         []string{"1.9.10", "1.9.11", "1.10.3", "1.10.4", "1.11.3", "1.11.4", "1.12.0-alpha.1"},
+			expectedUpgrades: []string{"1.9.10", "1.9.11"},
 		},
 		{
 			version:          "1.9.10",

--- a/pkg/api/orchestrators_test.go
+++ b/pkg/api/orchestrators_test.go
@@ -64,11 +64,11 @@ func TestOrchestratorUpgradeInfo(t *testing.T) {
 	}
 
 	// The latest version is not upgradable
-	csOrch = &OrchestratorProfile{
+	csOrch := &OrchestratorProfile{
 		OrchestratorType:    Kubernetes,
 		OrchestratorVersion: common.GetMaxVersion(common.GetAllSupportedKubernetesVersions(false, false), true),
 	}
-	orch, e = GetOrchestratorVersionProfile(csOrch, false)
+	orch, e := GetOrchestratorVersionProfile(csOrch, false)
 	Expect(e).To(BeNil())
 	Expect(len(orch.Upgrades)).To(Equal(0))
 }

--- a/pkg/api/orchestrators_test.go
+++ b/pkg/api/orchestrators_test.go
@@ -255,7 +255,7 @@ func TestGetKubernetesAvailableUpgradeVersions(t *testing.T) {
 		{
 			version:          "1.8.14",
 			versions:         []string{"1.7.15", "1.8.14", "1.8.15", "1.9.10", "1.9.11", "1.10.3", "1.10.4"},
-			expectedUpgrades: []string{"1.8.15"},
+			expectedUpgrades: []string{"1.8.15", "1.9.10", "1.9.11"},
 		},
 		{
 			version:          "1.8.14",
@@ -271,6 +271,11 @@ func TestGetKubernetesAvailableUpgradeVersions(t *testing.T) {
 			version:          "1.10.4",
 			versions:         []string{"1.9.10", "1.9.11", "1.10.3", "1.10.4", "1.11.3", "1.11.4", "1.12.0-alpha.1"},
 			expectedUpgrades: []string{"1.11.3", "1.11.4"},
+		},
+		{
+			version:          "1.12.1",
+			versions:         []string{"1.9.10", "1.9.11", "1.10.3", "1.10.4", "1.11.3", "1.11.4", "1.12.1", "1.12.2"},
+			expectedUpgrades: []string{"1.12.2"},
 		},
 		{
 			version:          "1.12.2",

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -190,7 +190,7 @@ func (mkc *MockKubernetesClient) GetNode(name string) (*v1.Node, error) {
 	}
 	node := &v1.Node{}
 	node.Status.Conditions = append(node.Status.Conditions, v1.NodeCondition{Type: v1.NodeReady, Status: v1.ConditionTrue})
-	node.Status.NodeInfo.KubeletVersion = "1.6.9"
+	node.Status.NodeInfo.KubeletVersion = "1.7.9"
 	return node, nil
 }
 
@@ -376,7 +376,7 @@ func (mc *MockACSEngineClient) ListVirtualMachines(ctx context.Context, resource
 	poolnameString := "poolName"
 
 	creationSource := "acsengine-k8s-agentpool1-12345678-0"
-	orchestrator := "Kubernetes:1.6.9"
+	orchestrator := "Kubernetes:1.7.9"
 	resourceNameSuffix := "12345678"
 	poolname := "agentpool1"
 
@@ -444,7 +444,7 @@ func (mc *MockACSEngineClient) GetVirtualMachine(ctx context.Context, resourceGr
 	poolnameString := "poolName"
 
 	creationSource := "acsengine-k8s-agentpool1-12345678-0"
-	orchestrator := "Kubernetes:1.6.9"
+	orchestrator := "Kubernetes:1.7.9"
 	resourceNameSuffix := "12345678"
 	poolname := "agentpool1"
 

--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -29,10 +29,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should succeed when cluster VMs are missing expected tags during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.7.9", 1, 1, false)
-
-		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
-
+		cs := api.CreateMockContainerService("testcluster", "1.7.16", 1, 1, false)
 		uc := UpgradeCluster{
 			Translator: &i18n.Translator{},
 			Logger:     log.NewEntry(log.New()),
@@ -53,10 +50,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should return error message when failing to list VMs during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.7.9", 1, 1, false)
-
-		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.14"
-
+		cs := api.CreateMockContainerService("testcluster", "1.7.14", 1, 1, false)
 		uc := UpgradeCluster{
 			Translator: &i18n.Translator{},
 			Logger:     log.NewEntry(log.New()),
@@ -77,9 +71,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should return error message when failing to delete VMs during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.7.9", 1, 1, false)
-
-		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
+		cs := api.CreateMockContainerService("testcluster", "1.7.16", 1, 1, false)
 		uc := UpgradeCluster{
 			Translator: &i18n.Translator{},
 			Logger:     log.NewEntry(log.New()),
@@ -98,7 +90,6 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 
 	It("Should return error message when failing to deploy template during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.7.16", 1, 1, false)
-		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
 		uc := UpgradeCluster{
 			Translator: &i18n.Translator{},
 			Logger:     log.NewEntry(log.New()),
@@ -116,8 +107,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should return error message when failing to get a virtual machine during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.7.9", 1, 6, false)
-		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
+		cs := api.CreateMockContainerService("testcluster", "1.7.16", 1, 6, false)
 		uc := UpgradeCluster{
 			Translator: &i18n.Translator{},
 			Logger:     log.NewEntry(log.New()),
@@ -135,8 +125,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should return error message when failing to get storage client during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.7.9", 5, 1, false)
-		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
+		cs := api.CreateMockContainerService("testcluster", "1.7.16", 5, 1, false)
 		uc := UpgradeCluster{
 			Translator: &i18n.Translator{},
 			Logger:     log.NewEntry(log.New()),
@@ -154,8 +143,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should return error message when failing to delete network interface during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.7.9", 3, 2, false)
-		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
+		cs := api.CreateMockContainerService("testcluster", "1.7.16", 3, 2, false)
 		uc := UpgradeCluster{
 			Translator: &i18n.Translator{},
 			Logger:     log.NewEntry(log.New()),
@@ -173,8 +161,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should return error message when failing on ClusterPreflightCheck operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.7.9", 3, 3, false)
-		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.0"
+		cs := api.CreateMockContainerService("testcluster", "1.7.0", 3, 3, false)
 		uc := UpgradeCluster{
 			Translator: &i18n.Translator{},
 			Logger:     log.NewEntry(log.New()),
@@ -192,8 +179,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should return error message when failing to delete role assignment during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.7.9", 3, 2, false)
-		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
+		cs := api.CreateMockContainerService("testcluster", "1.7.16", 3, 2, false)
 		cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{}
 		cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity = true
 		uc := UpgradeCluster{
@@ -214,8 +200,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should not fail if no managed identity is returned by azure during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.7.9", 3, 2, false)
-		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
+		cs := api.CreateMockContainerService("testcluster", "1.7.16", 3, 2, false)
 		cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{}
 		cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity = true
 		uc := UpgradeCluster{

--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -173,8 +173,8 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should return error message when failing on ClusterPreflightCheck operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.9.0", 3, 3, false)
-		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.8.15"
+		cs := api.CreateMockContainerService("testcluster", "1.7.9", 3, 3, false)
+		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.0"
 		uc := UpgradeCluster{
 			Translator: &i18n.Translator{},
 			Logger:     log.NewEntry(log.New()),
@@ -188,7 +188,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		err := uc.UpgradeCluster(subID, nil, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
 		Expect(err).NotTo(BeNil())
 		fmt.Print("GOT :   ", err.Error())
-		Expect(err.Error()).To(ContainSubstring("Error while querying ARM for resources: Kubernetes:1.9.0 cannot be upgraded to 1.8.15"))
+		Expect(err.Error()).To(ContainSubstring("Error while querying ARM for resources: Kubernetes:1.7.9 cannot be upgraded to 1.7.0"))
 	})
 
 	It("Should return error message when failing to delete role assignment during upgrade operation", func() {

--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should return error message when failing on ClusterPreflightCheck operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.6.9", 3, 3, false)
+		cs := api.CreateMockContainerService("testcluster", "1.9.0", 3, 3, false)
 		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.8.15"
 		uc := UpgradeCluster{
 			Translator: &i18n.Translator{},
@@ -188,7 +188,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		err := uc.UpgradeCluster(subID, nil, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
 		Expect(err).NotTo(BeNil())
 		fmt.Print("GOT :   ", err.Error())
-		Expect(err.Error()).To(ContainSubstring("Error while querying ARM for resources: Kubernetes:1.6.9 cannot be upgraded to 1.8.15"))
+		Expect(err.Error()).To(ContainSubstring("Error while querying ARM for resources: Kubernetes:1.9.0 cannot be upgraded to 1.8.15"))
 	})
 
 	It("Should return error message when failing to delete role assignment during upgrade operation", func() {

--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should succeed when cluster VMs are missing expected tags during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.6.9", 1, 1, false)
+		cs := api.CreateMockContainerService("testcluster", "1.7.9", 1, 1, false)
 
 		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
 
@@ -53,7 +53,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should return error message when failing to list VMs during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.6.9", 1, 1, false)
+		cs := api.CreateMockContainerService("testcluster", "1.7.9", 1, 1, false)
 
 		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.14"
 
@@ -77,7 +77,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should return error message when failing to delete VMs during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.6.9", 1, 1, false)
+		cs := api.CreateMockContainerService("testcluster", "1.7.9", 1, 1, false)
 
 		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
 		uc := UpgradeCluster{
@@ -116,7 +116,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should return error message when failing to get a virtual machine during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.6.9", 1, 6, false)
+		cs := api.CreateMockContainerService("testcluster", "1.7.9", 1, 6, false)
 		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
 		uc := UpgradeCluster{
 			Translator: &i18n.Translator{},
@@ -135,7 +135,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should return error message when failing to get storage client during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.6.9", 5, 1, false)
+		cs := api.CreateMockContainerService("testcluster", "1.7.9", 5, 1, false)
 		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
 		uc := UpgradeCluster{
 			Translator: &i18n.Translator{},
@@ -154,7 +154,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should return error message when failing to delete network interface during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.6.9", 3, 2, false)
+		cs := api.CreateMockContainerService("testcluster", "1.7.9", 3, 2, false)
 		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
 		uc := UpgradeCluster{
 			Translator: &i18n.Translator{},
@@ -192,7 +192,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should return error message when failing to delete role assignment during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.6.9", 3, 2, false)
+		cs := api.CreateMockContainerService("testcluster", "1.7.9", 3, 2, false)
 		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
 		cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{}
 		cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity = true
@@ -214,7 +214,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 	})
 
 	It("Should not fail if no managed identity is returned by azure during upgrade operation", func() {
-		cs := api.CreateMockContainerService("testcluster", "1.6.9", 3, 2, false)
+		cs := api.CreateMockContainerService("testcluster", "1.7.9", 3, 2, false)
 		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
 		cs.Properties.OrchestratorProfile.KubernetesConfig = &api.KubernetesConfig{}
 		cs.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Remove constraint of only being able to upgrade to the next minor version if the next minor version is deprecated. Instead, allow upgrading to the next minor version OR the next available minor version. So if I have 1.7 cluster and 1.7 and 1.8 are deprecated, I can upgrade to 1.9 but not 1.10+. If I have a 1.9 cluster I can upgrade to 1.9 or 1.10.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
