### PR TITLE
Strengthen unit tests for cluster ID

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -8,6 +8,7 @@ import (
 	neturl "net/url"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/Azure/acs-engine/pkg/api/agentPoolOnlyApi/v20170831"
 	"github.com/Azure/acs-engine/pkg/api/agentPoolOnlyApi/v20180331"
@@ -886,6 +887,7 @@ func (p *Properties) AreAgentProfilesCustomVNET() bool {
 
 // GetClusterID creates a unique 8 string cluster ID.
 func (p *Properties) GetClusterID() string {
+	var mutex = &sync.Mutex{}
 	if p.ClusterID == "" {
 		uniqueNameSuffixSize := 8
 		// the name suffix uniquely identifies the cluster and is generated off a hash
@@ -899,7 +901,9 @@ func (p *Properties) GetClusterID() string {
 			h.Write([]byte(p.AgentPoolProfiles[0].Name))
 		}
 		rand.Seed(int64(h.Sum64()))
+		mutex.Lock()
 		p.ClusterID = fmt.Sprintf("%08d", rand.Uint32())[:uniqueNameSuffixSize]
+		mutex.Unlock()
 	}
 	return p.ClusterID
 }

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -1666,7 +1666,7 @@ func TestGenerateClusterID(t *testing.T) {
 					},
 				},
 			},
-			expectedClusterID: "11729301",
+			expectedClusterID: "24569115",
 		},
 		{
 			name: "From Hosted Master Profile",
@@ -1691,7 +1691,7 @@ func TestGenerateClusterID(t *testing.T) {
 					},
 				},
 			},
-			expectedClusterID: "24569115",
+			expectedClusterID: "11729301",
 		},
 	}
 

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"log"
-	"regexp"
 	"testing"
 
 	"github.com/Azure/acs-engine/pkg/helpers"
@@ -1650,42 +1649,62 @@ func TestAreAgentProfilesCustomVNET(t *testing.T) {
 }
 
 func TestGenerateClusterID(t *testing.T) {
-	p := &Properties{
-		AgentPoolProfiles: []*AgentPoolProfile{
-			{
-				Name: "foo_agent",
+	tests := []struct {
+		name              string
+		properties        *Properties
+		expectedClusterID string
+	}{
+		{
+			name: "From Master Profile",
+			properties: &Properties{
+				MasterProfile: &MasterProfile{
+					DNSPrefix: "foo_master",
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Name: "foo_agent0",
+					},
+				},
 			},
+			expectedClusterID: "11729301",
+		},
+		{
+			name: "From Hosted Master Profile",
+			properties: &Properties{
+				HostedMasterProfile: &HostedMasterProfile{
+					DNSPrefix: "foo_hosted_master",
+				},
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Name: "foo_agent1",
+					},
+				},
+			},
+			expectedClusterID: "42761241",
+		},
+		{
+			name: "No Master Profile",
+			properties: &Properties{
+				AgentPoolProfiles: []*AgentPoolProfile{
+					{
+						Name: "foo_agent2",
+					},
+				},
+			},
+			expectedClusterID: "24569115",
 		},
 	}
 
-	clusterID := p.GetClusterID()
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			actual := test.properties.GetClusterID()
 
-	r, err := regexp.Compile("[0-9]{8}")
-
-	if err != nil {
-		t.Errorf("unexpected error while parsing regex : %s", err.Error())
-	}
-
-	if !r.MatchString(clusterID) {
-		t.Fatal("ClusterID should be an 8 digit integer string")
-	}
-
-	p = &Properties{
-		HostedMasterProfile: &HostedMasterProfile{
-			DNSPrefix: "foodnsprefx",
-		},
-	}
-
-	clusterID = p.GetClusterID()
-
-	r, err = regexp.Compile("[0-9]{8}")
-
-	if err != nil {
-		t.Errorf("unexpected error while parsing regex : %s", err.Error())
-	}
-
-	if !r.MatchString(clusterID) {
-		t.Fatal("ClusterID should be an 8 digit integer string")
+			if actual != test.expectedClusterID {
+				t.Errorf("expected cluster ID %s, but got %s", test.expectedClusterID, actual)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Check for expected, deterministic, cluster ID based on inputs for `MasterProfile.DNSPrefix`, `HostedMasterProfileDNSPrefix`, and `AgentPoolProfiles[0].Name`.

**Which issue this PR fixes***(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
