### PR TITLE
Using local rand object to generate cluster ids

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -900,9 +900,9 @@ func (p *Properties) GetClusterID() string {
 		} else {
 			h.Write([]byte(p.AgentPoolProfiles[0].Name))
 		}
-		rand.Seed(int64(h.Sum64()))
+		r := rand.New(rand.NewSource(int64(h.Sum64())))
 		mutex.Lock()
-		p.ClusterID = fmt.Sprintf("%08d", rand.Uint32())[:uniqueNameSuffixSize]
+		p.ClusterID = fmt.Sprintf("%08d", r.Uint32())[:uniqueNameSuffixSize]
 		mutex.Unlock()
 	}
 	return p.ClusterID


### PR DESCRIPTION
The current rand object that we use is globally instantiated and it has shown to cause inconsistent outputs in race conditions. We will now use a locally instantiated rand object instead and perform rand operations with mute locks.

This PR should hopefully eliminate the current flakiness observed in our unit test suite.