### PR TITLE
E2E: actually fail when no InternalIP, ssh master tweaks, delete retries

### DIFF
--- a/test/e2e/kubernetes/deployment/deployment.go
+++ b/test/e2e/kubernetes/deployment/deployment.go
@@ -163,11 +163,7 @@ func (d *Deployment) Delete(retries int) error {
 		}
 	}
 
-	if kubectlError != nil {
-		return kubectlError
-	}
-
-	return nil
+	return kubectlError
 }
 
 // Expose will create a load balancer and expose the deployment on a given port

--- a/test/e2e/kubernetes/job/job.go
+++ b/test/e2e/kubernetes/job/job.go
@@ -175,9 +175,5 @@ func (j *Job) Delete(retries int) error {
 		break
 	}
 
-	if kubectlError != nil {
-		return kubectlError
-	}
-
-	return nil
+	return kubectlError
 }

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -32,12 +32,13 @@ import (
 const (
 	WorkloadDir = "workloads"
 	PolicyDir   = "workloads/policies"
-	SSHPort     = "50001"
 )
 
 var (
-	cfg config.Config
-	eng engine.Engine
+	cfg                         config.Config
+	eng                         engine.Engine
+	masterSSHPort               string
+	masterSSHPrivateKeyFilepath string
 )
 
 var _ = BeforeSuite(func() {
@@ -59,6 +60,15 @@ var _ = BeforeSuite(func() {
 		ClusterDefinition:  csInput,
 		ExpandedDefinition: csGenerated,
 	}
+	masterNodes, err := node.GetByPrefix("k8s-master")
+	Expect(err).NotTo(HaveOccurred())
+	masterName := masterNodes[0].Metadata.Name
+	if strings.Contains(masterName, "vmss") {
+		masterSSHPort = "50001"
+	} else {
+		masterSSHPort = "22"
+	}
+	masterSSHPrivateKeyFilepath = cfg.GetSSHKeyPath()
 })
 
 var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", func() {
@@ -67,18 +77,10 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			kubeConfig, err := GetConfig()
 			Expect(err).NotTo(HaveOccurred())
 			master := fmt.Sprintf("azureuser@%s", kubeConfig.GetServerName())
-			sshKeyPath := cfg.GetSSHKeyPath()
-			masterNodes, err := node.GetByPrefix("k8s-master")
-			Expect(err).NotTo(HaveOccurred())
-			masterName := masterNodes[0].Metadata.Name
-			lsbReleaseCmd := fmt.Sprintf("lsb_release -a && uname -r")
 
+			lsbReleaseCmd := fmt.Sprintf("lsb_release -a && uname -r")
 			var cmd *exec.Cmd
-			if strings.Contains(masterName, "vmss") {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-p", SSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, lsbReleaseCmd)
-			} else {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, lsbReleaseCmd)
-			}
+			cmd = exec.Command("ssh", "-i", masterSSHPrivateKeyFilepath, "-p", masterSSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, lsbReleaseCmd)
 			util.PrintCommand(cmd)
 			out, err := cmd.CombinedOutput()
 			log.Printf("%s\n", out)
@@ -87,11 +89,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			}
 
 			kernelVerCmd := fmt.Sprintf("cat /proc/version")
-			if strings.Contains(masterName, "vmss") {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-p", SSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, kernelVerCmd)
-			} else {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, kernelVerCmd)
-			}
+			cmd = exec.Command("ssh", "-i", masterSSHPrivateKeyFilepath, "-p", masterSSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, kernelVerCmd)
 			util.PrintCommand(cmd)
 			out, err = cmd.CombinedOutput()
 			log.Printf("%s\n", out)
@@ -143,19 +141,10 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			kubeConfig, err := GetConfig()
 			Expect(err).NotTo(HaveOccurred())
 			master := fmt.Sprintf("azureuser@%s", kubeConfig.GetServerName())
-			sshKeyPath := cfg.GetSSHKeyPath()
-
-			masterNodes, err := node.GetByPrefix("k8s-master")
-			Expect(err).NotTo(HaveOccurred())
-			masterName := masterNodes[0].Metadata.Name
 
 			ifconfigCmd := fmt.Sprintf("ifconfig -a -v")
 			var cmd *exec.Cmd
-			if strings.Contains(masterName, "vmss") {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-p", SSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, ifconfigCmd)
-			} else {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, ifconfigCmd)
-			}
+			cmd = exec.Command("ssh", "-i", masterSSHPrivateKeyFilepath, "-p", masterSSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, ifconfigCmd)
 			util.PrintCommand(cmd)
 			out, err := cmd.CombinedOutput()
 			log.Printf("%s\n", out)
@@ -164,11 +153,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			}
 
 			resolvCmd := fmt.Sprintf("cat /etc/resolv.conf")
-			if strings.Contains(masterName, "vmss") {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-p", SSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, resolvCmd)
-			} else {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, resolvCmd)
-			}
+			cmd = exec.Command("ssh", "-i", masterSSHPrivateKeyFilepath, "-p", masterSSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, resolvCmd)
 			util.PrintCommand(cmd)
 			out, err = cmd.CombinedOutput()
 			log.Printf("%s\n", out)
@@ -178,11 +163,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 			By("Ensuring that we have a valid connection to our resolver")
 			digCmd := fmt.Sprintf("dig +short +search +answer `hostname`")
-			if strings.Contains(masterName, "vmss") {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-p", SSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
-			} else {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
-			}
+			cmd = exec.Command("ssh", "-i", masterSSHPrivateKeyFilepath, "-p", masterSSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
 			util.PrintCommand(cmd)
 			out, err = cmd.CombinedOutput()
 			log.Printf("%s\n", out)
@@ -196,11 +177,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				By("Ensuring that we get a DNS lookup answer response for each node hostname")
 				digCmd := fmt.Sprintf("dig +short +search +answer %s | grep -v -e '^$'", node.Metadata.Name)
 
-				if strings.Contains(masterName, "vmss") {
-					cmd = exec.Command("ssh", "-i", sshKeyPath, "-p", SSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
-				} else {
-					cmd = exec.Command("ssh", "-i", sshKeyPath, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
-				}
+				cmd = exec.Command("ssh", "-i", masterSSHPrivateKeyFilepath, "-p", masterSSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
 				util.PrintCommand(cmd)
 				out, err = cmd.CombinedOutput()
 				log.Printf("%s\n", out)
@@ -212,22 +189,14 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 			By("Ensuring that we get a DNS lookup answer response for external names")
 			digCmd = fmt.Sprintf("dig +short +search www.bing.com | grep -v -e '^$'")
-			if strings.Contains(masterName, "vmss") {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-p", SSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
-			} else {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
-			}
+			cmd = exec.Command("ssh", "-i", masterSSHPrivateKeyFilepath, "-p", masterSSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
 			util.PrintCommand(cmd)
 			out, err = cmd.CombinedOutput()
 			if err != nil {
 				log.Printf("Error while querying DNS: %s\n", out)
 			}
 			digCmd = fmt.Sprintf("dig +short +search google.com | grep -v -e '^$'")
-			if strings.Contains(masterName, "vmss") {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-p", SSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
-			} else {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
-			}
+			cmd = exec.Command("ssh", "-i", masterSSHPrivateKeyFilepath, "-p", masterSSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
 			util.PrintCommand(cmd)
 			out, err = cmd.CombinedOutput()
 			log.Printf("%s\n", out)
@@ -237,11 +206,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 			By("Ensuring that we get a DNS lookup answer response for external names using external resolver")
 			digCmd = fmt.Sprintf("dig +short +search www.bing.com @8.8.8.8 | grep -v -e '^$'")
-			if strings.Contains(masterName, "vmss") {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-p", SSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
-			} else {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
-			}
+			cmd = exec.Command("ssh", "-i", masterSSHPrivateKeyFilepath, "-p", masterSSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
 			util.PrintCommand(cmd)
 			out, err = cmd.CombinedOutput()
 			log.Printf("%s\n", out)
@@ -249,11 +214,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				log.Printf("Error while querying DNS: %s\n", err)
 			}
 			digCmd = fmt.Sprintf("dig +short +search google.com @8.8.8.8 | grep -v -e '^$'")
-			if strings.Contains(masterName, "vmss") {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-p", SSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
-			} else {
-				cmd = exec.Command("ssh", "-i", sshKeyPath, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
-			}
+			cmd = exec.Command("ssh", "-i", masterSSHPrivateKeyFilepath, "-p", masterSSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, digCmd)
 			util.PrintCommand(cmd)
 			out, err = cmd.CombinedOutput()
 			log.Printf("%s\n", out)
@@ -372,10 +333,6 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					Expect(err).NotTo(HaveOccurred())
 					master := fmt.Sprintf("azureuser@%s", kubeConfig.GetServerName())
 
-					sshKeyPath := cfg.GetSSHKeyPath()
-					masterNodes, err := node.GetByPrefix("k8s-master")
-					Expect(err).NotTo(HaveOccurred())
-					masterName := masterNodes[0].Metadata.Name
 					if dashboardPort == 80 {
 						By("Ensuring that we can connect via HTTP to the dashboard on any one node")
 					} else {
@@ -394,11 +351,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 							dashboardURL := fmt.Sprintf("http://%s:%v", address.Address, port)
 							curlCMD := fmt.Sprintf("curl --max-time 60 %s", dashboardURL)
 							var cmd *exec.Cmd
-							if strings.Contains(masterName, "vmss") {
-								cmd = exec.Command("ssh", "-i", sshKeyPath, "-p", SSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, curlCMD)
-							} else {
-								cmd = exec.Command("ssh", "-i", sshKeyPath, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, curlCMD)
-							}
+							cmd = exec.Command("ssh", "-i", masterSSHPrivateKeyFilepath, "-p", masterSSHPort, "-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", master, curlCMD)
 							util.PrintCommand(cmd)
 							out, err := cmd.CombinedOutput()
 							if err == nil {
@@ -1242,10 +1195,9 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					kubeConfig, err := GetConfig()
 					Expect(err).NotTo(HaveOccurred())
 					master := fmt.Sprintf("azureuser@%s", kubeConfig.GetServerName())
-					sshKeyPath := cfg.GetSSHKeyPath()
 
 					for _, iisPod := range iisPods {
-						valid := iisPod.ValidateHostPort("(IIS Windows Server)", 10, 10*time.Second, master, sshKeyPath)
+						valid := iisPod.ValidateHostPort("(IIS Windows Server)", 10, 10*time.Second, master, masterSSHPrivateKeyFilepath)
 						Expect(valid).To(BeTrue())
 					}
 

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -389,8 +389,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 							address := node.Status.GetAddressByType("InternalIP")
 							if address == nil {
 								log.Printf("One of our nodes does not have an InternalIP value!: %s\n", node.Metadata.Name)
+								Fail("All nodes should have an InternalIP address")
 							}
-							Expect(address).NotTo(Equal(nil))
 							dashboardURL := fmt.Sprintf("http://%s:%v", address.Address, port)
 							curlCMD := fmt.Sprintf("curl --max-time 60 %s", dashboardURL)
 							var cmd *exec.Cmd

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -345,10 +346,12 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 						success := false
 						for i := 0; i < 60; i++ {
 							address := node.Status.GetAddressByType("InternalIP")
+							var getAddressError error
 							if address == nil {
 								log.Printf("One of our nodes does not have an InternalIP value!: %s\n", node.Metadata.Name)
-								Fail("All nodes should have an InternalIP address")
+								getAddressError = errors.New("All nodes should have an InternalIP address")
 							}
+							Expect(getAddressError).NotTo(HaveOccurred())
 							dashboardURL := fmt.Sprintf("http://%s:%v", address.Address, port)
 							curlCMD := fmt.Sprintf("curl --max-time 60 %s", dashboardURL)
 							var cmd *exec.Cmd

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -346,12 +345,10 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 						success := false
 						for i := 0; i < 60; i++ {
 							address := node.Status.GetAddressByType("InternalIP")
-							var getAddressError error
 							if address == nil {
 								log.Printf("One of our nodes does not have an InternalIP value!: %s\n", node.Metadata.Name)
-								getAddressError = errors.New("All nodes should have an InternalIP address")
 							}
-							Expect(getAddressError).NotTo(HaveOccurred())
+							Expect(address).NotTo(BeNil())
 							dashboardURL := fmt.Sprintf("http://%s:%v", address.Address, port)
 							curlCMD := fmt.Sprintf("curl --max-time 60 %s", dashboardURL)
 							var cmd *exec.Cmd

--- a/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
+++ b/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
@@ -85,14 +85,23 @@ func Describe(pvcName, namespace string) error {
 }
 
 // Delete will delete a PersistentVolumeClaims in a given namespace
-func (pvc *PersistentVolumeClaims) Delete() error {
-	cmd := exec.Command("kubectl", "delete", "pvc", "-n", pvc.Metadata.NameSpace, pvc.Metadata.Name)
-	util.PrintCommand(cmd)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Printf("Error while trying to delete PVC %s in namespace %s:%s\n", pvc.Metadata.Name, pvc.Metadata.NameSpace, string(out))
-		return err
+func (pvc *PersistentVolumeClaims) Delete(retries int) error {
+	var kubectlOutput []byte
+	var kubectlError error
+	for i := 0; i < retries; i++ {
+		cmd := exec.Command("kubectl", "delete", "pvc", "-n", pvc.Metadata.NameSpace, pvc.Metadata.Name)
+		kubectlOutput, kubectlError = util.RunAndLogCommand(cmd)
+		if kubectlError != nil {
+			log.Printf("Error while trying to delete PVC %s in namespace %s:%s\n", pvc.Metadata.Name, pvc.Metadata.NameSpace, string(kubectlOutput))
+			continue
+		}
+		break
 	}
+
+	if kubectlError != nil {
+		return kubectlError
+	}
+
 	return nil
 }
 

--- a/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
+++ b/test/e2e/kubernetes/persistentvolumeclaims/persistentvolumeclaims.go
@@ -98,11 +98,7 @@ func (pvc *PersistentVolumeClaims) Delete(retries int) error {
 		break
 	}
 
-	if kubectlError != nil {
-		return kubectlError
-	}
-
-	return nil
+	return kubectlError
 }
 
 // WaitOnReady will block until PersistentVolumeClaims is available

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -502,11 +502,7 @@ func (p *Pod) Delete(retries int) error {
 		break
 	}
 
-	if kubectlError != nil {
-		return kubectlError
-	}
-
-	return nil
+	return kubectlError
 }
 
 // CheckLinuxOutboundConnection will keep retrying the check if an error is received until the timeout occurs or it passes. This helps us when DNS may not be available for some time after a pod starts.

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -219,7 +219,7 @@ func RunCommandMultipleTimes(podRunnerCmd podRunnerCmd, image, name, command str
 			log.Printf("%s\n", string(out[:]))
 		}
 
-		err = p.Delete()
+		err = p.Delete(3)
 		if err != nil {
 			return successfulAttempts, err
 		}

--- a/test/e2e/kubernetes/service/service.go
+++ b/test/e2e/kubernetes/service/service.go
@@ -87,11 +87,7 @@ func (s *Service) Delete(retries int) error {
 		break
 	}
 
-	if kubectlError != nil {
-		return kubectlError
-	}
-
-	return nil
+	return kubectlError
 }
 
 // GetNodePort will return the node port for a given pod

--- a/test/e2e/kubernetes/service/service.go
+++ b/test/e2e/kubernetes/service/service.go
@@ -74,14 +74,23 @@ func Get(name, namespace string) (*Service, error) {
 }
 
 // Delete will delete a service in a given namespace
-func (s *Service) Delete() error {
-	cmd := exec.Command("kubectl", "delete", "svc", "-n", s.Metadata.Namespace, s.Metadata.Name)
-	util.PrintCommand(cmd)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Printf("Error while trying to delete service %s in namespace %s:%s\n", s.Metadata.Namespace, s.Metadata.Name, string(out))
-		return err
+func (s *Service) Delete(retries int) error {
+	var kubectlOutput []byte
+	var kubectlError error
+	for i := 0; i < retries; i++ {
+		cmd := exec.Command("kubectl", "delete", "svc", "-n", s.Metadata.Namespace, s.Metadata.Name)
+		kubectlOutput, kubectlError = util.RunAndLogCommand(cmd)
+		if kubectlError != nil {
+			log.Printf("Error while trying to delete service %s in namespace %s:%s\n", s.Metadata.Namespace, s.Metadata.Name, string(kubectlOutput))
+			continue
+		}
+		break
 	}
+
+	if kubectlError != nil {
+		return kubectlError
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Prior usage was not failing when a node had no InternalIP. Additionally, simplify "the ssh to master" implementations, and retry all deletes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
E2E: actually fail when no InternalIP
```
