### PR TITLE
Update Windows to use Azure cni v1.0.12

### DIFF
--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -46,7 +46,7 @@ var (
 		WindowsTelemetryGUID:             "fb801154-36b9-41bc-89c2-f4d4f05472b0",
 		CNIPluginsDownloadURL:            "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-" + CNIPluginVer + ".tgz",
 		VnetCNILinuxPluginsDownloadURL:   "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-" + AzureCniPluginVerLinux + ".tgz",
-		VnetCNIWindowsPluginsDownloadURL: "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-" + AzureCniPluginVerWindows + ".zip",
+		VnetCNIWindowsPluginsDownloadURL: "https://github.com/Azure/azure-container-networking/releases/download/v1.0.12/azure-vnet-cni-windows-amd64" + AzureCniPluginVerWindows + ".zip",
 		ContainerdDownloadURLBase:        "https://storage.googleapis.com/cri-containerd-release/",
 	}
 

--- a/pkg/acsengine/defaults.go
+++ b/pkg/acsengine/defaults.go
@@ -26,7 +26,211 @@ const (
 	// AzureCniPluginVerWindows specifies version of Azure CNI plugin, which has been mirrored from
 	// https://github.com/Azure/azure-container-networking/releases/download/${AZURE_PLUGIN_VER}/azure-vnet-cni-windows-amd64-${AZURE_PLUGIN_VER}.tgz
 	// to https://acs-mirror.azureedge.net/cni
-	AzureCniPluginVerWindows = "v1.0.11"
+	AzureCniPluginVerWindows = "v1.0.12"
+	// CNIPluginVer specifies the version of CNI implementation
+	// https://github.com/containernetworking/plugins
+	CNIPluginVer = "v0.7.1"
+)
+
+var (
+	//DefaultKubernetesSpecConfig is the default Docker image source of Kubernetes
+	DefaultKubernetesSpecConfig = KubernetesSpecConfig{
+		KubernetesImageBase:              "k8s.gcr.io/",
+		TillerImageBase:                  "gcr.io/kubernetes-helm/",
+		ACIConnectorImageBase:            "microsoft/",
+		NVIDIAImageBase:                  "nvidia/",
+		AzureCNIImageBase:                "containernetworking/",
+		EtcdDownloadURLBase:              "https://acs-mirror.azureedge.net/github-coreos",
+		KubeBinariesSASURLBase:           "https://acs-mirror.azureedge.net/wink8s/",
+		WindowsPackageSASURLBase:         "https://acs-mirror.azureedge.net/wink8s/",
+		WindowsTelemetryGUID:             "fb801154-36b9-41bc-89c2-f4d4f05472b0",
+		CNIPluginsDownloadURL:            "https://acs-mirror.azureedge.net/cni/cni-plugins-amd64-" + CNIPluginVer + ".tgz",
+		VnetCNILinuxPluginsDownloadURL:   "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-linux-amd64-" + AzureCniPluginVerLinux + ".tgz",
+		VnetCNIWindowsPluginsDownloadURL: "https://acs-mirror.azureedge.net/cni/azure-vnet-cni-windows-amd64-" + AzureCniPluginVerWindows + ".zip",
+		ContainerdDownloadURLBase:        "https://storage.googleapis.com/cri-containerd-release/",
+	}
+
+	//DefaultDCOSSpecConfig is the default DC/OS binary download URL.
+	DefaultDCOSSpecConfig = DCOSSpecConfig{
+		DCOS188BootstrapDownloadURL:     fmt.Sprintf(AzureEdgeDCOSBootstrapDownloadURL, "stable", "5df43052907c021eeb5de145419a3da1898c58a5"),
+		DCOS190BootstrapDownloadURL:     fmt.Sprintf(AzureEdgeDCOSBootstrapDownloadURL, "stable", "58fd0833ce81b6244fc73bf65b5deb43217b0bd7"),
+		DCOS198BootstrapDownloadURL:     fmt.Sprintf(AzureEdgeDCOSBootstrapDownloadURL, "stable/1.9.8", "f4ae0d20665fc68ee25282d6f78681b2773c6e10"),
+		DCOS110BootstrapDownloadURL:     fmt.Sprintf(AzureEdgeDCOSBootstrapDownloadURL, "stable/1.10.0", "4d92536e7381176206e71ee15b5ffe454439920c"),
+		DCOS111BootstrapDownloadURL:     fmt.Sprintf(AzureEdgeDCOSBootstrapDownloadURL, "stable/1.11.0", "a0654657903fb68dff60f6e522a7f241c1bfbf0f"),
+		DCOSWindowsBootstrapDownloadURL: "http://dcos-win.westus.cloudapp.azure.com/dcos-windows/stable/",
+		DcosRepositoryURL:               "https://dcosio.azureedge.net/dcos/stable/1.11.0",
+		DcosClusterPackageListID:        "248a66388bba1adbcb14a52fd3b7b424ab06fa76",
+	}
+
+	//DefaultDockerSpecConfig is the default Docker engine repo.
+	DefaultDockerSpecConfig = DockerSpecConfig{
+		DockerEngineRepo:         "https://aptdocker.azureedge.net/repo",
+		DockerComposeDownloadURL: "https://github.com/docker/compose/releases/download",
+	}
+
+	//DefaultUbuntuImageConfig is the default Linux distribution.
+	DefaultUbuntuImageConfig = AzureOSImageConfig{
+		ImageOffer:     "UbuntuServer",
+		ImageSku:       "16.04-LTS",
+		ImagePublisher: "Canonical",
+		ImageVersion:   "16.04.201809120",
+	}
+
+	//SovereignCloudsUbuntuImageConfig is the Linux distribution for Azure Sovereign Clouds.
+	SovereignCloudsUbuntuImageConfig = AzureOSImageConfig{
+		ImageOffer:     "UbuntuServer",
+		ImageSku:       "16.04-LTS",
+		ImagePublisher: "Canonical",
+		ImageVersion:   "latest",
+	}
+
+	//GermanCloudUbuntuImageConfig is the Linux distribution for Azure Sovereign Clouds.
+	GermanCloudUbuntuImageConfig = AzureOSImageConfig{
+		ImageOffer:     "UbuntuServer",
+		ImageSku:       "16.04-LTS",
+		ImagePublisher: "Canonical",
+		ImageVersion:   "16.04.201801050",
+	}
+
+	//DefaultRHELOSImageConfig is the RHEL Linux distribution.
+	DefaultRHELOSImageConfig = AzureOSImageConfig{
+		ImageOffer:     "RHEL",
+		ImageSku:       "7.3",
+		ImagePublisher: "RedHat",
+		ImageVersion:   "latest",
+	}
+
+	//DefaultCoreOSImageConfig is the CoreOS Linux distribution.
+	DefaultCoreOSImageConfig = AzureOSImageConfig{
+		ImageOffer:     "CoreOS",
+		ImageSku:       "Stable",
+		ImagePublisher: "CoreOS",
+		ImageVersion:   "latest",
+	}
+
+	// DefaultAKSOSImageConfig is the AKS image based on Ubuntu 16.04.
+	DefaultAKSOSImageConfig = AzureOSImageConfig{
+		ImageOffer:     "aks",
+		ImageSku:       "aksbase",
+		ImagePublisher: "microsoft-aks",
+		ImageVersion:   "0.16.0",
+	}
+
+	//DefaultOpenShift39RHELImageConfig is the OpenShift on RHEL distribution.
+	DefaultOpenShift39RHELImageConfig = AzureOSImageConfig{
+		ImageOffer:     "acsengine-preview",
+		ImageSku:       "rhel74",
+		ImagePublisher: "redhat",
+		ImageVersion:   "latest",
+	}
+
+	//DefaultOpenShift39CentOSImageConfig is the OpenShift on CentOS distribution.
+	DefaultOpenShift39CentOSImageConfig = AzureOSImageConfig{
+		ImageOffer:     "origin-acsengine-preview",
+		ImageSku:       "centos7",
+		ImagePublisher: "redhat",
+		ImageVersion:   "latest",
+	}
+
+	//AzureCloudSpec is the default configurations for global azure.
+	AzureCloudSpec = AzureEnvironmentSpecConfig{
+		CloudName: azurePublicCloud,
+		//DockerSpecConfig specify the docker engine download repo
+		DockerSpecConfig: DefaultDockerSpecConfig,
+		//KubernetesSpecConfig is the default kubernetes container image url.
+		KubernetesSpecConfig: DefaultKubernetesSpecConfig,
+		DCOSSpecConfig:       DefaultDCOSSpecConfig,
+
+		EndpointConfig: AzureEndpointConfig{
+			ResourceManagerVMDNSSuffix: "cloudapp.azure.com",
+		},
+
+		OSImageConfig: map[api.Distro]AzureOSImageConfig{
+			api.Ubuntu: DefaultUbuntuImageConfig,
+			api.RHEL:   DefaultRHELOSImageConfig,
+			api.CoreOS: DefaultCoreOSImageConfig,
+			api.AKS:    DefaultAKSOSImageConfig,
+			// Image config supported for OpenShift
+			api.OpenShift39RHEL: DefaultOpenShift39RHELImageConfig,
+			api.OpenShiftCentOS: DefaultOpenShift39CentOSImageConfig,
+		},
+	}
+
+	//AzureGermanCloudSpec is the German cloud config.
+	AzureGermanCloudSpec = AzureEnvironmentSpecConfig{
+		CloudName:            azureGermanCloud,
+		DockerSpecConfig:     DefaultDockerSpecConfig,
+		KubernetesSpecConfig: DefaultKubernetesSpecConfig,
+		DCOSSpecConfig:       DefaultDCOSSpecConfig,
+		EndpointConfig: AzureEndpointConfig{
+			ResourceManagerVMDNSSuffix: "cloudapp.microsoftazure.de",
+		},
+		OSImageConfig: map[api.Distro]AzureOSImageConfig{
+			api.Ubuntu: GermanCloudUbuntuImageConfig,
+			api.RHEL:   DefaultRHELOSImageConfig,
+			api.CoreOS: DefaultCoreOSImageConfig,
+			api.AKS:    GermanCloudUbuntuImageConfig,
+		},
+	}
+
+	//AzureUSGovernmentCloud is the US government config.
+	AzureUSGovernmentCloud = AzureEnvironmentSpecConfig{
+		CloudName:            azureUSGovernmentCloud,
+		DockerSpecConfig:     DefaultDockerSpecConfig,
+		KubernetesSpecConfig: DefaultKubernetesSpecConfig,
+		DCOSSpecConfig:       DefaultDCOSSpecConfig,
+		EndpointConfig: AzureEndpointConfig{
+			ResourceManagerVMDNSSuffix: "cloudapp.usgovcloudapi.net",
+		},
+		OSImageConfig: map[api.Distro]AzureOSImageConfig{
+			api.Ubuntu: SovereignCloudsUbuntuImageConfig,
+			api.RHEL:   DefaultRHELOSImageConfig,
+			api.CoreOS: DefaultCoreOSImageConfig,
+			api.AKS:    SovereignCloudsUbuntuImageConfig,
+		},
+	}
+
+	//AzureChinaCloudSpec is the configurations for Azure China (Mooncake)
+	AzureChinaCloudSpec = AzureEnvironmentSpecConfig{
+		CloudName: azureChinaCloud,
+		//DockerSpecConfig specify the docker engine download repo
+		DockerSpecConfig: DockerSpecConfig{
+			DockerEngineRepo:         "https://mirror.azure.cn/docker-engine/apt/repo/",
+			DockerComposeDownloadURL: "https://mirror.azure.cn/docker-toolbox/linux/compose",
+		},
+		//KubernetesSpecConfig - Due to Chinese firewall issue, the default containers from google is blocked, use the Chinese local mirror instead
+		KubernetesSpecConfig: KubernetesSpecConfig{
+			KubernetesImageBase:              "gcr.akscn.io/google_containers/",
+			TillerImageBase:                  "gcr.akscn.io/kubernetes-helm/",
+			ACIConnectorImageBase:            "dockerhub.akscn.io/microsoft/",
+			NVIDIAImageBase:                  "dockerhub.akscn.io/nvidia/",
+			AzureCNIImageBase:                "dockerhub.akscn.io/containernetworking/",
+			EtcdDownloadURLBase:              DefaultKubernetesSpecConfig.EtcdDownloadURLBase,
+			KubeBinariesSASURLBase:           DefaultKubernetesSpecConfig.KubeBinariesSASURLBase,
+			WindowsPackageSASURLBase:         DefaultKubernetesSpecConfig.WindowsPackageSASURLBase,
+			WindowsTelemetryGUID:             DefaultKubernetesSpecConfig.WindowsTelemetryGUID,
+			CNIPluginsDownloadURL:            DefaultKubernetesSpecConfig.CNIPluginsDownloadURL,
+			VnetCNILinuxPluginsDownloadURL:   DefaultKubernetesSpecConfig.VnetCNILinuxPluginsDownloadURL,
+			VnetCNIWindowsPluginsDownloadURL: DefaultKubernetesSpecConfig.VnetCNIWindowsPluginsDownloadURL,
+			ContainerdDownloadURLBase:        "https://mirror.azure.cn/kubernetes/containerd/",
+		},
+		DCOSSpecConfig: DCOSSpecConfig{
+			DCOS188BootstrapDownloadURL:     fmt.Sprintf(AzureChinaCloudDCOSBootstrapDownloadURL, "5df43052907c021eeb5de145419a3da1898c58a5"),
+			DCOSWindowsBootstrapDownloadURL: "https://dcosdevstorage.blob.core.windows.net/dcos-windows",
+			DCOS190BootstrapDownloadURL:     fmt.Sprintf(AzureChinaCloudDCOSBootstrapDownloadURL, "58fd0833ce81b6244fc73bf65b5deb43217b0bd7"),
+			DCOS198BootstrapDownloadURL:     fmt.Sprintf(AzureChinaCloudDCOSBootstrapDownloadURL, "f4ae0d20665fc68ee25282d6f78681b2773c6e10"),
+		},
+
+		EndpointConfig: AzureEndpointConfig{
+			ResourceManagerVMDNSSuffix: "cloudapp.chinacloudapi.cn",
+		},
+		OSImageConfig: map[api.Distro]AzureOSImageConfig{
+			api.Ubuntu: SovereignCloudsUbuntuImageConfig,
+			api.RHEL:   DefaultRHELOSImageConfig,
+			api.CoreOS: DefaultCoreOSImageConfig,
+			api.AKS:    SovereignCloudsUbuntuImageConfig,
+		},
+	}
 )
 
 // setPropertiesDefaults for the container Properties, returns true if certs are generated


### PR DESCRIPTION
**What this PR does / why we need it**:

Improving Windows networking reliability

**Which issue this PR fixes** 
Deploying fix for https://github.com/Azure/azure-container-networking/issues/232 and mitigation for https://github.com/Azure/azure-container-networking/issues/242

Resolves #3405 in most cases. More fixes may still be needed but this is the first step.