### PR TITLE
E2E: clusterFirst DNS liveness probe

### DIFF
--- a/test/e2e/kubernetes/workloads/dns-liveness-cluster-first.yaml
+++ b/test/e2e/kubernetes/workloads/dns-liveness-cluster-first.yaml
@@ -6,7 +6,7 @@ metadata:
   name: dns-liveness
 spec:
   containers:
-  - name: dns-liveness
+  - name: dns-liveness-cluster-first
     image: k8s.gcr.io/busybox
     args:
     - /bin/sh
@@ -21,3 +21,4 @@ spec:
       periodSeconds: 5
   nodeSelector:
     beta.kubernetes.io/os: linux 
+  dnsPolicy: ClusterFirst

--- a/test/e2e/kubernetes/workloads/dns-liveness-cluster-first.yaml
+++ b/test/e2e/kubernetes/workloads/dns-liveness-cluster-first.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   labels:
     test: liveness
-  name: dns-liveness
+  name: dns-liveness-cluster-first
 spec:
   containers:
   - name: dns-liveness-cluster-first


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
E2E: clusterFirst DNS liveness probe
```