### PR TITLE
Replace aad-pod-identity docker image with official MS container registry

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-aad-pod-identity-deployment.yaml
@@ -104,7 +104,7 @@ spec:
       hostNetwork: true
       containers:
       - name: nmi
-        image: "nikhilbh/nmi:1.2"
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.2"
         imagePullPolicy: Always
         resources:
           requests:
@@ -202,7 +202,7 @@ spec:
       serviceAccountName: aad-pod-id-mic-service-account
       containers:
       - name: mic
-        image: "nikhilbh/mic:1.2"
+        image: "mcr.microsoft.com/k8s/aad-pod-identity/mic:1.2"
         imagePullPolicy: Always
         resources:
           requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
The current add-on `aad-pod-identity` uses a docker image originating from an individual's account at docker hub. The official project repo provides a Microsoft container registry to source the same images:

`nikhilbh/nmi:1.2` instead of `mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.2`
`nikhilbh/mci:1.2` instead of `mcr.microsoft.com/k8s/aad-pod-identity/mic:1.2`

Source: https://github.com/Azure/aad-pod-identity/blob/master/deploy/infra/deployment-rbac.yaml
