### PR TITLE
health-monitor script doesn’t require docker

### DIFF
--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -36,6 +36,43 @@ write_files:
   content: !!binary |
     {{WrapAsVariable "provisionConfigs"}}
 
+- path: "/usr/local/bin/health-monitor.sh"
+  permissions: "0544"
+  encoding: gzip
+  owner: "root"
+  content: !!binary |
+    {{WrapAsVariable "healthMonitorScript"}}
+
+- path: "/etc/systemd/system/kubelet-monitor.service"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    [Unit]
+    Description=a script that checks kubelet health and restarts if needed
+    After=kubelet.service
+    [Service]
+    Restart=always
+    RestartSec=10
+    RemainAfterExit=yes
+    ExecStart=/usr/local/bin/health-monitor.sh kubelet
+    [Install]
+    WantedBy=multi-user.target
+
+- path: "/etc/systemd/system/docker-monitor.service"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    [Unit]
+    Description=a script that checks docker health and restarts if needed
+    After=docker.service
+    [Service]
+    Restart=always
+    RestartSec=10
+    RemainAfterExit=yes
+    ExecStart=/usr/local/bin/health-monitor.sh container-runtime
+    [Install]
+    WantedBy=multi-user.target
+
 {{if .KubernetesConfig.RequiresDocker}}
     {{if not .IsCoreOS}}
 - path: "/etc/systemd/system/docker.service.d/clear_mount_propagation_flags.conf"
@@ -72,43 +109,6 @@ write_files:
         }
       }{{end}}{{end}}
     }
-
-- path: "/usr/local/bin/health-monitor.sh"
-  permissions: "0544"
-  encoding: gzip
-  owner: "root"
-  content: !!binary |
-    {{WrapAsVariable "healthMonitorScript"}}
-
-- path: "/etc/systemd/system/docker-monitor.service"
-  permissions: "0644"
-  owner: "root"
-  content: |
-    [Unit]
-    Description=a script that checks docker health and restarts if needed
-    After=docker.service
-    [Service]
-    Restart=always
-    RestartSec=10
-    RemainAfterExit=yes
-    ExecStart=/usr/local/bin/health-monitor.sh container-runtime
-    [Install]
-    WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet-monitor.service"
-  permissions: "0644"
-  owner: "root"
-  content: |
-    [Unit]
-    Description=a script that checks kubelet health and restarts if needed
-    After=kubelet.service
-    [Service]
-    Restart=always
-    RestartSec=10
-    RemainAfterExit=yes
-    ExecStart=/usr/local/bin/health-monitor.sh kubelet
-    [Install]
-    WantedBy=multi-user.target
 {{end}}
 
 {{if IsNSeriesSKU .}}

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -42,6 +42,43 @@ write_files:
   content: !!binary |
     {{WrapAsVariable "provisionConfigs"}}
 
+- path: "/usr/local/bin/health-monitor.sh"
+  permissions: "0544"
+  encoding: gzip
+  owner: "root"
+  content: !!binary |
+    {{WrapAsVariable "healthMonitorScript"}}
+
+- path: "/etc/systemd/system/kubelet-monitor.service"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    [Unit]
+    Description=a script that checks kubelet health and restarts if needed
+    After=kubelet.service
+    [Service]
+    Restart=always
+    RestartSec=10
+    RemainAfterExit=yes
+    ExecStart=/usr/local/bin/health-monitor.sh kubelet
+    [Install]
+    WantedBy=multi-user.target
+
+- path: "/etc/systemd/system/docker-monitor.service"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    [Unit]
+    Description=a script that checks docker health and restarts if needed
+    After=docker.service
+    [Service]
+    Restart=always
+    RestartSec=10
+    RemainAfterExit=yes
+    ExecStart=/usr/local/bin/health-monitor.sh container-runtime
+    [Install]
+    WantedBy=multi-user.target
+
 {{if .OrchestratorProfile.KubernetesConfig.RequiresDocker}}
     {{if not .MasterProfile.IsCoreOS}}
 - path: "/etc/systemd/system/docker.service.d/clear_mount_propagation_flags.conf"
@@ -75,43 +112,6 @@ write_files:
          "max-file": "5"
       }
     }
-
-- path: "/usr/local/bin/health-monitor.sh"
-  permissions: "0544"
-  encoding: gzip
-  owner: "root"
-  content: !!binary |
-    {{WrapAsVariable "healthMonitorScript"}}
-
-- path: "/etc/systemd/system/docker-monitor.service"
-  permissions: "0644"
-  owner: "root"
-  content: |
-    [Unit]
-    Description=a script that checks docker health and restarts if needed
-    After=docker.service
-    [Service]
-    Restart=always
-    RestartSec=10
-    RemainAfterExit=yes
-    ExecStart=/usr/local/bin/health-monitor.sh container-runtime
-    [Install]
-    WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet-monitor.service"
-  permissions: "0644"
-  owner: "root"
-  content: |
-    [Unit]
-    Description=a script that checks kubelet health and restarts if needed
-    After=kubelet.service
-    [Service]
-    Restart=always
-    RestartSec=10
-    RemainAfterExit=yes
-    ExecStart=/usr/local/bin/health-monitor.sh kubelet
-    [Install]
-    WantedBy=multi-user.target
 {{end}}
 
 - path: "/etc/kubernetes/certs/ca.crt"

--- a/parts/k8s/kubernetesmastercustomdatavmss.yml
+++ b/parts/k8s/kubernetesmastercustomdatavmss.yml
@@ -42,6 +42,43 @@ write_files:
   content: !!binary |
     {{WrapAsVariable "provisionConfigs"}}
 
+- path: "/usr/local/bin/health-monitor.sh"
+  permissions: "0544"
+  encoding: gzip
+  owner: "root"
+  content: !!binary |
+    {{WrapAsVariable "healthMonitorScript"}}
+
+- path: "/etc/systemd/system/kubelet-monitor.service"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    [Unit]
+    Description=a script that checks kubelet health and restarts if needed
+    After=kubelet.service
+    [Service]
+    Restart=always
+    RestartSec=10
+    RemainAfterExit=yes
+    ExecStart=/usr/local/bin/health-monitor.sh kubelet
+    [Install]
+    WantedBy=multi-user.target
+
+- path: "/etc/systemd/system/docker-monitor.service"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    [Unit]
+    Description=a script that checks docker health and restarts if needed
+    After=docker.service
+    [Service]
+    Restart=always
+    RestartSec=10
+    RemainAfterExit=yes
+    ExecStart=/usr/local/bin/health-monitor.sh container-runtime
+    [Install]
+    WantedBy=multi-user.target
+
 {{if .OrchestratorProfile.KubernetesConfig.RequiresDocker}}
     {{if not .MasterProfile.IsCoreOS}}
 - path: "/etc/systemd/system/docker.service.d/clear_mount_propagation_flags.conf"
@@ -75,43 +112,6 @@ write_files:
          "max-file": "5"
       }
     }
-
-- path: "/usr/local/bin/health-monitor.sh"
-  permissions: "0544"
-  encoding: gzip
-  owner: "root"
-  content: !!binary |
-    {{WrapAsVariable "healthMonitorScript"}}
-
-- path: "/etc/systemd/system/docker-monitor.service"
-  permissions: "0644"
-  owner: "root"
-  content: |
-    [Unit]
-    Description=a script that checks docker health and restarts if needed
-    After=docker.service
-    [Service]
-    Restart=always
-    RestartSec=10
-    RemainAfterExit=yes
-    ExecStart=/usr/local/bin/health-monitor.sh container-runtime
-    [Install]
-    WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet-monitor.service"
-  permissions: "0644"
-  owner: "root"
-  content: |
-    [Unit]
-    Description=a script that checks kubelet health and restarts if needed
-    After=kubelet.service
-    [Service]
-    Restart=always
-    RestartSec=10
-    RemainAfterExit=yes
-    ExecStart=/usr/local/bin/health-monitor.sh kubelet
-    [Install]
-    WantedBy=multi-user.target
 {{end}}
 
 - path: "/etc/kubernetes/certs/ca.crt"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Ensure health-monitor artifacts are installed on all cluster configs

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
health-monitor script doesn’t require docker
```
