### PR TITLE
Fix linter errors reported by gosimple

### DIFF
--- a/pkg/api/defaults_test.go
+++ b/pkg/api/defaults_test.go
@@ -627,9 +627,10 @@ func TestMasterProfileDefaults(t *testing.T) {
 	properties.OrchestratorProfile.OrchestratorType = "Kubernetes"
 	properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku = "Standard"
 	mockCS.SetPropertiesDefaults(false, false)
-	if *properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB != DefaultExcludeMasterFromStandardLB {
+	excludeMaster := DefaultExcludeMasterFromStandardLB
+	if *properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB != excludeMaster {
 		t.Fatalf("OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB did not have the expected configuration, got %t, expected %t",
-			*properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB, DefaultExcludeMasterFromStandardLB)
+			*properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB, excludeMaster)
 	}
 }
 
@@ -780,9 +781,10 @@ func TestSetVMSSDefaultsAndZones(t *testing.T) {
 	properties.MasterProfile.AvailabilityProfile = VirtualMachineScaleSets
 	properties.MasterProfile.AvailabilityZones = []string{"1", "2"}
 	mockCS.SetPropertiesDefaults(false, false)
-	if *properties.MasterProfile.SinglePlacementGroup != DefaultSinglePlacementGroup {
+	singlePlacementGroup := DefaultSinglePlacementGroup
+	if *properties.MasterProfile.SinglePlacementGroup != singlePlacementGroup {
 		t.Fatalf("MasterProfile.SinglePlacementGroup default did not have the expected configuration, got %t, expected %t",
-			*properties.MasterProfile.SinglePlacementGroup, DefaultSinglePlacementGroup)
+			*properties.MasterProfile.SinglePlacementGroup, singlePlacementGroup)
 	}
 	if !properties.MasterProfile.HasAvailabilityZones() {
 		t.Fatalf("MasterProfile.HasAvailabilityZones did not have the expected return, got %t, expected %t",
@@ -792,9 +794,10 @@ func TestSetVMSSDefaultsAndZones(t *testing.T) {
 		t.Fatalf("OrchestratorProfile.KubernetesConfig.LoadBalancerSku did not have the expected configuration, got %s, expected %s",
 			properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, "Standard")
 	}
-	if *properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB != DefaultExcludeMasterFromStandardLB {
+	excludeMaster := DefaultExcludeMasterFromStandardLB
+	if *properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB != excludeMaster {
 		t.Fatalf("OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB did not have the expected configuration, got %t, expected %t",
-			*properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB, DefaultExcludeMasterFromStandardLB)
+			*properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB, excludeMaster)
 	}
 	// agents with vmss and no zones
 	mockCS = getMockBaseContainerService("1.12.0")
@@ -825,17 +828,19 @@ func TestSetVMSSDefaultsAndZones(t *testing.T) {
 		t.Fatalf("AgentPoolProfiles[0].HasAvailabilityZones did not have the expected return, got %t, expected %t",
 			properties.AgentPoolProfiles[0].HasAvailabilityZones(), true)
 	}
-	if *properties.AgentPoolProfiles[0].SinglePlacementGroup != DefaultSinglePlacementGroup {
+	singlePlacementGroup = DefaultSinglePlacementGroup
+	if *properties.AgentPoolProfiles[0].SinglePlacementGroup != singlePlacementGroup {
 		t.Fatalf("AgentPoolProfile[0].SinglePlacementGroup default did not have the expected configuration, got %t, expected %t",
-			*properties.AgentPoolProfiles[0].SinglePlacementGroup, DefaultSinglePlacementGroup)
+			*properties.AgentPoolProfiles[0].SinglePlacementGroup, singlePlacementGroup)
 	}
 	if properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != "Standard" {
 		t.Fatalf("OrchestratorProfile.KubernetesConfig.LoadBalancerSku did not have the expected configuration, got %s, expected %s",
 			properties.OrchestratorProfile.KubernetesConfig.LoadBalancerSku, "Standard")
 	}
-	if *properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB != DefaultExcludeMasterFromStandardLB {
+	excludeMaster = DefaultExcludeMasterFromStandardLB
+	if *properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB != excludeMaster {
 		t.Fatalf("OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB did not have the expected configuration, got %t, expected %t",
-			*properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB, DefaultExcludeMasterFromStandardLB)
+			*properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB, excludeMaster)
 	}
 
 	properties.AgentPoolProfiles[0].Count = 110


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Fixes some errors reported by the current version of `gosimple` that keep tripping me up in local development.

```sh
$ make test-style

==> Running static validations <==
pkg/api/defaults_test.go:630:5:warning: should omit comparison to bool constant, can be simplified to !*properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB (S1002) (gosimple)
pkg/api/defaults_test.go:783:5:warning: should omit comparison to bool constant, can be simplified to !*properties.MasterProfile.SinglePlacementGroup (S1002) (gosimple)
pkg/api/defaults_test.go:795:5:warning: should omit comparison to bool constant, can be simplified to !*properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB (S1002) (gosimple)
pkg/api/defaults_test.go:828:5:warning: should omit comparison to bool constant, can be simplified to !*properties.AgentPoolProfiles[0].SinglePlacementGroup (S1002) (gosimple)
pkg/api/defaults_test.go:836:5:warning: should omit comparison to bool constant, can be simplified to !*properties.OrchestratorProfile.KubernetesConfig.ExcludeMasterFromStandardLB (S1002) (gosimple)
```


**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
