### PR TITLE
Fix typo in prometheus-grafana-k8s extension

### DIFF
--- a/extensions/prometheus-grafana-k8s/v1/template-link.json
+++ b/extensions/prometheus-grafana-k8s/v1/template-link.json
@@ -1,7 +1,7 @@
 {
     "name": "[concat(EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), 'PrometheusGrafanaK8s')]",
     "type": "Microsoft.Resources/deployments",
-    "apiVersion": "[variables('apiVersionComput')]",
+    "apiVersion": "[variables('apiVersionCompute')]",
     "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', EXTENSION_TARGET_VM_NAME_PREFIX, copyIndex(EXTENSION_LOOP_OFFSET), '/extensions/cse', '-EXTENSION_TARGET_VM_TYPE-', copyIndex(EXTENSION_LOOP_OFFSET))]"
     ],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Fix typo in prometheus-grafana-k8s extension

error:
```
FATA[0020] resources.DeploymentsClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidTemplate" Message="Deployment template validation failed: 'The template variable 'apiVersionComput' is not found. Please see https://aka.ms/arm-template/#variables for usage details.'." 
```