### PR TITLE
schedule ip-masq-agent on masters

### DIFF
--- a/parts/k8s/addons/ip-masq-agent.yaml
+++ b/parts/k8s/addons/ip-masq-agent.yaml
@@ -18,6 +18,13 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/os: linux
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
       containers:
       - name: azure-ip-masq-agent
         image: gcr.io/google-containers/ip-masq-agent-amd64:v2.0.0

--- a/test/e2e/kubernetes/workloads/nginx-master.yaml
+++ b/test/e2e/kubernetes/workloads/nginx-master.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-master
+  labels:
+    app: nginx-master
+spec:
+  containers:
+  - image: library/nginx:latest
+    name: nginx-master
+    command:
+      - sleep
+      - "1000000"
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: "Exists"
+  nodeSelector:
+    kubernetes.io/role: master


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Enables SNAT enforcement for pods scheduled on master nodes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: This fixes a regression introduced here:

https://github.com/Azure/acs-engine/pull/3916/files#diff-91eb315fd90ae6b7177cd6290a360600

Previously, for Azure CNI clusters we were enforcing OS SNAT via static iptables masquerade rules applied at provisioning time on *both* agent and master nodes. (See the above link for the removal of master iptables rule).

With the introduction of ip-masq-agent daemonset addon to do the same, we failed to include a master no schedule toleration, so without this fix there is no equivalent SNAT on master nodes.

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
schedule ip-masq-agent on masters
```
