### PR TITLE
delay docker and kubelet health monitors for 30 mins

### DIFF
--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -43,6 +43,17 @@ write_files:
   content: !!binary |
     {{WrapAsVariable "healthMonitorScript"}}
 
+- path: "/etc/systemd/system/kubelet-monitor.timer"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    [Unit]
+    Description=a timer that delays kubelet-monitor from starting too soon after boot
+    [Timer]
+    OnBootSec=30min
+    [Install]
+    WantedBy=multi-user.target
+
 - path: "/etc/systemd/system/kubelet-monitor.service"
   permissions: "0644"
   owner: "root"
@@ -55,6 +66,15 @@ write_files:
     RestartSec=10
     RemainAfterExit=yes
     ExecStart=/usr/local/bin/health-monitor.sh kubelet
+
+- path: "/etc/systemd/system/docker-monitor.timer"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    [Unit]
+    Description=a timer that delays docker-monitor from starting too soon after boot
+    [Timer]
+    OnBootSec=30min
     [Install]
     WantedBy=multi-user.target
 
@@ -70,8 +90,6 @@ write_files:
     RestartSec=10
     RemainAfterExit=yes
     ExecStart=/usr/local/bin/health-monitor.sh container-runtime
-    [Install]
-    WantedBy=multi-user.target
 
 {{if .KubernetesConfig.RequiresDocker}}
     {{if not .IsCoreOS}}

--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -247,6 +247,7 @@ function ensureDocker() {
     systemctlEnableAndStart docker
     DOCKER_MONITOR_SYSTEMD_FILE=/etc/systemd/system/docker-monitor.service
     wait_for_file 1200 1 $DOCKER_MONITOR_SYSTEMD_FILE || exit $ERR_FILE_WATCH_TIMEOUT
+    # TODO don't systemctl enable docker-monitor for 30 mins
     systemctlEnableAndStart docker-monitor || exit $ERR_SYSTEMCTL_START_FAIL
 }
 function ensureKMS() {
@@ -263,6 +264,7 @@ function ensureKubelet() {
     systemctlEnableAndStart kubelet || exit $ERR_KUBELET_START_FAIL
     KUBELET_MONITOR_SYSTEMD_FILE=/etc/systemd/system/kubelet-monitor.service
     wait_for_file 1200 1 $KUBELET_MONITOR_SYSTEMD_FILE || exit $ERR_FILE_WATCH_TIMEOUT
+    # TODO don't systemctl enable docker-monitor for 30 mins
     systemctlEnableAndStart kubelet-monitor || exit $ERR_SYSTEMCTL_START_FAIL
 }
 

--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -245,10 +245,12 @@ function ensureDocker() {
     DOCKER_JSON_FILE=/etc/docker/daemon.json
     wait_for_file 1200 1 $DOCKER_JSON_FILE || exit $ERR_FILE_WATCH_TIMEOUT
     systemctlEnableAndStart docker
+    # Delay start of docker-monitor for 30 mins after booting
+    DOCKER_MONITOR_SYSTEMD_TIMER_FILE=/etc/systemd/system/docker-monitor.timer
+    wait_for_file 1200 1 $DOCKER_MONITOR_SYSTEMD_TIMER_FILE || exit $ERR_FILE_WATCH_TIMEOUT
     DOCKER_MONITOR_SYSTEMD_FILE=/etc/systemd/system/docker-monitor.service
     wait_for_file 1200 1 $DOCKER_MONITOR_SYSTEMD_FILE || exit $ERR_FILE_WATCH_TIMEOUT
-    # TODO don't systemctl enable docker-monitor for 30 mins
-    systemctlEnableAndStart docker-monitor || exit $ERR_SYSTEMCTL_START_FAIL
+    systemctlEnableAndStart docker-monitor.timer || exit $ERR_SYSTEMCTL_START_FAIL
 }
 function ensureKMS() {
     systemctlEnableAndStart kms || exit $ERR_SYSTEMCTL_START_FAIL
@@ -262,10 +264,12 @@ function ensureKubelet() {
     KUBELET_RUNTIME_CONFIG_SCRIPT_FILE=/opt/azure/containers/kubelet.sh
     wait_for_file 1200 1 $KUBELET_RUNTIME_CONFIG_SCRIPT_FILE || exit $ERR_FILE_WATCH_TIMEOUT
     systemctlEnableAndStart kubelet || exit $ERR_KUBELET_START_FAIL
+    # Delay start of kubelet-monitor for 30 mins after booting
+    KUBELET_MONITOR_SYSTEMD_TIMER_FILE=/etc/systemd/system/kubelet-monitor.timer
+    wait_for_file 1200 1 $KUBELET_MONITOR_SYSTEMD_TIMER_FILE || exit $ERR_FILE_WATCH_TIMEOUT
     KUBELET_MONITOR_SYSTEMD_FILE=/etc/systemd/system/kubelet-monitor.service
     wait_for_file 1200 1 $KUBELET_MONITOR_SYSTEMD_FILE || exit $ERR_FILE_WATCH_TIMEOUT
-    # TODO don't systemctl enable docker-monitor for 30 mins
-    systemctlEnableAndStart kubelet-monitor || exit $ERR_SYSTEMCTL_START_FAIL
+    systemctlEnableAndStart kubelet-monitor.timer || exit $ERR_SYSTEMCTL_START_FAIL
 }
 
 function ensureJournal(){

--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -49,6 +49,17 @@ write_files:
   content: !!binary |
     {{WrapAsVariable "healthMonitorScript"}}
 
+- path: "/etc/systemd/system/kubelet-monitor.timer"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    [Unit]
+    Description=a timer that delays kubelet-monitor from starting too soon after boot
+    [Timer]
+    OnBootSec=30min
+    [Install]
+    WantedBy=multi-user.target
+
 - path: "/etc/systemd/system/kubelet-monitor.service"
   permissions: "0644"
   owner: "root"
@@ -61,6 +72,15 @@ write_files:
     RestartSec=10
     RemainAfterExit=yes
     ExecStart=/usr/local/bin/health-monitor.sh kubelet
+
+- path: "/etc/systemd/system/docker-monitor.timer"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    [Unit]
+    Description=a timer that delays docker-monitor from starting too soon after boot
+    [Timer]
+    OnBootSec=30min
     [Install]
     WantedBy=multi-user.target
 
@@ -76,8 +96,6 @@ write_files:
     RestartSec=10
     RemainAfterExit=yes
     ExecStart=/usr/local/bin/health-monitor.sh container-runtime
-    [Install]
-    WantedBy=multi-user.target
 
 {{if .OrchestratorProfile.KubernetesConfig.RequiresDocker}}
     {{if not .MasterProfile.IsCoreOS}}

--- a/parts/k8s/kubernetesmastercustomdatavmss.yml
+++ b/parts/k8s/kubernetesmastercustomdatavmss.yml
@@ -49,6 +49,17 @@ write_files:
   content: !!binary |
     {{WrapAsVariable "healthMonitorScript"}}
 
+- path: "/etc/systemd/system/kubelet-monitor.timer"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    [Unit]
+    Description=a timer that delays kubelet-monitor from starting too soon after boot
+    [Timer]
+    OnBootSec=30min
+    [Install]
+    WantedBy=multi-user.target
+
 - path: "/etc/systemd/system/kubelet-monitor.service"
   permissions: "0644"
   owner: "root"
@@ -61,6 +72,15 @@ write_files:
     RestartSec=10
     RemainAfterExit=yes
     ExecStart=/usr/local/bin/health-monitor.sh kubelet
+
+- path: "/etc/systemd/system/docker-monitor.timer"
+  permissions: "0644"
+  owner: "root"
+  content: |
+    [Unit]
+    Description=a timer that delays docker-monitor from starting too soon after boot
+    [Timer]
+    OnBootSec=30min
     [Install]
     WantedBy=multi-user.target
 
@@ -76,8 +96,6 @@ write_files:
     RestartSec=10
     RemainAfterExit=yes
     ExecStart=/usr/local/bin/health-monitor.sh container-runtime
-    [Install]
-    WantedBy=multi-user.target
 
 {{if .OrchestratorProfile.KubernetesConfig.RequiresDocker}}
     {{if not .MasterProfile.IsCoreOS}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: We are observing health monitor enforcement as docker first comes online. Let's include a cooling down period after first boot until we enable the health monitors.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
delay docker and kubelet health monitors for 30 mins
```
