### PR TITLE
Don't block on Kubernetes installation cleanup operations

### DIFF
--- a/parts/k8s/kubernetesinstalls.sh
+++ b/parts/k8s/kubernetesinstalls.sh
@@ -7,7 +7,7 @@ CNI_BIN_DIR="/opt/cni/bin"
 CNI_DOWNLOADS_DIR="/opt/cni/downloads"
 
 function removeEtcd() {
-    rm -rf /usr/bin/etcd
+    rm -rf /usr/bin/etcd &
 }
 
 function installEtcd() {
@@ -110,7 +110,7 @@ function installNetworkPlugin() {
         installAzureCNI
     fi
     installCNI
-    rm -rf $CNI_DOWNLOADS_DIR
+    rm -rf $CNI_DOWNLOADS_DIR &
 }
 
 function downloadCNI() {
@@ -192,8 +192,7 @@ function extractHyperkube() {
     mv "/usr/local/bin/kubelet-${KUBERNETES_VERSION}" "/usr/local/bin/kubelet"
     mv "/usr/local/bin/kubectl-${KUBERNETES_VERSION}" "/usr/local/bin/kubectl"
     chmod a+x /usr/local/bin/kubelet /usr/local/bin/kubectl
-    rm -rf /usr/local/bin/kubelet-* /usr/local/bin/kubectl-*
-    rm -rf /home/rootfs-*
+    rm -rf /usr/local/bin/kubelet-* /usr/local/bin/kubectl-* /home/rootfs-* &
 }
 
 function pullContainerImage() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Some `rm -rf` operations take several seconds, so doing this cleanup asynchronously should speed things up.

**Which issue this PR fixes**:

Fixes #4052 

**Special notes for your reviewer**:

Will this play nice with our VHD build process? It works fine in manual testing.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Kubernetes: don't block on installation cleanup operations
```
