### PR TITLE
set default masterSubnet value for custom VNET

### DIFF
--- a/parts/masterparams.t
+++ b/parts/masterparams.t
@@ -40,6 +40,13 @@
       "type": "string"
     },
     {{end}}
+    "masterSubnet": {
+      "defaultValue": "",
+      "metadata": {
+        "description": "Sets the subnet of the master node(s)"
+      },
+      "type": "string"
+    },
   {{else}}
     "masterSubnet": {
       "defaultValue": "{{.MasterProfile.Subnet}}",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4027

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
set default masterSubnet value for custom VNET
```
