### PR TITLE
 Don't test k8s 1.8 or 1.9 in CircleCI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,32 +65,6 @@ jobs:
           path: /go/src/github.com/Azure/acs-engine/_logs
       - store_artifacts:
           path: /go/src/github.com/Azure/acs-engine/_output
-  k8s-1.9-release-e2e:
-    <<: *defaults
-    steps:
-      - checkout
-      - run: |
-          echo 'export TIMEOUT=20m' >> $BASH_ENV
-          echo 'export ORCHESTRATOR_RELEASE=1.9' >> $BASH_ENV
-          echo 'export CLUSTER_DEFINITION=examples/e2e-tests/kubernetes/release/default/definition.json' >> $BASH_ENV
-          echo 'export CREATE_VNET=true' >> $BASH_ENV
-          echo 'export CLEANUP_ON_EXIT=${CLEANUP_ON_EXIT}' >> $BASH_ENV
-          echo 'export CLEANUP_IF_FAIL=${CLEANUP_IF_FAIL_LINUX}' >> $BASH_ENV
-          echo 'export RETAIN_SSH=false' >> $BASH_ENV
-          echo 'export SUBSCRIPTION_ID=${SUBSCRIPTION_ID_E2E_KUBERNETES}' >> $BASH_ENV
-          echo 'export CLIENT_ID=${SERVICE_PRINCIPAL_CLIENT_ID_E2E_KUBERNETES}' >> $BASH_ENV
-          echo 'export CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET_E2E_KUBERNETES}' >> $BASH_ENV
-      - run:
-          name: compile
-          command: make build-binary
-      - run:
-          name: ginkgo k8s e2e tests
-          command: make test-kubernetes
-          no_output_timeout: "30m"
-      - store_artifacts:
-          path: /go/src/github.com/Azure/acs-engine/_logs
-      - store_artifacts:
-          path: /go/src/github.com/Azure/acs-engine/_output
   k8s-1.10-release-e2e:
     <<: *defaults
     steps:
@@ -197,57 +171,6 @@ jobs:
           command: make build-binary
       - run:
           name: ginkgo k8s e2e tests
-          command: make test-kubernetes
-          no_output_timeout: "30m"
-      - store_artifacts:
-          path: /go/src/github.com/Azure/acs-engine/_logs
-      - store_artifacts:
-          path: /go/src/github.com/Azure/acs-engine/_output
-  k8s-1.8-release-e2e:
-    <<: *defaults
-    steps:
-      - checkout
-      - run: |
-          echo 'export TIMEOUT=20m' >> $BASH_ENV
-          echo 'export ORCHESTRATOR_RELEASE=1.8' >> $BASH_ENV
-          echo 'export CLUSTER_DEFINITION=examples/e2e-tests/kubernetes/release/default/definition.json' >> $BASH_ENV
-          echo 'export CREATE_VNET=true' >> $BASH_ENV
-          echo 'export CLEANUP_ON_EXIT=${CLEANUP_ON_EXIT}' >> $BASH_ENV
-          echo 'export CLEANUP_IF_FAIL=${CLEANUP_IF_FAIL_LINUX}' >> $BASH_ENV
-          echo 'export RETAIN_SSH=false' >> $BASH_ENV
-          echo 'export SUBSCRIPTION_ID=${SUBSCRIPTION_ID_E2E_KUBERNETES}' >> $BASH_ENV
-          echo 'export CLIENT_ID=${SERVICE_PRINCIPAL_CLIENT_ID_E2E_KUBERNETES}' >> $BASH_ENV
-          echo 'export CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET_E2E_KUBERNETES}' >> $BASH_ENV
-      - run:
-          name: compile
-          command: make build-binary
-      - run:
-          name: ginkgo k8s e2e tests
-          command: make test-kubernetes
-          no_output_timeout: "30m"
-      - store_artifacts:
-          path: /go/src/github.com/Azure/acs-engine/_logs
-      - store_artifacts:
-          path: /go/src/github.com/Azure/acs-engine/_output
-  k8s-windows-1.9-release-e2e:
-    <<: *defaults
-    steps:
-      - checkout
-      - run: |
-          echo 'export TIMEOUT=30m' >> $BASH_ENV
-          echo 'export ORCHESTRATOR_RELEASE=1.9' >> $BASH_ENV
-          echo 'export CLUSTER_DEFINITION=examples/e2e-tests/kubernetes/windows/hybrid/definition.json' >> $BASH_ENV
-          echo 'export CLEANUP_ON_EXIT=${CLEANUP_ON_EXIT}' >> $BASH_ENV
-          echo 'export CLEANUP_IF_FAIL=${CLEANUP_IF_FAIL_WINDOWS}' >> $BASH_ENV
-          echo 'export RETAIN_SSH=false' >> $BASH_ENV
-          echo 'export SUBSCRIPTION_ID=${SUBSCRIPTION_ID_E2E_KUBERNETES}' >> $BASH_ENV
-          echo 'export CLIENT_ID=${SERVICE_PRINCIPAL_CLIENT_ID_E2E_KUBERNETES}' >> $BASH_ENV
-          echo 'export CLIENT_SECRET=${SERVICE_PRINCIPAL_CLIENT_SECRET_E2E_KUBERNETES}' >> $BASH_ENV
-      - run:
-          name: compile
-          command: make build-binary
-      - run:
-          name: ginkgo k8s windows e2e tests
           command: make test-kubernetes
           no_output_timeout: "30m"
       - store_artifacts:
@@ -375,18 +298,6 @@ workflows:
           filters:
             branches:
               ignore: master
-      - k8s-1.8-release-e2e:
-          requires:
-            - pr-e2e-hold
-          filters:
-            branches:
-              ignore: master
-      - k8s-windows-1.9-release-e2e:
-          requires:
-            - pr-e2e-hold
-          filters:
-            branches:
-              ignore: master
       - k8s-windows-1.10-release-e2e:
           requires:
             - pr-e2e-hold
@@ -406,12 +317,6 @@ workflows:
             branches:
               ignore: master
       - k8s-windows-1.13-release-e2e:
-          requires:
-            - pr-e2e-hold
-          filters:
-            branches:
-              ignore: master
-      - k8s-1.9-release-e2e:
           requires:
             - pr-e2e-hold
           filters:
@@ -444,24 +349,6 @@ workflows:
   build_and_test_master:
     jobs:
       - test:
-          filters:
-            branches:
-              only: master
-      - k8s-1.8-release-e2e:
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
-      - k8s-windows-1.9-release-e2e:
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
-      - k8s-1.9-release-e2e:
-          requires:
-            - test
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,31 +298,13 @@ workflows:
           filters:
             branches:
               ignore: master
-      - k8s-windows-1.10-release-e2e:
-          requires:
-            - pr-e2e-hold
-          filters:
-            branches:
-              ignore: master
-      - k8s-windows-1.11-release-e2e:
-          requires:
-            - pr-e2e-hold
-          filters:
-            branches:
-              ignore: master
-      - k8s-windows-1.12-release-e2e:
-          requires:
-            - pr-e2e-hold
-          filters:
-            branches:
-              ignore: master
-      - k8s-windows-1.13-release-e2e:
-          requires:
-            - pr-e2e-hold
-          filters:
-            branches:
-              ignore: master
       - k8s-1.10-release-e2e:
+          requires:
+            - pr-e2e-hold
+          filters:
+            branches:
+              ignore: master
+      - k8s-windows-1.10-release-e2e:
           requires:
             - pr-e2e-hold
           filters:
@@ -334,13 +316,31 @@ workflows:
           filters:
             branches:
               ignore: master
+      - k8s-windows-1.11-release-e2e:
+          requires:
+            - pr-e2e-hold
+          filters:
+            branches:
+              ignore: master
       - k8s-1.12-release-e2e:
           requires:
             - pr-e2e-hold
           filters:
             branches:
               ignore: master
+      - k8s-windows-1.12-release-e2e:
+          requires:
+            - pr-e2e-hold
+          filters:
+            branches:
+              ignore: master
       - k8s-1.13-release-e2e:
+          requires:
+            - pr-e2e-hold
+          filters:
+            branches:
+              ignore: master
+      - k8s-windows-1.13-release-e2e:
           requires:
             - pr-e2e-hold
           filters:
@@ -370,19 +370,31 @@ workflows:
           filters:
             branches:
               only: master
-      - k8s-1.12-release-e2e:
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
       - k8s-windows-1.11-release-e2e:
           requires:
             - test
           filters:
             branches:
               only: master
+      - k8s-1.12-release-e2e:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master
       - k8s-windows-1.12-release-e2e:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master
+      - k8s-1.13-release-e2e:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master
+      - k8s-windows-1.13-release-e2e:
           requires:
             - test
           filters:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

It's not practical for us to test *every* minor release of Kubernetes on each pull request, so let's drop 1.8 and 1.9. We still have regularly-scheduled Jenkins CI jobs to point out regression failures for those versions.

This also adds Kubernetes 1.13 to the build_and_test_master task since I missed that previously. It sorts the jobs so that they all follow this order which I think will help with future maintenance:

```yaml
- k8s-1.10-release-e2e
- k8s-windows-1.10-release-e2e
- k8s-1.11-release-e2e
- k8s-windows-1.11-release-e2e
```

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Kubernetes: don't test 1.8 or 1.9 in CircleCI
```
