### PR TITLE
E2E: enable pod-svc connection test

### DIFF
--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	ForceDeploy         bool   `envconfig:"FORCE_DEPLOY"`
 	UseDeployCommand    bool   `envconfig:"USE_DEPLOY_COMMAND"`
 	GinkgoFocus         string `envconfig:"GINKGO_FOCUS"`
+	GinkgoSkip          string `envconfig:"GINKGO_SKIP"`
 }
 
 const (

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -429,8 +429,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 
 		It("should have stable pod-to-pod networking", func() {
 			if eng.HasLinuxAgents() {
-				By("Creating a test php-apache deployment with request limit thresholds")
-				// Inspired by http://blog.kubernetes.io/2016/07/autoscaling-in-kubernetes.html
+				By("Creating a test php-apache deployment")
 				r := rand.New(rand.NewSource(time.Now().UnixNano()))
 				phpApacheName := fmt.Sprintf("php-apache-%s-%v", cfg.Name, r.Intn(99999))
 				phpApacheDeploy, err := deployment.CreateLinuxDeploy("k8s.gcr.io/hpa-example", phpApacheName, "default", "--requests=cpu=10m,memory=10M")

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -670,6 +670,45 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			}
 		})
 
+		It("should be able to have pod-to-pod networking", func() {
+			if eng.HasLinuxAgents() {
+				By("Creating a test php-apache deployment with request limit thresholds")
+				// Inspired by http://blog.kubernetes.io/2016/07/autoscaling-in-kubernetes.html
+				r := rand.New(rand.NewSource(time.Now().UnixNano()))
+				phpApacheName := fmt.Sprintf("php-apache-%s-%v", cfg.Name, r.Intn(99999))
+				phpApacheDeploy, err := deployment.CreateLinuxDeploy("k8s.gcr.io/hpa-example", phpApacheName, "default", "--requests=cpu=10m,memory=10M")
+				if err != nil {
+					fmt.Println(err)
+				}
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Ensuring that php-apache pod is running")
+				running, err := pod.WaitOnReady(phpApacheName, "default", 3, 5*time.Second, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(running).To(Equal(true))
+
+				By("Exposing TCP 80 internally on the php-apache deployment")
+				err = phpApacheDeploy.Expose("ClusterIP", 80, 80)
+				Expect(err).NotTo(HaveOccurred())
+				s, err := service.Get(phpApacheName, "default")
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Creating another pod that will connect to the php-apache pod")
+				// Launch a simple busybox pod that wget's continuously to the apache serviceto simulate load
+				commandString := fmt.Sprintf("nc -vz %s.default.svc.cluster.local 80", phpApacheName)
+				consumerPodName := fmt.Sprintf("consumer-pod-%s-%v", cfg.Name, r.Intn(99999))
+				successes, err := pod.RunCommandMultipleTimes(pod.RunLinuxPod, "busybox", consumerPodName, commandString, cfg.StabilityIterations)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(successes).To(Equal(cfg.StabilityIterations))
+
+				By("Cleaning up after ourselves")
+				err = phpApacheDeploy.Delete(deleteResourceRetries)
+				Expect(err).NotTo(HaveOccurred())
+				err = s.Delete(deleteResourceRetries)
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
 		It("should be able to autoscale", func() {
 			if eng.HasLinuxAgents() && eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.EnableAggregatedAPIs {
 				By("Creating a test php-apache deployment with request limit thresholds")

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -210,9 +210,9 @@ func RunCommandMultipleTimes(podRunnerCmd podRunnerCmd, image, name, command str
 		if err != nil {
 			return successfulAttempts, err
 		}
-		succeeded, _ := p.WaitOnSucceeded(1*time.Second, 2*time.Minute)
+		succeeded, _ := p.WaitOnSucceeded(1*time.Second, 10*time.Minute)
 		cmd := exec.Command("kubectl", "logs", podName, "-n", "default")
-		out, err := util.RunAndLogCommand(cmd)
+		out, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Printf("Unable to get logs from pod %s\n", podName)
 		} else {

--- a/test/e2e/runner/ginkgo.go
+++ b/test/e2e/runner/ginkgo.go
@@ -35,11 +35,7 @@ func (g *Ginkgo) Run() error {
 	g.Point.SetTestStart()
 	testDir := fmt.Sprintf("test/e2e/%s", g.Config.Orchestrator)
 	var cmd *exec.Cmd
-	if g.Config.GinkgoFocus != "" {
-		cmd = exec.Command("ginkgo", "-slowSpecThreshold", "180", "-failFast", "-r", "-v", "--focus", g.Config.GinkgoFocus, testDir)
-	} else {
-		cmd = exec.Command("ginkgo", "-slowSpecThreshold", "180", "-failFast", "-r", "-v", testDir)
-	}
+	cmd = exec.Command("ginkgo", "-slowSpecThreshold", "180", "-failFast", "-r", "-v", "--focus", g.Config.GinkgoFocus, "--skip", g.Config.GinkgoSkip, testDir)
 	util.PrintCommand(cmd)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This introduces a test that:

1. Deploys an apache pod listening on TCP 80
2. Exposes a service to that pod on TCP 80
3. Deploys a test pod that connects to the svc endpoint on TCP 80

Does the above `<STABILITY_ITERATIONS>` num of times.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
E2E: enable pod-svc connection test
```
