### PR TITLE
Azure CNI 1.0.12 should be in VHD image

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -17,7 +17,7 @@ installClearContainersRuntime
 
 installGPUDrivers
 
-VNET_CNI_VERSIONS="1.0.10 1.0.11"
+VNET_CNI_VERSIONS="1.0.10 1.0.11 1.0.12"
 CNI_PLUGIN_VERSIONS="0.7.1"
 
 for VNET_CNI_VERSION in $VNET_CNI_VERSIONS; do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Azure CNI 1.0.12 should be in VHD image
```
