### PR TITLE
E2E: reuse long-running apache pod, HPA stabilization

### DIFF
--- a/test/e2e/kubernetes/hpa/hpa.go
+++ b/test/e2e/kubernetes/hpa/hpa.go
@@ -1,0 +1,78 @@
+package hpa
+
+import (
+	"encoding/json"
+	"log"
+	"os/exec"
+	"time"
+
+	"github.com/Azure/acs-engine/test/e2e/kubernetes/util"
+)
+
+// HPA represents a kubernetes HPA
+type HPA struct {
+	Metadata Metadata `json:"metadata"`
+	Spec     Spec     `json:"spec"`
+	Status   Status   `json:"status"`
+}
+
+// Metadata holds information like name, namespace, and labels
+type Metadata struct {
+	CreatedAt time.Time `json:"creationTimestamp"`
+	Name      string    `json:"name"`
+	Namespace string    `json:"namespace"`
+}
+
+// Spec holds information like clusterIP and port
+type Spec struct {
+	MinReplicas                    int `json:"minReplicas"`
+	MaxReplicas                    int `json:"maxReplicas"`
+	TargetCPUUtilizationPercentage int `json:"targetCPUUtilizationPercentage"`
+}
+
+// Status holds the load balancer definition
+type Status struct {
+	LoadBalancer LoadBalancer `json:"loadBalancer"`
+}
+
+// LoadBalancer holds the ingress definitions
+type LoadBalancer struct {
+	CurrentCPUUtilizationPercentage int `json:"currentCPUUtilizationPercentage"`
+	CurrentReplicas                 int `json:"currentReplicas"`
+	DesiredReplicas                 int `json:"desiredReplicas"`
+}
+
+// Get returns the HPA definition specified in a given namespace
+func Get(name, namespace string) (*HPA, error) {
+	cmd := exec.Command("kubectl", "get", "hpa", "-o", "json", "-n", namespace, name)
+	util.PrintCommand(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Error trying to run 'kubectl get svc':%s\n", string(out))
+		return nil, err
+	}
+	h := HPA{}
+	err = json.Unmarshal(out, &h)
+	if err != nil {
+		log.Printf("Error unmarshalling service json:%s\n", err)
+		return nil, err
+	}
+	return &h, nil
+}
+
+// Delete will delete a HPA in a given namespace
+func (h *HPA) Delete(retries int) error {
+	var kubectlOutput []byte
+	var kubectlError error
+	for i := 0; i < retries; i++ {
+		cmd := exec.Command("kubectl", "delete", "hpa", "-n", h.Metadata.Namespace, h.Metadata.Name)
+		kubectlOutput, kubectlError = util.RunAndLogCommand(cmd)
+		if kubectlError != nil {
+			log.Printf("Error while trying to delete service %s in namespace %s:%s\n", h.Metadata.Namespace, h.Metadata.Name, string(kubectlOutput))
+			continue
+		}
+		break
+	}
+
+	return kubectlError
+}

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1343,12 +1343,5 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			err = phpApacheDeploy.Delete(deleteResourceRetries)
 			Expect(err).NotTo(HaveOccurred())
 		})
-
-		It("should be able to cleanup hpa", func() {
-			h, err := hpa.Get(longRunningApacheDeploymentName, "default")
-			Expect(err).NotTo(HaveOccurred())
-			err = h.Delete(deleteResourceRetries)
-			Expect(err).NotTo(HaveOccurred())
-		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This PR creates a re-usable, long-running php-apache deployment for various E2E tests. Also includes an HPA object so that we can cleanup the HPA resources after each run.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
