### PR TITLE
CSE apt lock hygiene

### DIFF
--- a/parts/k8s/kubernetesprovisionsource.sh
+++ b/parts/k8s/kubernetesprovisionsource.sh
@@ -120,10 +120,17 @@ wait_for_file() {
         fi
     done
 }
+wait_for_apt_locks() {
+    while fuser /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; do
+        echo 'Waiting for release of apt locks'
+        sleep 3
+    done
+}
 apt_get_update() {
     retries=10
     apt_update_output=/tmp/apt-get-update.out
     for i in $(seq 1 $retries); do
+        wait_for_apt_locks
         timeout 30 dpkg --configure -a
         timeout 30 apt-get -f -y install
         timeout 120 apt-get update 2>&1 | tee $apt_update_output | grep -E "^([WE]:.*)|([eE]rr.*)$"
@@ -135,10 +142,12 @@ apt_get_update() {
         fi
     done
     echo Executed apt-get update $i times
+    wait_for_apt_locks
 }
 apt_get_install() {
     retries=$1; wait_sleep=$2; timeout=$3; shift && shift && shift
     for i in $(seq 1 $retries); do
+        wait_for_apt_locks
         timeout 30 dpkg --configure -a
         timeout $timeout apt-get install --no-install-recommends -y ${@}
         [ $? -eq 0  ] && break || \
@@ -150,6 +159,7 @@ apt_get_install() {
         fi
     done
     echo Executed apt-get install --no-install-recommends -y \"$@\" $i times;
+    wait_for_apt_locks
 }
 systemctl_restart() {
     retries=$1; wait_sleep=$2; timeout=$3 svcname=$4

--- a/parts/k8s/setup-custom-search-domains.sh
+++ b/parts/k8s/setup-custom-search-domains.sh
@@ -4,5 +4,7 @@ source /opt/azure/containers/provision_source.sh
 
 sudo echo "  dns-search <searchDomainName>" >> /etc/network/interfaces.d/50-cloud-init.cfg
 systemctl_restart 20 5 10 restart networking
+wait_for_apt_locks
 retrycmd_if_failure 10 5 120 apt-get -y install realmd sssd sssd-tools samba-common samba samba-common python2.7 samba-libs packagekit
+wait_for_apt_locks
 echo "<searchDomainRealmPassword>" | realm join -U <searchDomainRealmUser>@`echo "<searchDomainName>" | tr /a-z/ /A-Z/` `echo "<searchDomainName>" | tr /a-z/ /A-Z/`


### PR DESCRIPTION
- only invoke an apt command if nothing else is holding a lock
- only return after an apt command after locks are verified released

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Don't run apt commands unless we validate there isn't an apt lock held elsewhere; explicitly wait for lock release after running an apt command.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
CSE apt lock hygiene
```
