### PR TITLE
Update vmss master EncryptionWithExternalKms with userassignedidentity

### DIFF
--- a/parts/k8s/kubernetesmastervarsvmss.t
+++ b/parts/k8s/kubernetesmastervarsvmss.t
@@ -59,6 +59,7 @@
     "useManagedIdentityExtension": "{{ UseManagedIdentity }}",
     "userAssignedID": "{{UserAssignedID}}",
     "userAssignedClientID": "{{UserAssignedClientID}}",
+    "userAssignedIDReference": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities/', variables('userAssignedID'))]",
     "useInstanceMetadata": "{{ UseInstanceMetadata }}",
     "loadBalancerSku": "{{ LoadBalancerSku }}",
     "excludeMasterFromStandardLB": "{{ ExcludeMasterFromStandardLB }}",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Fix issue with template generation when both`enableEncryptionWithExternalKms` and `useManagedIdentity` are enabled. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4060 

**Special notes for your reviewer**:
NOTE: 
- `userAssignedIdentity` cannot currently be tested via our E2E pipeline until PR #4032 is merged. This change has been tested manually. 
- Due to a known issue we had around system-assigned msi for VMSS, we now default to use userAssignedIdentity if `UseManagedIdentity` is enabled in the apimodel. This PR also removes traces of reference to a system-assigned managed identity in the vmss template.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
