### PR TITLE
adjust pagefile size on Windows node

### DIFF
--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -229,6 +229,9 @@ try
         Write-Log "Disable Internet Explorer compat mode and set homepage"
         Set-Explorer
 
+        Write-Log "Adjust pagefile size"
+        Adjust-PageFileSize
+
         Write-Log "Start preProvisioning script"
         PREPROVISION_EXTENSION
 

--- a/parts/k8s/windowsconfigfunc.ps1
+++ b/parts/k8s/windowsconfigfunc.ps1
@@ -54,4 +54,8 @@ function Install-Docker
     }
 }
 
-# TODO: Pagefile adjustments
+# Pagefile adjustments
+function Adjust-PageFileSize()
+{
+    wmic pagefileset set InitialSize=8096,MaximumSize=8096
+}


### PR DESCRIPTION
adjust pagefile size on Windows

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
adjust pagefile size on Windows node

With this PR, the pagefileset would be like following:
```
PS D:\> wmic pagefileset
Caption             Description           InitialSize  MaximumSize  Name             SettingID
D:\ 'pagefile.sys'  'pagefile.sys' @ D:\  8096         8096         D:\pagefile.sys  pagefile.sys @ D:
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4013

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
adjust pagefile size on Windows node
```

@PatrickLang 