### PR TITLE
use azk8s.cn instead of akscn.io for azure china

### DIFF
--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -229,11 +229,11 @@ var (
 		},
 		//KubernetesSpecConfig - Due to Chinese firewall issue, the default containers from google is blocked, use the Chinese local mirror instead
 		KubernetesSpecConfig: KubernetesSpecConfig{
-			KubernetesImageBase:              "gcr.akscn.io/google_containers/",
-			TillerImageBase:                  "gcr.akscn.io/kubernetes-helm/",
-			ACIConnectorImageBase:            "dockerhub.akscn.io/microsoft/",
-			NVIDIAImageBase:                  "dockerhub.akscn.io/nvidia/",
-			AzureCNIImageBase:                "dockerhub.akscn.io/containernetworking/",
+			KubernetesImageBase:              "gcr.azk8s.cn/google_containers/",
+			TillerImageBase:                  "gcr.azk8s.cn/kubernetes-helm/",
+			ACIConnectorImageBase:            "dockerhub.azk8s.cn/microsoft/",
+			NVIDIAImageBase:                  "dockerhub.azk8s.cn/nvidia/",
+			AzureCNIImageBase:                "dockerhub.azk8s.cn/containernetworking/",
 			EtcdDownloadURLBase:              DefaultKubernetesSpecConfig.EtcdDownloadURLBase,
 			KubeBinariesSASURLBase:           DefaultKubernetesSpecConfig.KubeBinariesSASURLBase,
 			WindowsPackageSASURLBase:         DefaultKubernetesSpecConfig.WindowsPackageSASURLBase,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Since `https://mirror.azk8s.cn/` has got ICP license in China, this PR use `azk8s.cn` instead of `akscn.io` for container proxy repositories in Azure China


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
use azk8s.cn instead of akscn.io for azure china
```
