### PR TITLE
Don't require vm tags

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -223,23 +223,22 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 				return errors.New("The provided resource group does not contain any vms")
 			}
 			for _, vm := range vmsListPage.Values() {
-				vmTags := vm.Tags
-				poolName := *vmTags["poolName"]
-				nameSuffix := *vmTags["resourceNameSuffix"]
-
-				//Changed to string contains for the nameSuffix as the Windows Agent Pools use only a substring of the first 5 characters of the entire nameSuffix
-				if err != nil || !strings.EqualFold(poolName, sc.agentPoolToScale) || !strings.Contains(sc.nameSuffix, nameSuffix) {
+				vmName := *vm.Name
+				if !sc.vmInAgentPool(vmName, vm.Tags) {
 					continue
 				}
 
 				osPublisher := vm.StorageProfile.ImageReference.Publisher
 				if osPublisher != nil && strings.EqualFold(*osPublisher, "MicrosoftWindowsServer") {
-					_, _, winPoolIndex, index, err = utils.WindowsVMNameParts(*vm.Name)
+					_, _, winPoolIndex, index, err = utils.WindowsVMNameParts(vmName)
 				} else {
-					_, _, index, err = utils.K8sLinuxVMNameParts(*vm.Name)
+					_, _, index, err = utils.K8sLinuxVMNameParts(vmName)
+				}
+				if err != nil {
+					return err
 				}
 
-				indexToVM[index] = *vm.Name
+				indexToVM[index] = vmName
 				indexes = append(indexes, index)
 			}
 		}
@@ -318,18 +317,14 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 				return errors.Wrap(err, "failed to get vmss list in the resource group")
 			}
 			for _, vmss := range vmssListPage.Values() {
-				vmTags := vmss.Tags
-				poolName := *vmTags["poolName"]
-				nameSuffix := *vmTags["resourceNameSuffix"]
-
-				//Changed to string contains for the nameSuffix as the Windows Agent Pools use only a substring of the first 5 characters of the entire nameSuffix
-				if err != nil || !strings.EqualFold(poolName, sc.agentPoolToScale) || !strings.Contains(sc.nameSuffix, nameSuffix) {
+				vmName := *vmss.Name
+				if !sc.vmInAgentPool(vmName, vmss.Tags) {
 					continue
 				}
 
 				osPublisher := vmss.VirtualMachineProfile.StorageProfile.ImageReference.Publisher
 				if osPublisher != nil && strings.EqualFold(*osPublisher, "MicrosoftWindowsServer") {
-					_, _, winPoolIndex, err = utils.WindowsVMSSNameParts(*vmss.Name)
+					_, _, winPoolIndex, err = utils.WindowsVMSSNameParts(vmName)
 					log.Errorln(err)
 				}
 
@@ -454,6 +449,25 @@ func (sc *scaleCmd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	return f.SaveFile(sc.deploymentDirectory, "apimodel.json", b)
+}
+
+func (sc *scaleCmd) vmInAgentPool(vmName string, tags map[string]*string) bool {
+	// First try to locate the VM by expected tags.
+	if tags != nil {
+		poolName := *tags["poolName"]
+		nameSuffix := *tags["resourceNameSuffix"]
+		// Use strings.Contains for the nameSuffix as the Windows Agent Pools use only a substring of the first 5 characters of the entire nameSuffix
+		if strings.EqualFold(poolName, sc.agentPoolToScale) && strings.Contains(sc.nameSuffix, nameSuffix) {
+			return true
+		}
+	}
+
+	// Finally check the VM's name to see if it fits the naming pattern.
+	if strings.Contains(vmName, sc.nameSuffix[:5]) && strings.Contains(vmName, sc.agentPoolToScale) {
+		return true
+	}
+
+	return false
 }
 
 type paramsMap map[string]interface{}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -229,7 +229,7 @@ func (uc *upgradeCmd) run(cmd *cobra.Command, args []string) error {
 		log.Fatalf("failed to generate kube config: %v", err) // TODO: cleanup
 	}
 
-	if err = upgradeCluster.UpgradeCluster(uc.authArgs.SubscriptionID, kubeConfig, uc.resourceGroupName,
+	if err = upgradeCluster.UpgradeCluster(uc.authArgs.SubscriptionID, uc.client, kubeConfig, uc.resourceGroupName,
 		uc.containerService, uc.nameSuffix, uc.agentPoolsToUpgrade, BuildTag); err != nil {
 		log.Fatalf("Error upgrading cluster: %v\n", err)
 	}

--- a/pkg/armhelpers/mockclients.go
+++ b/pkg/armhelpers/mockclients.go
@@ -30,6 +30,7 @@ type MockACSEngineClient struct {
 	FailDeployTemplateWithProperties      bool
 	FailEnsureResourceGroup               bool
 	FailListVirtualMachines               bool
+	FailListVirtualMachinesTags           bool
 	FailListVirtualMachineScaleSets       bool
 	FailGetVirtualMachine                 bool
 	FailDeleteVirtualMachine              bool
@@ -189,6 +190,7 @@ func (mkc *MockKubernetesClient) GetNode(name string) (*v1.Node, error) {
 	}
 	node := &v1.Node{}
 	node.Status.Conditions = append(node.Status.Conditions, v1.NodeCondition{Type: v1.NodeReady, Status: v1.ConditionTrue})
+	node.Status.NodeInfo.KubeletVersion = "1.6.9"
 	return node, nil
 }
 
@@ -383,6 +385,9 @@ func (mc *MockACSEngineClient) ListVirtualMachines(ctx context.Context, resource
 		orchestratorString:       &orchestrator,
 		resourceNameSuffixString: &resourceNameSuffix,
 		poolnameString:           &poolname,
+	}
+	if mc.FailListVirtualMachinesTags {
+		tags = nil
 	}
 
 	vm1 := compute.VirtualMachine{

--- a/pkg/operations/kubernetesupgrade/upgradecluster.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster.go
@@ -74,7 +74,7 @@ const MasterVMNamePrefix = "k8s-master-"
 const MasterPoolName = "master"
 
 // UpgradeCluster runs the workflow to upgrade a Kubernetes cluster.
-func (uc *UpgradeCluster) UpgradeCluster(subscriptionID uuid.UUID, kubeConfig, resourceGroup string,
+func (uc *UpgradeCluster) UpgradeCluster(subscriptionID uuid.UUID, az armhelpers.ACSEngineClient, kubeConfig, resourceGroup string,
 	cs *api.ContainerService, nameSuffix string, agentPoolsToUpgrade []string, acsengineVersion string) error {
 	uc.ClusterTopology = ClusterTopology{}
 	uc.SubscriptionID = subscriptionID.String()
@@ -91,7 +91,7 @@ func (uc *UpgradeCluster) UpgradeCluster(subscriptionID uuid.UUID, kubeConfig, r
 	}
 	uc.AgentPoolsToUpgrade[MasterPoolName] = true
 
-	if err := uc.getClusterNodeStatus(subscriptionID, resourceGroup); err != nil {
+	if err := uc.getClusterNodeStatus(subscriptionID, az, resourceGroup, kubeConfig); err != nil {
 		return uc.Translator.Errorf("Error while querying ARM for resources: %+v", err)
 	}
 
@@ -135,11 +135,22 @@ func (uc *UpgradeCluster) UpgradeCluster(subscriptionID uuid.UUID, kubeConfig, r
 	return nil
 }
 
-func (uc *UpgradeCluster) getClusterNodeStatus(subscriptionID uuid.UUID, resourceGroup string) error {
+func (uc *UpgradeCluster) getClusterNodeStatus(subscriptionID uuid.UUID, az armhelpers.ACSEngineClient, resourceGroup, kubeConfig string) error {
 	targetOrchestratorTypeVersion := fmt.Sprintf("%s:%s", uc.DataModel.Properties.OrchestratorProfile.OrchestratorType, uc.DataModel.Properties.OrchestratorProfile.OrchestratorVersion)
 
 	ctx, cancel := context.WithTimeout(context.Background(), armhelpers.DefaultARMOperationTimeout)
 	defer cancel()
+
+	var kubeClient armhelpers.KubernetesClient
+	if az != nil {
+		timeout := time.Duration(60) * time.Minute
+		k, err := az.GetKubernetesClient("", kubeConfig, interval, timeout)
+		if err != nil {
+			uc.Logger.Warnf("Failed to get a Kubernetes client: %v", err)
+		}
+		kubeClient = k
+	}
+
 	for vmScaleSetPage, err := uc.Client.ListVirtualMachineScaleSets(ctx, resourceGroup); vmScaleSetPage.NotDone(); err = vmScaleSetPage.Next() {
 		if err != nil {
 			return err
@@ -155,16 +166,16 @@ func (uc *UpgradeCluster) getClusterNodeStatus(subscriptionID uuid.UUID, resourc
 					Location: *vmScaleSet.Location,
 				}
 				for _, vm := range vmScaleSetVMsPage.Values() {
-					if vm.Tags == nil || vm.Tags["orchestrator"] == nil {
-						uc.Logger.Infof("No tags found for scale set VM: %s skipping.\n", *vm.Name)
+					scaleSetVMOrchestratorTypeAndVersion := uc.getClusterNodeVersion(kubeClient, *vm.Name, vm.Tags)
+					if scaleSetVMOrchestratorTypeAndVersion == "" {
+						uc.Logger.Infof("Skipping VM: %s for upgrade as the orchestrator version could not be determined.", *vm.Name)
 						continue
 					}
 
-					scaleSetVMOrchestratorTypeAndVersion := *vm.Tags["orchestrator"]
 					if scaleSetVMOrchestratorTypeAndVersion != targetOrchestratorTypeVersion {
 						// This condition is a scale set VM that is an older version and should be handled
 						uc.Logger.Infof(
-							"VM %s in VMSS %s has a current tag of %s and a desired tag of %s. Upgrading this node.\n",
+							"VM %s in VMSS %s has a current version of %s and a desired version of %s. Upgrading this node.",
 							*vm.Name,
 							*vmScaleSet.Name,
 							scaleSetVMOrchestratorTypeAndVersion,
@@ -190,12 +201,12 @@ func (uc *UpgradeCluster) getClusterNodeStatus(subscriptionID uuid.UUID, resourc
 		}
 
 		for _, vm := range vmListPage.Values() {
-			if vm.Tags == nil || vm.Tags["orchestrator"] == nil {
-				uc.Logger.Infof("No tags found for VM: %s skipping.\n", *vm.Name)
+			vmOrchestratorTypeAndVersion := uc.getClusterNodeVersion(kubeClient, *vm.Name, vm.Tags)
+			if vmOrchestratorTypeAndVersion == "" {
+				uc.Logger.Infof("Skipping VM: %s for upgrade as the orchestrator version could not be determined.", *vm.Name)
 				continue
 			}
 
-			vmOrchestratorTypeAndVersion := *vm.Tags["orchestrator"]
 			if vmOrchestratorTypeAndVersion != targetOrchestratorTypeVersion {
 				if strings.Contains(*(vm.Name), MasterVMNamePrefix) {
 					if !strings.Contains(*(vm.Name), uc.NameSuffix) {
@@ -233,6 +244,39 @@ func (uc *UpgradeCluster) getClusterNodeStatus(subscriptionID uuid.UUID, resourc
 	return nil
 }
 
+// getClusterNodeVersion returns a node's "orchestrator:version" via Kubernetes API or VM tag.
+func (uc *UpgradeCluster) getClusterNodeVersion(client armhelpers.KubernetesClient, name string, tags map[string]*string) string {
+	if tags != nil && tags["orchestrator"] != nil {
+		return *tags["orchestrator"]
+	}
+	uc.Logger.Warnf("Expected tag \"orchestrator\" not found for VM: %s", name)
+	if client != nil {
+		node, err := client.GetNode(name)
+		if err == nil {
+			return api.Kubernetes + ":" + strings.TrimPrefix(node.Status.NodeInfo.KubeletVersion, "v")
+		}
+		uc.Logger.Warnf("Failed to get node %s: %v", name, err)
+		// If it's a VMSS cluster, generate the likely Kubernetes node name and try again.
+		if strings.Contains(name, "vmss_") {
+			parts := strings.Split(name, "_")
+			if len(parts) == 2 {
+				end := 28 // keep the overall node name at 34 chars or less
+				if len(parts[0]) < end {
+					end = len(parts[0])
+				}
+				vmssName := fmt.Sprintf("%s%06s", parts[0][0:end], parts[1])
+				node, err := client.GetNode(vmssName)
+				if err == nil {
+					uc.Logger.Infof("Found VMSS node %s under the name %s", name, vmssName)
+					return api.Kubernetes + ":" + strings.TrimPrefix(node.Status.NodeInfo.KubeletVersion, "v")
+				}
+				uc.Logger.Warnf("Failed to get node %s: %v", vmssName, err)
+			}
+		}
+	}
+	return ""
+}
+
 func (uc *UpgradeCluster) upgradable(vmOrchestratorTypeAndVersion string) error {
 	arr := strings.Split(vmOrchestratorTypeAndVersion, ":")
 	if len(arr) != 2 {
@@ -262,35 +306,38 @@ func (uc *UpgradeCluster) addVMToAgentPool(vm compute.VirtualMachine, isUpgradab
 	var poolIdentifier string
 	var poolPrefix string
 	var err error
+	var vmPoolName string
 
-	if vm.Tags == nil || vm.Tags["poolName"] == nil {
-		uc.Logger.Infof("poolName tag not found for VM: %s skipping.\n", *vm.Name)
+	if vm.Tags != nil && vm.Tags["poolName"] != nil {
+		vmPoolName = *vm.Tags["poolName"]
+	} else {
+		uc.Logger.Infof("poolName tag not found for VM: %s.", *vm.Name)
+		// If there's only one agent pool, assume this VM is a member.
+		agentPools := []string{}
+		for k := range uc.AgentPoolsToUpgrade {
+			if !strings.HasPrefix(k, "master") {
+				agentPools = append(agentPools, k)
+			}
+		}
+		if len(agentPools) == 1 {
+			vmPoolName = agentPools[0]
+		}
+	}
+	if vmPoolName == "" {
+		uc.Logger.Warnf("Couldn't determine agent pool membership for VM: %s.", *vm.Name)
 		return nil
 	}
 
-	vmPoolName := *vm.Tags["poolName"]
-	uc.Logger.Infof("Evaluating VM: %s in pool: %s...\n", *vm.Name, vmPoolName)
+	uc.Logger.Infof("Evaluating VM: %s in pool: %s...", *vm.Name, vmPoolName)
 	if vmPoolName == "" {
-		uc.Logger.Infof("VM: %s does not contain `poolName` tag, skipping.\n", *vm.Name)
+		uc.Logger.Infof("VM: %s does not contain `poolName` tag, skipping.", *vm.Name)
 		return nil
 	} else if !uc.AgentPoolsToUpgrade[vmPoolName] {
-		uc.Logger.Infof("Skipping upgrade of VM: %s in pool: %s.\n", *vm.Name, vmPoolName)
+		uc.Logger.Infof("Skipping upgrade of VM: %s in pool: %s.", *vm.Name, vmPoolName)
 		return nil
 	}
 
-	if vm.StorageProfile.OsDisk.OsType == compute.Linux {
-		poolIdentifier, poolPrefix, _, err = utils.K8sLinuxVMNameParts(*vm.Name)
-		if err != nil {
-			uc.Logger.Errorf(err.Error())
-			return err
-		}
-
-		if !strings.EqualFold(uc.NameSuffix, poolPrefix) {
-			uc.Logger.Infof("Skipping VM: %s for upgrade as it does not belong to cluster with expected name suffix: %s\n",
-				*vm.Name, uc.NameSuffix)
-			return nil
-		}
-	} else if vm.StorageProfile.OsDisk.OsType == compute.Windows {
+	if vm.StorageProfile.OsDisk.OsType == compute.Windows {
 		poolPrefix, _, _, _, err := utils.WindowsVMNameParts(*vm.Name)
 		if err != nil {
 			uc.Logger.Errorf(err.Error())
@@ -306,20 +353,36 @@ func (uc *UpgradeCluster) addVMToAgentPool(vm compute.VirtualMachine, isUpgradab
 				*vm.Name, uc.NameSuffix)
 			return nil
 		}
+	} else { // vm.StorageProfile.OsDisk.OsType == compute.Linux
+		poolIdentifier, poolPrefix, _, err = utils.K8sLinuxVMNameParts(*vm.Name)
+		if err != nil {
+			uc.Logger.Errorf(err.Error())
+			return err
+		}
+
+		if !strings.EqualFold(uc.NameSuffix, poolPrefix) {
+			uc.Logger.Infof("Skipping VM: %s for upgrade as it does not belong to cluster with expected name suffix: %s\n",
+				*vm.Name, uc.NameSuffix)
+			return nil
+		}
 	}
 
 	if uc.AgentPools[poolIdentifier] == nil {
 		uc.AgentPools[poolIdentifier] =
-			&AgentPoolTopology{&poolIdentifier, vm.Tags["poolName"], &[]compute.VirtualMachine{}, &[]compute.VirtualMachine{}}
+			&AgentPoolTopology{&poolIdentifier, &vmPoolName, &[]compute.VirtualMachine{}, &[]compute.VirtualMachine{}}
 	}
 
+	orchestrator := "unknown"
+	if vm.Tags != nil {
+		orchestrator = *vm.Tags["orchestrator"]
+	}
 	if isUpgradableVM {
 		uc.Logger.Infof("Adding Agent VM: %s, orchestrator: %s to pool: %s (AgentVMs)\n",
-			*vm.Name, *vm.Tags["orchestrator"], poolIdentifier)
+			*vm.Name, orchestrator, poolIdentifier)
 		*uc.AgentPools[poolIdentifier].AgentVMs = append(*uc.AgentPools[poolIdentifier].AgentVMs, vm)
 	} else {
 		uc.Logger.Infof("Adding Agent VM: %s, orchestrator: %s to pool: %s (UpgradedAgentVMs)\n",
-			*vm.Name, *vm.Tags["orchestrator"], poolIdentifier)
+			*vm.Name, orchestrator, poolIdentifier)
 		*uc.AgentPools[poolIdentifier].UpgradedAgentVMs = append(*uc.AgentPools[poolIdentifier].UpgradedAgentVMs, vm)
 	}
 

--- a/pkg/operations/kubernetesupgrade/upgradecluster_test.go
+++ b/pkg/operations/kubernetesupgrade/upgradecluster_test.go
@@ -28,6 +28,30 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 		os.RemoveAll("_output")
 	})
 
+	It("Should succeed when cluster VMs are missing expected tags during upgrade operation", func() {
+		cs := api.CreateMockContainerService("testcluster", "1.6.9", 1, 1, false)
+
+		cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.7.16"
+
+		uc := UpgradeCluster{
+			Translator: &i18n.Translator{},
+			Logger:     log.NewEntry(log.New()),
+		}
+
+		mockClient := armhelpers.MockACSEngineClient{}
+		mockClient.FailListVirtualMachinesTags = true
+		uc.Client = &mockClient
+
+		subID, _ := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
+
+		err := uc.UpgradeCluster(subID, &mockClient, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
+		Expect(err).To(BeNil())
+		Expect(uc.ClusterTopology.AgentPools).NotTo(BeEmpty())
+
+		// Clean up
+		os.RemoveAll("./translations")
+	})
+
 	It("Should return error message when failing to list VMs during upgrade operation", func() {
 		cs := api.CreateMockContainerService("testcluster", "1.6.9", 1, 1, false)
 
@@ -44,7 +68,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 
 		subID, _ := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
 
-		err := uc.UpgradeCluster(subID, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
+		err := uc.UpgradeCluster(subID, nil, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(Equal("Error while querying ARM for resources: ListVirtualMachines failed"))
 
@@ -67,7 +91,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 
 		subID, _ := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
 
-		err := uc.UpgradeCluster(subID, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
+		err := uc.UpgradeCluster(subID, nil, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(Equal("DeleteVirtualMachine failed"))
 	})
@@ -86,7 +110,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 
 		subID, _ := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
 
-		err := uc.UpgradeCluster(subID, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
+		err := uc.UpgradeCluster(subID, nil, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(Equal("DeployTemplate failed"))
 	})
@@ -105,7 +129,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 
 		subID, _ := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
 
-		err := uc.UpgradeCluster(subID, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
+		err := uc.UpgradeCluster(subID, nil, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(Equal("GetVirtualMachine failed"))
 	})
@@ -124,7 +148,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 
 		subID, _ := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
 
-		err := uc.UpgradeCluster(subID, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
+		err := uc.UpgradeCluster(subID, nil, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(Equal("GetStorageClient failed"))
 	})
@@ -143,7 +167,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 
 		subID, _ := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
 
-		err := uc.UpgradeCluster(subID, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
+		err := uc.UpgradeCluster(subID, nil, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(Equal("DeleteNetworkInterface failed"))
 	})
@@ -161,7 +185,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 
 		subID, _ := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
 
-		err := uc.UpgradeCluster(subID, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
+		err := uc.UpgradeCluster(subID, nil, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
 		Expect(err).NotTo(BeNil())
 		fmt.Print("GOT :   ", err.Error())
 		Expect(err.Error()).To(ContainSubstring("Error while querying ARM for resources: Kubernetes:1.6.9 cannot be upgraded to 1.8.15"))
@@ -184,7 +208,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 
 		subID, _ := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
 
-		err := uc.UpgradeCluster(subID, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
+		err := uc.UpgradeCluster(subID, nil, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(Equal("DeleteRoleAssignmentByID failed"))
 	})
@@ -204,7 +228,7 @@ var _ = Describe("Upgrade Kubernetes cluster tests", func() {
 
 		subID, _ := uuid.FromString("DEC923E3-1EF1-4745-9516-37906D56DEC4")
 
-		err := uc.UpgradeCluster(subID, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
+		err := uc.UpgradeCluster(subID, nil, "kubeConfig", "TestRg", cs, "12345678", []string{"agentpool1"}, TestACSEngineVersion)
 		Expect(err).To(BeNil())
 	})
 })

--- a/test/e2e/runner/ginkgo.go
+++ b/test/e2e/runner/ginkgo.go
@@ -34,8 +34,7 @@ func BuildGinkgoRunner(cfg *config.Config, pt *metrics.Point) (*Ginkgo, error) {
 func (g *Ginkgo) Run() error {
 	g.Point.SetTestStart()
 	testDir := fmt.Sprintf("test/e2e/%s", g.Config.Orchestrator)
-	var cmd *exec.Cmd
-	cmd = exec.Command("ginkgo", "-slowSpecThreshold", "180", "-failFast", "-r", "-v", "--focus", g.Config.GinkgoFocus, "--skip", g.Config.GinkgoSkip, testDir)
+	var cmd = exec.Command("ginkgo", "-slowSpecThreshold", "180", "-failFast", "-r", "-v", "--focus", g.Config.GinkgoFocus, "--skip", g.Config.GinkgoSkip, testDir)
 	util.PrintCommand(cmd)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes our absolute reliance on VM tags in the `upgrade` and `scale` commands.

In the common case of a single agent pool, the upgrade and scale commands can identify VMs to be updated even if the user has deleted the tags we attached. (After upgrade or scale, these tags are restored as well.) This is preferable to the current behavior where VMs that lack tags are skipped over in upgrade, which is confusing to users.

This preserves the current tag-based strategy, only falling back to other methods such as contacting the Kubernetes API or testing the VM name if that approach fails.

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [x] unit tests
- [x] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Don't require VM tags when upgrading or scaling most clusters
```
