### PR TITLE
Fix standard lb for vmss master

### DIFF
--- a/parts/k8s/kubernetesmasterresourcesvmss.t
+++ b/parts/k8s/kubernetesmasterresourcesvmss.t
@@ -171,7 +171,7 @@
     "dnsSettings": {
       "domainNameLabel": "[variables('masterFqdnPrefix')]"
     },
-    {{ if .MasterProfile.HasAvailabilityZones}}
+    {{ if eq LoadBalancerSku "Standard"}}
     "publicIPAllocationMethod": "Static"
     {{else}}
     "publicIPAllocationMethod": "Dynamic"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Fix standard lb for vmss master when zones is not enabled. Zones enabled defaults to `Standard` load balancer.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
