### PR TITLE
Make --profiling user configurable

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -365,6 +365,12 @@ const (
 	DefaultKubernetesMaxPodsKubenet = "110"
 	// DefaultKubernetesMaxPodsAzureCNI is the maximum number of pods to run on a node for Azure CNI.
 	DefaultKubernetesMaxPodsAzureCNI = "30"
+	// DefaultKubernetesAPIServerEnableProfiling is the config that enables profiling via web interface host:port/debug/pprof/
+	DefaultKubernetesAPIServerEnableProfiling = "false"
+	// DefaultKubernetesCtrMgrEnableProfiling is the config that enables profiling via web interface host:port/debug/pprof/
+	DefaultKubernetesCtrMgrEnableProfiling = "false"
+	// DefaultKubernetesSchedulerEnableProfiling is the config that enables profiling via web interface host:port/debug/pprof/
+	DefaultKubernetesSchedulerEnableProfiling = "false"
 )
 
 const (

--- a/pkg/api/defaults-apiserver.go
+++ b/pkg/api/defaults-apiserver.go
@@ -25,7 +25,6 @@ func (cs *ContainerService) setAPIServerConfig() {
 		"--tls-cert-file":              "/etc/kubernetes/certs/apiserver.crt",
 		"--tls-private-key-file":       "/etc/kubernetes/certs/apiserver.key",
 		"--client-ca-file":             "/etc/kubernetes/certs/ca.crt",
-		"--profiling":                  "false",
 		"--repair-malformed-updates":   "false",
 		"--service-account-key-file":   "/etc/kubernetes/certs/apiserver.key",
 		"--kubelet-client-certificate": "/etc/kubernetes/certs/client.crt",
@@ -40,6 +39,7 @@ func (cs *ContainerService) setAPIServerConfig() {
 		"--audit-log-maxage":    "30",
 		"--audit-log-maxbackup": "10",
 		"--audit-log-maxsize":   "100",
+		"--profiling":           DefaultKubernetesAPIServerEnableProfiling,
 	}
 
 	// Data Encryption at REST configuration conditions

--- a/pkg/api/defaults-apiserver_test.go
+++ b/pkg/api/defaults-apiserver_test.go
@@ -362,3 +362,29 @@ func TestAPIServerConfigDefaultAdmissionControls(t *testing.T) {
 		t.Fatalf("Admission control key '%s' not set in API server config for version %s", enableAdmissionPluginsKey, version)
 	}
 }
+
+func TestAPIServerConfigEnableProfiling(t *testing.T) {
+	// Test
+	// "apiServerConfig": {
+	// 	"--profiling": "true"
+	// },
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = map[string]string{
+		"--profiling": "true",
+	}
+	cs.setAPIServerConfig()
+	a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--profiling"] != "true" {
+		t.Fatalf("got unexpected '--profiling' API server config value for \"--profiling\": \"true\": %s",
+			a["--profiling"])
+	}
+
+	// Test default
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setAPIServerConfig()
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	if a["--profiling"] != DefaultKubernetesAPIServerEnableProfiling {
+		t.Fatalf("got unexpected default value for '--profiling' API server config: %s",
+			a["--profiling"])
+	}
+}

--- a/pkg/api/defaults-controller-manager.go
+++ b/pkg/api/defaults-controller-manager.go
@@ -19,7 +19,6 @@ func (cs *ContainerService) setControllerManagerConfig() {
 		"--service-account-private-key-file": "/etc/kubernetes/certs/apiserver.key",
 		"--leader-elect":                     "true",
 		"--v":                                "2",
-		"--profiling":                        "false",
 	}
 
 	// Set --cluster-name based on appropriate DNS prefix
@@ -42,6 +41,7 @@ func (cs *ContainerService) setControllerManagerConfig() {
 		"--route-reconciliation-period":     DefaultKubernetesCtrlMgrRouteReconciliationPeriod,
 		"--terminated-pod-gc-threshold":     DefaultKubernetesCtrlMgrTerminatedPodGcThreshold,
 		"--use-service-account-credentials": DefaultKubernetesCtrlMgrUseSvcAccountCreds,
+		"--profiling":                       DefaultKubernetesCtrMgrEnableProfiling,
 	}
 
 	// If no user-configurable controller-manager config values exists, use the defaults

--- a/pkg/api/defaults-controller-manager_test.go
+++ b/pkg/api/defaults-controller-manager_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/Azure/acs-engine/pkg/helpers"
+)
+
+func TestControllerManagerConfigEnableRbac(t *testing.T) {
+	// Test EnableRbac = true
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableRbac = helpers.PointerToBool(true)
+	cs.setControllerManagerConfig()
+	cm := cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--use-service-account-credentials"] != "true" {
+		t.Fatalf("got unexpected '--use-service-account-credentials' Controller Manager config value for EnableRbac=true: %s",
+			cm["--use-service-account-credentials"])
+	}
+
+	// Test default
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.EnableRbac = helpers.PointerToBool(false)
+	cs.setControllerManagerConfig()
+	cm = cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--use-service-account-credentials"] != DefaultKubernetesCtrlMgrUseSvcAccountCreds {
+		t.Fatalf("got unexpected '--use-service-account-credentials' Controller Manager config value for EnableRbac=false: %s",
+			cm["--use-service-account-credentials"])
+	}
+
+}
+func TestControllerManagerConfigEnableProfiling(t *testing.T) {
+	// Test
+	// "controllerManagerConfig": {
+	// 	"--profiling": "true"
+	// },
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig = map[string]string{
+		"--profiling": "true",
+	}
+	cs.setControllerManagerConfig()
+	cm := cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--profiling"] != "true" {
+		t.Fatalf("got unexpected '--profiling' Controller Manager config value for \"--profiling\": \"true\": %s",
+			cm["--profiling"])
+	}
+
+	// Test default
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setControllerManagerConfig()
+	cm = cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+	if cm["--profiling"] != DefaultKubernetesCtrMgrEnableProfiling {
+		t.Fatalf("got unexpected default value for '--profiling' Controller Manager config: %s",
+			cm["--profiling"])
+	}
+}

--- a/pkg/api/defaults-scheduler.go
+++ b/pkg/api/defaults-scheduler.go
@@ -4,12 +4,12 @@ package api
 var staticSchedulerConfig = map[string]string{
 	"--kubeconfig":   "/var/lib/kubelet/kubeconfig",
 	"--leader-elect": "true",
-	"--profiling":    "false",
 }
 
 // defaultSchedulerConfig provides targeted defaults, but is user-overridable
 var defaultSchedulerConfig = map[string]string{
-	"--v": "2",
+	"--v":         "2",
+	"--profiling": DefaultKubernetesSchedulerEnableProfiling,
 }
 
 func (cs *ContainerService) setSchedulerConfig() {

--- a/pkg/api/defaults-scheduler_test.go
+++ b/pkg/api/defaults-scheduler_test.go
@@ -53,3 +53,29 @@ func TestSchedulerStaticConfig(t *testing.T) {
 		}
 	}
 }
+
+func TestSchedulerConfigEnableProfiling(t *testing.T) {
+	// Test
+	// "schedulerConfig": {
+	// 	"--profiling": "true"
+	// },
+	cs := CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig = map[string]string{
+		"--profiling": "true",
+	}
+	cs.setSchedulerConfig()
+	s := cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig
+	if s["--profiling"] != "true" {
+		t.Fatalf("got unexpected '--profiling' Scheduler config value for \"--profiling\": \"true\": %s",
+			s["--profiling"])
+	}
+
+	// Test default
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.setSchedulerConfig()
+	s = cs.Properties.OrchestratorProfile.KubernetesConfig.SchedulerConfig
+	if s["--profiling"] != DefaultKubernetesSchedulerEnableProfiling {
+		t.Fatalf("got unexpected default value for '--profiling' Scheduler config: %s",
+			s["--profiling"])
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Make `--profiling` user configurable

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3500

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
cc @PatrickLang 