### PR TITLE
Configure Docker Version on Windows Nodes

### DIFF
--- a/examples/windows/kubernetes-windows-docker-version.json
+++ b/examples/windows/kubernetes-windows-docker-version.json
@@ -1,0 +1,41 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes"
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_D2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "windowspool2",
+        "count": 2,
+        "vmSize": "Standard_D2",
+        "availabilityProfile": "AvailabilitySet",
+        "osType": "Windows"
+      }
+    ],
+    "windowsProfile": {
+      "adminUsername": "azureuser",
+      "adminPassword": "replacepassword1234$",
+      "windowsDockerVersion": "17.06.2-ee-16"
+    },
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    }
+  }
+}

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -57,6 +57,9 @@ $global:KubeBinariesSASURL = "{{WrapAsParameter "kubeBinariesSASURL"}}"
 $global:WindowsPackageSASURLBase = "{{WrapAsParameter "windowsPackageSASURLBase"}}"
 $global:KubeBinariesVersion = "{{WrapAsParameter "kubeBinariesVersion"}}"
 
+## Docker Version
+$global:DockerVersion = "{{WrapAsParameter "windowsDockerVersion"}}"
+
 ## VM configuration passed by Azure
 $global:WindowsTelemetryGUID = "{{WrapAsParameter "windowsTelemetryGUID"}}"
 $global:TenantId = "{{WrapAsVariable "tenantID"}}"
@@ -141,6 +144,9 @@ try
 
         Write-Log "resize os drive if possible"
         Resize-OSDrive
+
+        Write-Log "install docker"
+        Install-Docker -DockerVersion $global:DockerVersion
 
         Write-Log "download kubelet binaries and unzip"
         Get-KubeBinaries -KubeBinariesSASURL $global:KubeBinariesSASURL

--- a/parts/k8s/windowsconfigfunc.ps1
+++ b/parts/k8s/windowsconfigfunc.ps1
@@ -34,4 +34,24 @@ function Set-Explorer
     New-ItemProperty -Path HKLM:"\\SOFTWARE\\Policies\\Microsoft\\Internet Explorer\\Main" -Name "Start Page" -Type String -Value http://bing.com
 }
 
+function Install-Docker
+{
+    Param(
+        [Parameter(Mandatory=$true)][string]
+        $DockerVersion
+    )
+
+    try {
+        Find-Package -Name Docker -ProviderName DockerMsftProvider -RequiredVersion $DockerVersion -ErrorAction Stop
+        Write-Log "Found version $DockerVersion. Installing..."
+        Install-Package -Name Docker -ProviderName DockerMsftProvider -Update -Force -RequiredVersion $DockerVersion
+        net start docker
+        Write-Log "Installed version $DockerVersion"
+    } catch {
+        Write-Log "Error while installing package: $_.Exception.Message"
+        $currentDockerVersion = (Get-Package -Name Docker -ProviderName DockerMsftProvider).Version
+        Write-Log "Not able to install docker version. Using default version $currentDockerVersion"
+    }
+}
+
 # TODO: Pagefile adjustments

--- a/parts/windowsparams.t
+++ b/parts/windowsparams.t
@@ -44,4 +44,11 @@
         "description": "The SKU of windows image for the agent virtual machines."
       },
       "type": "string"
+    },
+    "windowsDockerVersion": {
+      "defaultValue": "17.06.2-ee-16",
+      "metadata": {
+        "description": "The version of Docker to be installed on Windows Nodes"
+      },
+      "type": "string"
     }

--- a/pkg/acsengine/params.go
+++ b/pkg/acsengine/params.go
@@ -226,6 +226,9 @@ func getParameters(cs *api.ContainerService, generatorCode string, acsengineVers
 		if properties.WindowsProfile.WindowsSku != "" {
 			addValue(parametersMap, "agentWindowsSku", properties.WindowsProfile.WindowsSku)
 		}
+
+		addValue(parametersMap, "windowsDockerVersion", properties.WindowsProfile.GetWindowsDockerVersion())
+
 		if properties.OrchestratorProfile.IsKubernetes() || properties.OrchestratorProfile.IsOpenShift() {
 			k8sVersion := properties.OrchestratorProfile.OrchestratorVersion
 			kubeBinariesSASURL := properties.OrchestratorProfile.KubernetesConfig.CustomWindowsPackageURL

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -42,6 +42,8 @@ const (
 	DockerCEVersion = "17.03.*"
 	// DockerCEDockerComposeVersion is the Docker Compose version
 	DockerCEDockerComposeVersion = "1.14.0"
+	// KubernetesWindowsDockerVersion is the default version for docker on Windows nodes in kubernetes
+	KubernetesWindowsDockerVersion = "17.06.2-ee-16"
 )
 
 // validation values

--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -596,6 +596,7 @@ func convertWindowsProfileToVLabs(api *WindowsProfile, vlabsProfile *vlabs.Windo
 	vlabsProfile.WindowsPublisher = api.WindowsPublisher
 	vlabsProfile.WindowsOffer = api.WindowsOffer
 	vlabsProfile.WindowsSku = api.WindowsSku
+	vlabsProfile.WindowsDockerVersion = api.WindowsDockerVersion
 	vlabsProfile.Secrets = []vlabs.KeyVaultSecrets{}
 	for _, s := range api.Secrets {
 		secret := &vlabs.KeyVaultSecrets{}

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -520,6 +520,7 @@ func convertVLabsWindowsProfile(vlabs *vlabs.WindowsProfile, api *WindowsProfile
 	api.WindowsPublisher = vlabs.WindowsPublisher
 	api.WindowsOffer = vlabs.WindowsOffer
 	api.WindowsSku = vlabs.WindowsSku
+	api.WindowsDockerVersion = vlabs.WindowsDockerVersion
 	api.Secrets = []KeyVaultSecrets{}
 	for _, s := range vlabs.Secrets {
 		secret := &KeyVaultSecrets{}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -185,6 +185,7 @@ type WindowsProfile struct {
 	WindowsPublisher      string            `json:"windowsPublisher"`
 	WindowsOffer          string            `json:"windowsOffer"`
 	WindowsSku            string            `json:"windowsSku"`
+	WindowsDockerVersion  string            `json:"windowsDockerVersion"`
 	Secrets               []KeyVaultSecrets `json:"secrets,omitempty"`
 }
 
@@ -1080,6 +1081,14 @@ func (w *WindowsProfile) HasSecrets() bool {
 // HasCustomImage returns true if there is a custom windows os image url specified
 func (w *WindowsProfile) HasCustomImage() bool {
 	return len(w.WindowsImageSourceURL) > 0
+}
+
+// GetWindowsDockerVersion gets the docker version specified or returns default value
+func (w *WindowsProfile) GetWindowsDockerVersion() string {
+	if w.WindowsDockerVersion != "" {
+		return w.WindowsDockerVersion
+	}
+	return KubernetesWindowsDockerVersion
 }
 
 // HasSecrets returns true if the customer specified secrets to install

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -794,6 +794,11 @@ func TestWindowsProfile(t *testing.T) {
 		t.Fatalf("Expected HasSecrets() and HasCustomImage() to return false when WindowsProfile is empty")
 	}
 
+	dv := w.GetWindowsDockerVersion()
+	if dv != KubernetesWindowsDockerVersion {
+		t.Fatalf("Expected GetWindowsDockerVersion() to equal default KubernetesWindowsDockerVersion, got %s", dv)
+	}
+
 	w = WindowsProfile{
 		Secrets: []KeyVaultSecrets{
 			{
@@ -811,6 +816,15 @@ func TestWindowsProfile(t *testing.T) {
 
 	if !(w.HasSecrets() && w.HasCustomImage()) {
 		t.Fatalf("Expected HasSecrets() and HasCustomImage() to return true")
+	}
+
+	w = WindowsProfile{
+		WindowsDockerVersion: "18.03.1-ee-3",
+	}
+
+	dv = w.GetWindowsDockerVersion()
+	if dv != "18.03.1-ee-3" {
+		t.Fatalf("Expected GetWindowsDockerVersion() to equal 18.03.1-ee-3, got %s", dv)
 	}
 }
 

--- a/pkg/api/vlabs/types.go
+++ b/pkg/api/vlabs/types.go
@@ -157,6 +157,7 @@ type WindowsProfile struct {
 	WindowsPublisher      string            `json:"WindowsPublisher"`
 	WindowsOffer          string            `json:"WindowsOffer"`
 	WindowsSku            string            `json:"WindowsSku"`
+	WindowsDockerVersion  string            `json:"windowsDockerVersion"`
 	Secrets               []KeyVaultSecrets `json:"secrets,omitempty"`
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Allows configuration of Docker version on windows nodes and sets a default that fixes deployments with server 1803.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4118  and address making dockerEngineVersion configurable for #3852

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [x] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Make docker version configurable on Windows nodes with default of Docker EE 17.06
```
