### PR TITLE
Add support for Kubernetes v1.13.0-alpha.2

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -87,6 +87,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.12.0":         true,
 	"1.12.1":         true,
 	"1.13.0-alpha.1": true,
+	"1.13.0-alpha.2": true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release


### PR DESCRIPTION
**What this PR does / why we need it**:

See https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.13.md#v1130-alpha2

TODO: 

- [x] Upload Windows binary

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Kubernetes: add support for v1.13.0-alpha.2
```
