### PR TITLE
Add support for Kubernetes 1.12.2

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -120,7 +120,7 @@ done
 pullContainerImage "docker" "busybox"
 
 # TODO: fetch supported k8s versions from an acs-engine command instead of hardcoding them here
-K8S_VERSIONS="1.7.15 1.7.16 1.8.14 1.8.15 1.9.10 1.9.11 1.10.8 1.10.9 1.11.3 1.11.4 1.12.0 1.12.1"
+K8S_VERSIONS="1.7.15 1.7.16 1.8.14 1.8.15 1.9.10 1.9.11 1.10.8 1.10.9 1.11.3 1.11.4 1.12.1 1.12.2"
 
 for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
     HYPERKUBE_URL="k8s.gcr.io/hyperkube-amd64:v${KUBERNETES_VERSION}"

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -85,8 +85,9 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.12.0-beta.1":  false,
 	"1.12.0-rc.1":    false,
 	"1.12.0-rc.2":    false,
-	"1.12.0":         true,
+	"1.12.0":         false,
 	"1.12.1":         true,
+	"1.12.2":         true,
 	"1.13.0-alpha.1": true,
 	"1.13.0-alpha.2": true,
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

See https://github.com/kubernetes/kubernetes/releases/tag/v1.12.2

TODO:

- [x] upload Windows binary

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
```release-note
Add support for Kubernetes 1.12.2
```
