### PR TITLE
WIP: Temporary fix for #4118 in acs-engine v0.24

### DIFF
--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -352,6 +352,9 @@ Install-KubernetesServices
         $kubeStartStr += @"
 Write-Host "NetworkPlugin azure, starting kubelet."
 
+# Temporary workaround for #4118 - don't merge to acs-engine master
+`$ENV:DOCKER_API_VERSION="1.37"
+
 # Turn off Firewall to enable pods to talk to service endpoints. (Kubelet should eventually do this)
 netsh advfirewall set allprofiles state off
 # startup the service
@@ -417,6 +420,9 @@ $KubeletCommandLine
     {
         $KubeNetwork = "l2bridge"
         $kubeStartStr += @"
+
+# Temporary workaround for #4118 - don't merge to acs-engine master
+`$ENV:DOCKER_API_VERSION="1.37"
 
 function
 Get-DefaultGateway(`$CIDR)


### PR DESCRIPTION
**What this PR does / why we need it**:

The October windows image `MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1803-with-Containers-smalldisk:1803.0.20181017` brought in Docker EE-basic 18.03, which has a problem with Kubernetes v1.12 (https://github.com/kubernetes/kubernetes/issues/69996)

This puts in a temporary workaround. The best fix to avoid this problem long term is to enable acs-engine to deploy a specific Docker version so they can be tested before release, and pinned if necessary. That fix is in #4119 but will be in acs-engine v0.25 later.

**Which issue this PR fixes** 
fixes #4118 
