### PR TITLE
Adding DOCKER_API_VERSION workaround

### DIFF
--- a/parts/k8s/windowsconfigfunc.ps1
+++ b/parts/k8s/windowsconfigfunc.ps1
@@ -58,7 +58,7 @@ function Install-Docker
         }
 
         default {
-            Write-Log "Docker version $DockerVersion found, clearing DOCKER_API_VERSION")
+            Write-Log "Docker version $DockerVersion found, clearing DOCKER_API_VERSION"
             [System.Environment]::SetEnvironmentVariable('DOCKER_API_VERSION', $null, [System.EnvironmentVariableTarget]::Machine)
         }
     }

--- a/parts/k8s/windowsconfigfunc.ps1
+++ b/parts/k8s/windowsconfigfunc.ps1
@@ -41,6 +41,28 @@ function Install-Docker
         $DockerVersion
     )
 
+    # Note: to get a list of all versions, use this snippet
+    # $versions = (curl.exe -L "https://go.microsoft.com/fwlink/?LinkID=825636&clcid=0x409" | ConvertFrom-Json).Versions | Get-Member -Type NoteProperty | Select-Object Name
+    # Docker version to API version decoder: https://docs.docker.com/develop/sdk/#api-version-matrix
+
+    switch ($DockerVersion.Substring(0,5))
+    {
+        "17.06" {
+            Write-Log "Docker 17.06 found, setting DOCKER_API_VERSION to 1.30"
+            [System.Environment]::SetEnvironmentVariable('DOCKER_API_VERSION', '1.30', [System.EnvironmentVariableTarget]::Machine)
+        }
+
+        "18.03" {
+            Write-Log "Docker 18.03 found, setting DOCKER_API_VERSION to 1.37"
+            [System.Environment]::SetEnvironmentVariable('DOCKER_API_VERSION', '1.37', [System.EnvironmentVariableTarget]::Machine)
+        }
+
+        default {
+            Write-Log "Docker version $DockerVersion found, clearing DOCKER_API_VERSION")
+            [System.Environment]::SetEnvironmentVariable('DOCKER_API_VERSION', $null, [System.EnvironmentVariableTarget]::Machine)
+        }
+    }
+
     try {
         Find-Package -Name Docker -ProviderName DockerMsftProvider -RequiredVersion $DockerVersion -ErrorAction Stop
         Write-Log "Found version $DockerVersion. Installing..."


### PR DESCRIPTION
**What this PR does / why we need it**:

The October windows image `MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1803-with-Containers-smalldisk:1803.0.20181017` brought in Docker EE-basic 18.03, which has a problem with Kubernetes v1.12 (https://github.com/kubernetes/kubernetes/issues/69996)

This fix pins the `DOCKER_API_VERSION` environment variable system-wide to match the API supported by Docker for versions 17.06 and 18.03. This fixes the problem with kubelet startup. 

For newer versions, the key should be cleared.

**Which issue this PR fixes** 
fixes #4118 
depends on #4119 