### PR TITLE
Make orchestrator command Windows aware

### DIFF
--- a/cmd/orchestrators.go
+++ b/cmd/orchestrators.go
@@ -18,6 +18,7 @@ type orchestratorsCmd struct {
 	// user input
 	orchestrator string
 	version      string
+	windows      bool
 }
 
 func newOrchestratorsCmd() *cobra.Command {
@@ -35,12 +36,13 @@ func newOrchestratorsCmd() *cobra.Command {
 	f := command.Flags()
 	f.StringVar(&oc.orchestrator, "orchestrator", "", "orchestrator name (optional) ")
 	f.StringVar(&oc.version, "version", "", "orchestrator version (optional)")
+	f.BoolVar(&oc.windows, "windows", false, "orchestrator platform (optional)")
 
 	return command
 }
 
 func (oc *orchestratorsCmd) run(cmd *cobra.Command, args []string) error {
-	orchs, err := api.GetOrchestratorVersionProfileListVLabs(oc.orchestrator, oc.version)
+	orchs, err := api.GetOrchestratorVersionProfileListVLabs(oc.orchestrator, oc.version, oc.windows)
 	if err != nil {
 		return err
 	}

--- a/cmd/orchestrators.go
+++ b/cmd/orchestrators.go
@@ -36,7 +36,7 @@ func newOrchestratorsCmd() *cobra.Command {
 	f := command.Flags()
 	f.StringVar(&oc.orchestrator, "orchestrator", "", "orchestrator name (optional) ")
 	f.StringVar(&oc.version, "version", "", "orchestrator version (optional)")
-	f.BoolVar(&oc.windows, "windows", false, "orchestrator platform (optional)")
+	f.BoolVar(&oc.windows, "windows", false, "orchestrator platform (optional, applies to Kubernetes only)")
 
 	return command
 }

--- a/pkg/api/orchestrators.go
+++ b/pkg/api/orchestrators.go
@@ -68,8 +68,8 @@ func isVersionSupported(csOrch *OrchestratorProfile) bool {
 }
 
 // GetOrchestratorVersionProfileListVLabs returns vlabs OrchestratorVersionProfileList object per (optionally) specified orchestrator and version
-func GetOrchestratorVersionProfileListVLabs(orchestrator, version string) (*vlabs.OrchestratorVersionProfileList, error) {
-	apiOrchs, err := getOrchestratorVersionProfileList(orchestrator, version)
+func GetOrchestratorVersionProfileListVLabs(orchestrator, version string, windows bool) (*vlabs.OrchestratorVersionProfileList, error) {
+	apiOrchs, err := getOrchestratorVersionProfileList(orchestrator, version, windows)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func GetOrchestratorVersionProfileListVLabs(orchestrator, version string) (*vlab
 
 // GetOrchestratorVersionProfileListV20170930 returns v20170930 OrchestratorVersionProfileList object per (optionally) specified orchestrator and version
 func GetOrchestratorVersionProfileListV20170930(orchestrator, version string) (*v20170930.OrchestratorVersionProfileList, error) {
-	apiOrchs, err := getOrchestratorVersionProfileList(orchestrator, version)
+	apiOrchs, err := getOrchestratorVersionProfileList(orchestrator, version, false)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func GetOrchestratorVersionProfileListV20170930(orchestrator, version string) (*
 	return orchList, nil
 }
 
-func getOrchestratorVersionProfileList(orchestrator, version string) ([]*OrchestratorVersionProfile, error) {
+func getOrchestratorVersionProfileList(orchestrator, version string, windows bool) ([]*OrchestratorVersionProfile, error) {
 	var err error
 	if orchestrator, err = validate(orchestrator, version); err != nil {
 		return nil, err
@@ -110,7 +110,7 @@ func getOrchestratorVersionProfileList(orchestrator, version string) ([]*Orchest
 			orchs = append(orchs, arr...)
 		}
 	} else {
-		if orchs, err = funcmap[orchestrator](&OrchestratorProfile{OrchestratorType: orchestrator, OrchestratorVersion: version}, false); err != nil {
+		if orchs, err = funcmap[orchestrator](&OrchestratorProfile{OrchestratorType: orchestrator, OrchestratorVersion: version}, windows); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Make orchestrators command Windows-aware

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3807

**Special notes for your reviewer**: Was unsure whether to update `GetOrchestratorVersionProfileListV20170930` as well.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
