### PR TITLE
Enable billing extension for AzureChinaCloud

### DIFF
--- a/pkg/acsengine/const.go
+++ b/pkg/acsengine/const.go
@@ -204,7 +204,3 @@ const (
 	swarmWinAgentResourcesVMSS    = "swarm/swarmwinagentresourcesvmss.t"
 	windowsParams                 = "windowsparams.t"
 )
-
-const (
-	azurePublicCloud = "AzurePublicCloud"
-)

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -371,7 +371,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		},
 		"UseAksExtension": func() bool {
 			cloudSpecConfig := cs.GetCloudSpecConfig()
-			return cloudSpecConfig.CloudName == azurePublicCloud
+			return cloudSpecConfig.CloudName == api.AzurePublicCloud || cloudSpecConfig.CloudName == api.AzureChinaCloud
 		},
 		"UseInstanceMetadata": func() bool {
 			return helpers.IsTrueBoolPointer(cs.Properties.OrchestratorProfile.KubernetesConfig.UseInstanceMetadata)

--- a/pkg/api/azenvtypes.go
+++ b/pkg/api/azenvtypes.go
@@ -171,7 +171,7 @@ var (
 
 	//AzureCloudSpec is the default configurations for global azure.
 	AzureCloudSpec = AzureEnvironmentSpecConfig{
-		CloudName: azurePublicCloud,
+		CloudName: AzurePublicCloud,
 		//DockerSpecConfig specify the docker engine download repo
 		DockerSpecConfig: DefaultDockerSpecConfig,
 		//KubernetesSpecConfig is the default kubernetes container image url.
@@ -230,7 +230,7 @@ var (
 
 	//AzureChinaCloudSpec is the configurations for Azure China (Mooncake)
 	AzureChinaCloudSpec = AzureEnvironmentSpecConfig{
-		CloudName: azureChinaCloud,
+		CloudName: AzureChinaCloud,
 		//DockerSpecConfig specify the docker engine download repo
 		DockerSpecConfig: DockerSpecConfig{
 			DockerEngineRepo:         "https://mirror.azure.cn/docker-engine/apt/repo/",
@@ -272,9 +272,9 @@ var (
 
 	// AzureCloudSpecEnvMap is the environment configuration map for all the Azure cloid environments.
 	AzureCloudSpecEnvMap = map[string]AzureEnvironmentSpecConfig{
-		azureChinaCloud:        AzureChinaCloudSpec,
+		AzureChinaCloud:        AzureChinaCloudSpec,
 		azureGermanCloud:       AzureGermanCloudSpec,
 		azureUSGovernmentCloud: AzureUSGovernmentCloud,
-		azurePublicCloud:       AzureCloudSpec,
+		AzurePublicCloud:       AzureCloudSpec,
 	}
 )

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -382,8 +382,10 @@ const (
 )
 
 const (
-	azurePublicCloud       = "AzurePublicCloud"
-	azureChinaCloud        = "AzureChinaCloud"
+	// AzurePublicCloud is Azure Public Cloud
+	AzurePublicCloud = "AzurePublicCloud"
+	// AzureChinaCloud is Azure China Cloud
+	AzureChinaCloud        = "AzureChinaCloud"
 	azureGermanCloud       = "AzureGermanCloud"
 	azureUSGovernmentCloud = "AzureUSGovernmentCloud"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable billing extension for AzureChinaCloud
Compute.AKS-Engine.Linux.Billing & Compute.AKS.Linux.Billing are deployed in mooncake.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
```release-note
```
