### PR TITLE
Add support for Kubernetes v1.13.0-alpha.3

### DIFF
--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -90,6 +90,7 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.12.2":         true,
 	"1.13.0-alpha.1": true,
 	"1.13.0-alpha.2": true,
+	"1.13.0-alpha.3": true,
 }
 
 // GetDefaultKubernetesVersion returns the default Kubernetes version, that is the latest patch of the default release

--- a/pkg/api/k8s_versions.go
+++ b/pkg/api/k8s_versions.go
@@ -18,7 +18,7 @@ var k8sComponentVersions = map[string]map[string]string{
 		"metrics-server":                   "metrics-server-amd64:v0.2.1",
 		"coredns":                          "coredns:1.2.2",
 		"kube-dns":                         "k8s-dns-kube-dns-amd64:1.14.13",
-		"addon-manager":                    "kube-addon-manager-amd64:v8.8",
+		"addon-manager":                    "kube-addon-manager-amd64:v8.9",
 		"dnsmasq":                          "k8s-dns-dnsmasq-nanny-amd64:1.14.10",
 		"pause":                            "pause-amd64:3.1",
 		"tiller":                           "tiller:v2.8.1",


### PR DESCRIPTION
**What this PR does / why we need it**:

See https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.13.md#v1130-alpha3

TODO: 

- [x] Upload Windows binary

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Kubernetes: add support for v1.13.0-alpha.3
```
