### PR TITLE
#3444 set ETCDCTL_API

### DIFF
--- a/parts/k8s/kubernetesconfigs.sh
+++ b/parts/k8s/kubernetesconfigs.sh
@@ -66,6 +66,10 @@ function configureEtcd() {
     chmod 0644 "${ETCD_PEER_CERTIFICATE_PATH}"
     chown root:root "${ETCD_PEER_CERTIFICATE_PATH}"
 
+    ETCD_VERSION=$(etcd --version|head -1|cut -d\  -f 3)
+    echo "export ETCDCTL_API=${ETCD_VERSION:0:1}" >> /root/.bash_profile
+    echo "export ETCDCTL_API=${ETCD_VERSION:0:1}" >> ~admin/.bash_profile
+
     set +x
     echo "${APISERVER_PRIVATE_KEY}" | base64 --decode > "${APISERVER_PRIVATE_KEY_PATH}"
     echo "${CA_PRIVATE_KEY}" | base64 --decode > "${CA_PRIVATE_KEY_PATH}"

--- a/parts/k8s/kubernetesmastergenerateproxycertscript.sh
+++ b/parts/k8s/kubernetesmastergenerateproxycertscript.sh
@@ -10,6 +10,7 @@ PROXY_CLIENT_CRT="${PROXY_CLIENT_CRT:=/tmp/proxy-client.crt}"
 ETCD_REQUESTHEADER_CLIENT_CA="${ETCD_REQUESTHEADER_CLIENT_CA:=/proxycerts/requestheader-client-ca-file}"
 ETCD_PROXY_CERT="${ETCD_PROXY_CERT:=/proxycerts/proxy-client-cert-file}"
 ETCD_PROXY_KEY="${ETCD_PROXY_KEY:=/proxycerts/proxy-client-key-file}"
+ETCD_VERSION=$(etcd --version|head -1|cut -d\  -f 3)
 K8S_PROXY_CA_CRT_FILEPATH="${K8S_PROXY_CA_CRT_FILEPATH:=/etc/kubernetes/certs/proxy-ca.crt}"
 K8S_PROXY_KEY_FILEPATH="${K8S_PROXY_KEY_FILEPATH:=/etc/kubernetes/certs/proxy.key}"
 K8S_PROXY_CRT_FILEPATH="${K8S_PROXY_CRT_FILEPATH:=/etc/kubernetes/certs/proxy.crt}"
@@ -18,6 +19,7 @@ export ETCDCTL_ENDPOINTS="${ETCDCTL_ENDPOINTS:=https://127.0.0.1:2379}"
 export ETCDCTL_CA_FILE="${ETCDCTL_CA_FILE:=/etc/kubernetes/certs/ca.crt}"
 export ETCDCTL_KEY_FILE="${ETCDCTL_KEY_FILE:=/etc/kubernetes/certs/etcdclient.key}"
 export ETCDCTL_CERT_FILE="${ETCDCTL_CERT_FILE:=/etc/kubernetes/certs/etcdclient.crt}"
+export ETCDCTL_API="${ETCD_VERSION:0:1}"
 export RANDFILE=$(mktemp)
 
 # generate root CA
@@ -45,7 +47,7 @@ write_certs_to_disk_with_retry() {
 }
 
 # block until all etcd is ready
-retrycmd_if_failure 100 5 10 etcdctl cluster-health
+retrycmd_if_failure 100 5 10 etcdctl member list
 # Make etcd keys, adding a leading whitespace because etcd won't accept a val that begins with a '-' (hyphen)!
 # etcdctl will output the data it's given, stdout is redirected to dev null to avoid capturing sensitive data in logs
 if etcdctl mk $ETCD_REQUESTHEADER_CLIENT_CA " $(cat ${PROXY_CRT})" > /dev/null 2>&1; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR sets ETCDCTL_API to the installed version (should be 3 everywhere) where `etcdctl` is used. It also sets it in the root and admin `.bash_profile`s.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3444 / #3420 

**Special notes for your reviewer**:
I would had liked to add code coverage for this, but there isn't a test for templates.go [pkg/acs-engine/template.go](pkg/acs-engine/template.go), and I can't think of or find a great way of checking for this otherwise. If you have any ideas, would love some feedback here.

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Sets etcdctl api version to the installed version of etcd.
```
