### PR TITLE
use gcr.azk8s.cn for all add-on configs on Azure China

### DIFF
--- a/parts/k8s/kubernetesmastercustomdata.yml
+++ b/parts/k8s/kubernetesmastercustomdata.yml
@@ -450,6 +450,12 @@ MASTER_ARTIFACTS_CONFIG_PLACEHOLDER
     sed -i "s|<masqLinkLocalValue>|false|g" "/etc/kubernetes/addons/ip-masq-agent.yaml"
 {{end}}
 
+{{if IsMooncake}}
+    #`k8s.gcr.io` would redirect to `gcr.io/google-containers`, so we replace with `gcr.azk8s.cn/google-containers` here and it must be in the first order.
+    sed -i "s/k8s.gcr.io/gcr.azk8s.cn\/google-containers/g" /etc/kubernetes/addons/*.yaml
+    sed -i "s/gcr.io/gcr.azk8s.cn/g" /etc/kubernetes/addons/*.yaml
+{{end}}
+
 - path: "/opt/azure/containers/mountetcd.sh"
   permissions: "0744"
   encoding: gzip


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
use gcr.azk8s.cn for ip-masq-agent on Azure China
also `k8s.gcr.io` would redirect to `gcr.io/google-containers`, so we replace with `gcr.azk8s.cn/google-containers`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4063

**Special notes for your reviewer**:
Already tested in azure china, it works well.
```
$ kubectl describe po azure-ip-masq-agent-29k9q -n kube-system
Events:
  Type    Reason     Age   From                                Message
  ----    ------     ----  ----                                -------
  Normal  Scheduled  57s   default-scheduler                   Successfully assigned kube-system/azure-ip-masq-agent-29k9q to k8s-agentpool1-40524344-1
  Normal  Pulling    55s   kubelet, k8s-agentpool1-40524344-1  pulling image "gcr.azk8s.cn/google-containers/ip-masq-agent-amd64:v2.0.0"
  Normal  Pulled     45s   kubelet, k8s-agentpool1-40524344-1  Successfully pulled image "gcr.azk8s.cn/google-containers/ip-masq-agent-amd64:v2.0.0"
  Normal  Created    43s   kubelet, k8s-agentpool1-40524344-1  Created container
  Normal  Started    42s   kubelet, k8s-agentpool1-40524344-1  Started container
```
**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
use gcr.azk8s.cn for ip-masq-agent on Azure China
```

@jackfrancis 