### PR TITLE
More validations for custom vnet and vmss masters

### DIFF
--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -363,6 +363,12 @@ func (a *Properties) validateMasterProfile() error {
 		}
 	}
 
+	if a.OrchestratorProfile.OrchestratorType == Kubernetes {
+		if m.IsVirtualMachineScaleSets() && m.VnetSubnetID != "" && m.FirstConsecutiveStaticIP != "" {
+			return errors.New("when masterProfile's availabilityProfile is VirtualMachineScaleSets and a vnetSubnetID is specified, the firstConsecutiveStaticIP should be empty and will be determined by an offset from the first IP in the vnetCidr")
+		}
+	}
+
 	if m.ImageRef != nil {
 		if err := m.ImageRef.validateImageNameAndGroup(); err != nil {
 			return err

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -2148,6 +2148,27 @@ func TestProperties_ValidateVNET(t *testing.T) {
 			expectedMsg: "when master profile is using VirtualMachineScaleSets and is custom vnet, set \"vnetsubnetid\" and \"agentVnetSubnetID\" for master profile",
 		},
 		{
+			name: "User-provided MasterProfile FirstConsecutiveStaticIP when master is VMSS",
+			masterProfile: &MasterProfile{
+				VnetSubnetID:             validVNetSubnetID,
+				Count:                    1,
+				DNSPrefix:                "foo",
+				VMSize:                   "Standard_DS2_v2",
+				AvailabilityProfile:      VirtualMachineScaleSets,
+				FirstConsecutiveStaticIP: "10.0.0.4",
+			},
+			agentPoolProfiles: []*AgentPoolProfile{
+				{
+					Name:                "agentpool",
+					VMSize:              "Standard_D2_v2",
+					Count:               1,
+					AvailabilityProfile: VirtualMachineScaleSets,
+					VnetSubnetID:        validVNetSubnetID,
+				},
+			},
+			expectedMsg: "when masterProfile's availabilityProfile is VirtualMachineScaleSets and a vnetSubnetID is specified, the firstConsecutiveStaticIP should be empty and will be determined by an offset from the first IP in the vnetCidr",
+		},
+		{
 			name: "Invalid vnetcidr",
 			masterProfile: &MasterProfile{
 				VnetSubnetID:             validVNetSubnetID,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
- Add validation for `firstConsecutiveStaticIP` when using custom vnet and vmss masters
- Add unit test for validation of `firstConsecutiveStaticIP` and vmss masters
- Add docs for using custom VNET with VirtualMachineScaleSets MasterProfile

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4168 

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
