### PR TITLE
move kubeserviceCidr params to windowsparams tpl

### DIFF
--- a/parts/k8s/kubernetesparams.t
+++ b/parts/k8s/kubernetesparams.t
@@ -195,12 +195,6 @@
       },
       "type": "string"
     },
-    "kubeServiceCidr": {
-      "metadata": {
-        "description": "Kubernetes service address space"
-      },
-      "type": "string"
-    },
 {{if not IsHostedMaster}}
     "kubernetesNonMasqueradeCidr": {
       "metadata": {

--- a/parts/windowsparams.t
+++ b/parts/windowsparams.t
@@ -17,6 +17,12 @@
       },
       "type": "string"
     },
+    "kubeServiceCidr": {
+      "metadata": {
+        "description": "Kubernetes service address space"
+      },
+      "type": "string"
+    },
     "windowsTelemetryGUID": {
       "metadata": {
         "description": "The GUID to set in windows agent to collect telemetry data."

--- a/pkg/acsengine/params_k8s.go
+++ b/pkg/acsengine/params_k8s.go
@@ -42,7 +42,6 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 			}
 
 			addValue(parametersMap, "kubeDNSServiceIP", kubernetesConfig.DNSServiceIP)
-			addValue(parametersMap, "kubeServiceCidr", kubernetesConfig.ServiceCIDR)
 			addValue(parametersMap, "kubernetesHyperkubeSpec", kubernetesHyperkubeSpec)
 			addValue(parametersMap, "kubernetesAddonManagerSpec", cloudSpecConfig.KubernetesSpecConfig.KubernetesImageBase+k8sComponents["addonmanager"])
 			addValue(parametersMap, "kubernetesAddonResizerSpec", cloudSpecConfig.KubernetesSpecConfig.KubernetesImageBase+k8sComponents["addonresizer"])
@@ -315,7 +314,7 @@ func assignKubernetesParameters(properties *api.Properties, parametersMap params
 				// Kubernetes node binaries as packaged by upstream kubernetes
 				// example at https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md#node-binaries-1
 				addValue(parametersMap, "windowsKubeBinariesURL", kubernetesConfig.WindowsNodeBinariesURL)
-
+				addValue(parametersMap, "kubeServiceCidr", kubernetesConfig.ServiceCIDR)
 				addValue(parametersMap, "kubeBinariesVersion", k8sVersion)
 				addValue(parametersMap, "windowsTelemetryGUID", cloudSpecConfig.KubernetesSpecConfig.WindowsTelemetryGUID)
 			}


### PR DESCRIPTION
KubeServiceCIDR is used only in cases when the properties have windows profile. 