### PR TITLE
Update to Docker 18.09 for Windows

### DIFF
--- a/examples/windows/kubernetes-windows-docker-version.json
+++ b/examples/windows/kubernetes-windows-docker-version.json
@@ -21,7 +21,7 @@
     "windowsProfile": {
       "adminUsername": "azureuser",
       "adminPassword": "replacepassword1234$",
-      "windowsDockerVersion": "17.06.2-ee-16"
+      "windowsDockerVersion": "18.09.0"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/parts/windowsparams.t
+++ b/parts/windowsparams.t
@@ -78,7 +78,7 @@
       "type": "string"
     },
     "windowsDockerVersion": {
-      "defaultValue": "17.06.2-ee-16",
+      "defaultValue": "18.09.0",
       "metadata": {
         "description": "The version of Docker to be installed on Windows Nodes"
       },

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -44,7 +44,7 @@ const (
 	// DockerCEDockerComposeVersion is the Docker Compose version
 	DockerCEDockerComposeVersion = "1.14.0"
 	// KubernetesWindowsDockerVersion is the default version for docker on Windows nodes in kubernetes
-	KubernetesWindowsDockerVersion = "17.06.2-ee-16"
+	KubernetesWindowsDockerVersion = "18.09.0"
 )
 
 // validation values


### PR DESCRIPTION
**What this PR does / why we need it**:
[Docker EE 18.09](https://docs.docker.com/engine/release-notes/) is out, which has a newer API version. It's the version recommended by Docker Inc to work with Kubernetes 1.12+ on Windows. This PR sets it as the default version so we can get more test coverage on it.

Previously, we needed some workarounds to make k8s 1.12+ work (see #4118). That PR was designed so that when a new version came out, the workarounds would no longer be applied. That code will be kept in place so we can still test and use older versions if needed.

The same issue is also tracked in https://github.com/kubernetes/kubernetes/issues/69996

**Release note**:
```release-note
Use [Docker EE basic version 18.09.0](https://docs.docker.com/engine/release-notes/) by default for Windows nodes.
```
