### PR TITLE
Adding containermonitoring to the list of addons that need tested

### DIFF
--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -47,6 +47,19 @@
                 "memoryLimits": "200Mi"
               }
             ]
+          },
+          {
+            "name": "container-monitoring",
+            "enabled": true,
+            "containers": [
+              {
+                "name": "omsagent",
+                "cpuRequests": "20m",
+                "memoryRequests": "200Mi",
+                "cpuLimits": "20m",
+                "memoryLimits": "200Mi"
+              }
+            ]
           }
         ]
       }


### PR DESCRIPTION
This will be useful when oms agent team adds new versions of the oms agent