### PR TITLE
[WIP] add nvidia.com/gpu taint to N series nodes

### DIFF
--- a/parts/k8s/addons/kubernetesmasteraddons-kube-proxy-daemonset.yaml
+++ b/parts/k8s/addons/kubernetesmasteraddons-kube-proxy-daemonset.yaml
@@ -19,6 +19,10 @@ spec:
         operator: Equal
         value: "true"
         effect: NoSchedule
+      - key: nvidia.com/gpu
+        effect: NoSchedule
+        operator: Equal
+        value: "true"
       containers:
       - command:
         - /hyperkube

--- a/parts/k8s/containeraddons/azure-cni-networkmonitor.yaml
+++ b/parts/k8s/containeraddons/azure-cni-networkmonitor.yaml
@@ -24,6 +24,10 @@ spec:
         operator: Equal
         value: "true"
         effect: NoSchedule
+      - key: nvidia.com/gpu
+        effect: NoSchedule
+        operator: Equal
+        value: "true"
       nodeSelector:
         beta.kubernetes.io/os: linux
       containers:

--- a/parts/k8s/containeraddons/ip-masq-agent.yaml
+++ b/parts/k8s/containeraddons/ip-masq-agent.yaml
@@ -25,6 +25,10 @@ spec:
         operator: Equal
         value: "true"
         effect: NoSchedule
+      - key: nvidia.com/gpu
+        effect: NoSchedule
+        operator: Equal
+        value: "true"
       containers:
       - name: azure-ip-masq-agent
         image: {{ContainerImage "ip-masq-agent"}}

--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -212,7 +212,7 @@ write_files:
     KUBELET_CONFIG={{GetKubeletConfigKeyVals .KubernetesConfig }}
     KUBELET_IMAGE={{WrapAsParameter "kubernetesHyperkubeSpec"}}
     KUBELET_REGISTER_SCHEDULABLE=true
-    {{if IsNSeriesSKU .}}{{if IsNVIDIADevicePluginEnabled}}KUBELET_REGISTER_WITH_TAINTS=--register-with-taints=nvidia.com/gpu=true:NoSchedule{{end}}{{end}}
+    {{if IsNSeriesSKU .}}{{if IsNVIDIADevicePluginEnabled}}{{if HasNonNSeriesAgentPool}}KUBELET_REGISTER_WITH_TAINTS=--register-with-taints=nvidia.com/gpu=true:NoSchedule{{end}}{{end}}{{end}}
     KUBELET_NODE_LABELS={{GetAgentKubernetesLabels . "',variables('labelResourceGroup'),'"}}
 
 AGENT_ARTIFACTS_CONFIG_PLACEHOLDER

--- a/parts/k8s/kubernetesagentcustomdata.yml
+++ b/parts/k8s/kubernetesagentcustomdata.yml
@@ -212,6 +212,7 @@ write_files:
     KUBELET_CONFIG={{GetKubeletConfigKeyVals .KubernetesConfig }}
     KUBELET_IMAGE={{WrapAsParameter "kubernetesHyperkubeSpec"}}
     KUBELET_REGISTER_SCHEDULABLE=true
+    {{if IsNSeriesSKU .}}{{if IsNVIDIADevicePluginEnabled}}KUBELET_REGISTER_WITH_TAINTS=--register-with-taints=nvidia.com/gpu=true:NoSchedule{{end}}{{end}}
     KUBELET_NODE_LABELS={{GetAgentKubernetesLabels . "',variables('labelResourceGroup'),'"}}
 
 AGENT_ARTIFACTS_CONFIG_PLACEHOLDER

--- a/pkg/acsengine/template_generator.go
+++ b/pkg/acsengine/template_generator.go
@@ -789,6 +789,14 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 		"IsNSeriesSKU": func(profile *api.AgentPoolProfile) bool {
 			return common.IsNvidiaEnabledSKU(profile.VMSize)
 		},
+		"HasNonNSeriesAgentPool": func() bool {
+			for _, agentProfile := range cs.Properties.AgentPoolProfiles {
+				if !agentProfile.IsNSeriesSKU() {
+					return true
+				}
+			}
+			return false
+		},
 		"UseSinglePlacementGroup": func(profile *api.AgentPoolProfile) bool {
 			return *profile.SinglePlacementGroup
 		},

--- a/test/e2e/kubernetes/workloads/cuda-vector-add.yaml
+++ b/test/e2e/kubernetes/workloads/cuda-vector-add.yaml
@@ -8,6 +8,11 @@ spec:
       name: cuda-vector-add
     spec:
       restartPolicy: Never
+      tolerations:
+      - key: nvidia.com/gpu
+        effect: NoSchedule
+        operator: Equal
+        value: "true"
       containers:
       - name: cuda-vector-add
         image: k8s.gcr.io/cuda-vector-add:v0.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This PR adds a nvidia.com/gpu taint to nvidia-capable nodes when they are a part of a multiple agent pool cluster, one of which is non-N series VM SKU. The idea here is: if you have an N series pool, and a non-N series pool, you would only want to schedule non-nvidia workloads to your non-N series nodes, to ensure that your N-series nodes were optimized only to run nvidia workloads.

Merging this would mean communicating that gpu workloads running on clusters built with this logic would need the accompanying toleration.

Toleration added for:

- kube-proxy
- ip-masq-agent
- azure-cni-networkmonitor

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4236 

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
add nvidia.com/gpu taint to N series nodes
```
