### PR TITLE
Adding c:\tmp as needed to pass Kubernetes tests

### DIFF
--- a/parts/k8s/kuberneteswindowsfunctions.ps1
+++ b/parts/k8s/kuberneteswindowsfunctions.ps1
@@ -39,3 +39,16 @@ function New-TemporaryDirectory {
     [string] $name = [System.Guid]::NewGuid()
     New-Item -ItemType Directory -Path (Join-Path $parent $name)
 }
+
+function Initialize-DataDirectories {
+    # Some of the Kubernetes tests that were designed for Linux try to mount /tmp into a pod
+    # On Windows, Go translates to c:\tmp. If that path doesn't exist, then some node tests fail
+
+    $requiredPaths = 'c:\tmp'
+
+    $requiredPaths | ForEach-Object {
+        if (-Not (Test-Path $_)) {
+            New-Item -ItemType Directory -Path $_
+        }
+    }
+}

--- a/parts/k8s/kuberneteswindowssetup.ps1
+++ b/parts/k8s/kuberneteswindowssetup.ps1
@@ -145,6 +145,9 @@ try
         Write-Log "Resize os drive if possible"
         Resize-OSDrive
 
+        Write-Log "Create required data directories as needed"
+        Initialize-DataDirectories
+
         Write-Log "Install docker"
         Install-Docker -DockerVersion $global:DockerVersion
 


### PR DESCRIPTION
**What this PR does / why we need it**:

These two test cases will fail on Windows due to a missing path. Since people may want to run conformance or other tests on a cluster, we should create the path to avoid failure.

- Kubernetes e2e suite.[sig-storage] HostPath should support r/w [NodeConformance]
- Kubernetes e2e suite.[sig-storage] HostPath should support subPath [NodeConformance]

```
Error: Error response from daemon: invalid volume specification: 'c:/tmp:c:/test-volume': invalid mount config for type "bind": bind source path does not exist: c:\tmp
```

cc @jsturtevant @adelina-t 