### PR TITLE
Set stability iterations on Windows tests to 1

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -73,8 +73,8 @@ var _ = BeforeSuite(func() {
 		masterSSHPort = "22"
 	}
 	masterSSHPrivateKeyFilepath = cfg.GetSSHKeyPath()
-	if cfg.StabilityIterations == 0 && !eng.HasWindowsAgents() {
-		cfg.StabilityIterations = 10
+	if cfg.StabilityIterations == 0 {
+		cfg.StabilityIterations = 1
 	}
 	longRunningApacheDeploymentName = "php-apache-long-running"
 })

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -73,6 +73,9 @@ var _ = BeforeSuite(func() {
 		masterSSHPort = "22"
 	}
 	masterSSHPrivateKeyFilepath = cfg.GetSSHKeyPath()
+	if cfg.StabilityIterations == 0 && !eng.HasWindowsAgents() {
+		cfg.StabilityIterations = 10
+	}
 	longRunningApacheDeploymentName = "php-apache-long-running"
 })
 


### PR DESCRIPTION
The tests with `cfg.stabilityIterations` checks are important and shouldn't be skipped. If they're too flaky to run 10x, at least run 1x.

I heard a report that service IPs were broken in acs-engine deployments, so I went to check on the test cases and found that they weren't run. This sets it back to run at least once.

Resolves #4245