### PR TITLE
Using the conventional azure environment variable names

### DIFF
--- a/scripts/azure-const.sh
+++ b/scripts/azure-const.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
-if [ -z "$CLIENT_ID" ]; then
+if [ -z "$AZURE_CLIENT_ID" ]; then
     echo "must provide a CLIENT_ID env var"
     exit 1;
 fi
 
-if [ -z "$CLIENT_SECRET" ]; then
+if [ -z "$AZURE_CLIENT_SECRET" ]; then
     echo "must provide a CLIENT_SECRET env var"
     exit 1;
 fi
 
-if [ -z "$TENANT_ID" ]; then
+if [ -z "$AZURE_TENANT_ID" ]; then
     echo "must provide a TENANT_ID env var"
     exit 1;
 fi
 
-if [ -z "$SUBSCRIPTION_ID" ]; then
+if [ -z "$AZURE_SUBSCRIPTION_ID" ]; then
     echo "must provide a SUBSCRIPTION_ID env var"
     exit 1;
 fi
 
 az login --service-principal \
-		--username "${CLIENT_ID}" \
-		--password "${CLIENT_SECRET}" \
-		--tenant "${TENANT_ID}" &>/dev/null
+		--username "${AZURE_CLIENT_ID}" \
+		--password "${AZURE_CLIENT_SECRET}" \
+		--tenant "${AZURE_TENANT_ID}" &>/dev/null
 
 # set to the sub id we want to cleanup
-az account set -s $SUBSCRIPTION_ID
+az account set -s $AZURE_SUBSCRIPTION_ID
 
 python pkg/helpers/Get-AzureConstants.py
 git status | grep pkg/helpers/azureconst.go


### PR DESCRIPTION
Making sure the azure environment variables are name consistently across acs-engine