### PR TITLE
Add exechealthz to 1.12/13 section as 1.11 or earlier

### DIFF
--- a/pkg/api/k8s_versions.go
+++ b/pkg/api/k8s_versions.go
@@ -13,6 +13,7 @@ var k8sComponentVersions = map[string]map[string]string{
 	"1.13": {
 		"dockerEngine":                     "1.13.*",
 		"dashboard":                        "kubernetes-dashboard-amd64:v1.10.0",
+		"exechealthz":                      "exechealthz-amd64:1.2",
 		"addon-resizer":                    "addon-resizer:1.8.1",
 		"heapster":                         "heapster-amd64:v1.5.3",
 		"metrics-server":                   "metrics-server-amd64:v0.2.1",
@@ -46,6 +47,7 @@ var k8sComponentVersions = map[string]map[string]string{
 		"dockerEngine":                     "1.13.*",
 		"dashboard":                        "kubernetes-dashboard-amd64:v1.10.0",
 		"addon-resizer":                    "addon-resizer:1.8.1",
+		"exechealthz":                      "exechealthz-amd64:1.2",
 		"heapster":                         "heapster-amd64:v1.5.3",
 		"metrics-server":                   "metrics-server-amd64:v0.2.1",
 		"coredns":                          "coredns:1.2.2",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
AKS wants to use 1.12.x by default for VMSS agent nodes. There will be InvalidImageName error for kube-dns/healthz without this change

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

InvalidImageName error for kube-dns/healthz without this change

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
