### PR TITLE
Do not check agent & master pool size when using availability zones

### DIFF
--- a/pkg/api/vlabs/validate.go
+++ b/pkg/api/vlabs/validate.go
@@ -490,17 +490,10 @@ func (a *Properties) validateZones() error {
 		// all zones or no zones should be defined for the cluster
 		if a.HasAvailabilityZones() {
 			if a.MastersAndAgentsUseAvailabilityZones() {
-				// master profile
-				if a.MasterProfile.Count < len(a.MasterProfile.AvailabilityZones)*2 {
-					return errors.New("the node count and the number of availability zones provided can result in zone imbalance. To achieve zone balance, each zone should have at least 2 nodes or more")
-				}
 				// agent pool profiles
 				for _, agentPoolProfile := range a.AgentPoolProfiles {
 					if agentPoolProfile.AvailabilityProfile == AvailabilitySet {
 						return errors.New("Availability Zones are not supported with an AvailabilitySet. Please either remove availabilityProfile or set availabilityProfile to VirtualMachineScaleSets")
-					}
-					if agentPoolProfile.Count < len(agentPoolProfile.AvailabilityZones)*2 {
-						return errors.New("the node count and the number of availability zones provided can result in zone imbalance. To achieve zone balance, each zone should have at least 2 nodes or more")
 					}
 				}
 				if a.OrchestratorProfile.KubernetesConfig != nil && a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != "" && a.OrchestratorProfile.KubernetesConfig.LoadBalancerSku != "Standard" {

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -1740,27 +1740,6 @@ func TestProperties_ValidateZones(t *testing.T) {
 			expectedErr: "availabilityZone is only available in Kubernetes version 1.12 or greater",
 		},
 		{
-			name:                "Master profile with zones node count",
-			orchestratorRelease: "1.12",
-			masterProfile: &MasterProfile{
-				Count:               1,
-				DNSPrefix:           "foo",
-				VMSize:              "Standard_DS2_v2",
-				AvailabilityProfile: VirtualMachineScaleSets,
-				AvailabilityZones:   []string{"1", "2"},
-			},
-			agentProfiles: []*AgentPoolProfile{
-				{
-					Name:                "agentpool",
-					VMSize:              "Standard_DS2_v2",
-					Count:               4,
-					AvailabilityProfile: VirtualMachineScaleSets,
-					AvailabilityZones:   []string{"1", "2"},
-				},
-			},
-			expectedErr: "the node count and the number of availability zones provided can result in zone imbalance. To achieve zone balance, each zone should have at least 2 nodes or more",
-		},
-		{
 			name:                "Agent profile with zones version",
 			orchestratorRelease: "1.11",
 			masterProfile: &MasterProfile{
@@ -1780,27 +1759,6 @@ func TestProperties_ValidateZones(t *testing.T) {
 				},
 			},
 			expectedErr: "availabilityZone is only available in Kubernetes version 1.12 or greater",
-		},
-		{
-			name:                "Agent profile with zones node count",
-			orchestratorRelease: "1.12",
-			masterProfile: &MasterProfile{
-				Count:               5,
-				DNSPrefix:           "foo",
-				VMSize:              "Standard_DS2_v2",
-				AvailabilityProfile: VirtualMachineScaleSets,
-				AvailabilityZones:   []string{"1", "2"},
-			},
-			agentProfiles: []*AgentPoolProfile{
-				{
-					Name:                "agentpool",
-					VMSize:              "Standard_DS2_v2",
-					Count:               2,
-					AvailabilityProfile: VirtualMachineScaleSets,
-					AvailabilityZones:   []string{"1", "2"},
-				},
-			},
-			expectedErr: "the node count and the number of availability zones provided can result in zone imbalance. To achieve zone balance, each zone should have at least 2 nodes or more",
 		},
 		{
 			name:                "Agent profile with zones vmas",


### PR DESCRIPTION
**What this PR does / why we need it**:

You might want to start little and grow over time. You should not be
forced to use at least 2 times the amount of availability zones.


```release-note
Remove master & agent pools' size checks for availability zones
```
