### PR TITLE
E2E: rationalize node check + kube-system check, no kms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
           echo 'export ORCHESTRATOR_RELEASE=1.10' >> $BASH_ENV
           echo 'export CLUSTER_DEFINITION=examples/e2e-tests/kubernetes/release/default/definition.json' >> $BASH_ENV
           echo 'export CREATE_VNET=true' >> $BASH_ENV
-          echo 'export ENABLE_KMS_ENCRYPTION=true' >> $BASH_ENV
+          echo 'export ENABLE_KMS_ENCRYPTION=false' >> $BASH_ENV
           echo 'export CLEANUP_ON_EXIT=${CLEANUP_ON_EXIT}' >> $BASH_ENV
           echo 'export CLEANUP_IF_FAIL=${CLEANUP_IF_FAIL_LINUX}' >> $BASH_ENV
           echo 'export RETAIN_SSH=false' >> $BASH_ENV
@@ -98,7 +98,7 @@ jobs:
           echo 'export ORCHESTRATOR_RELEASE=1.11' >> $BASH_ENV
           echo 'export CLUSTER_DEFINITION=examples/e2e-tests/kubernetes/release/default/definition.json' >> $BASH_ENV
           echo 'export CREATE_VNET=true' >> $BASH_ENV
-          echo 'export ENABLE_KMS_ENCRYPTION=true' >> $BASH_ENV
+          echo 'export ENABLE_KMS_ENCRYPTION=false' >> $BASH_ENV
           echo 'export CLEANUP_ON_EXIT=${CLEANUP_ON_EXIT}' >> $BASH_ENV
           echo 'export CLEANUP_IF_FAIL=${CLEANUP_IF_FAIL_LINUX}' >> $BASH_ENV
           echo 'export RETAIN_SSH=false' >> $BASH_ENV
@@ -124,7 +124,7 @@ jobs:
           echo 'export ORCHESTRATOR_RELEASE=1.12' >> $BASH_ENV
           echo 'export CLUSTER_DEFINITION=examples/e2e-tests/kubernetes/release/default/definition.json' >> $BASH_ENV
           echo 'export CREATE_VNET=true' >> $BASH_ENV
-          echo 'export ENABLE_KMS_ENCRYPTION=true' >> $BASH_ENV
+          echo 'export ENABLE_KMS_ENCRYPTION=false' >> $BASH_ENV
           echo 'export CLEANUP_ON_EXIT=${CLEANUP_ON_EXIT}' >> $BASH_ENV
           echo 'export CLEANUP_IF_FAIL=${CLEANUP_IF_FAIL_LINUX}' >> $BASH_ENV
           echo 'export RETAIN_SSH=false' >> $BASH_ENV
@@ -150,7 +150,7 @@ jobs:
           echo 'export ORCHESTRATOR_RELEASE=1.13' >> $BASH_ENV
           echo 'export CLUSTER_DEFINITION=examples/e2e-tests/kubernetes/release/default/definition.json' >> $BASH_ENV
           echo 'export CREATE_VNET=true' >> $BASH_ENV
-          echo 'export ENABLE_KMS_ENCRYPTION=true' >> $BASH_ENV
+          echo 'export ENABLE_KMS_ENCRYPTION=false' >> $BASH_ENV
           echo 'export CLEANUP_ON_EXIT=${CLEANUP_ON_EXIT}' >> $BASH_ENV
           echo 'export CLEANUP_IF_FAIL=${CLEANUP_IF_FAIL_LINUX}' >> $BASH_ENV
           echo 'export RETAIN_SSH=false' >> $BASH_ENV

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -183,6 +183,9 @@ func Build(cfg *config.Config, masterSubnetID string, agentSubnetID string, isVM
 	}
 
 	if config.EnableKMSEncryption && config.ClientObjectID != "" {
+		if prop.OrchestratorProfile.KubernetesConfig == nil {
+			prop.OrchestratorProfile.KubernetesConfig = &vlabs.KubernetesConfig{}
+		}
 		cs.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.EnableEncryptionWithExternalKms = &config.EnableKMSEncryption
 		cs.ContainerService.Properties.ServicePrincipalProfile.ObjectID = config.ClientObjectID
 	}

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -183,8 +183,8 @@ func Build(cfg *config.Config, masterSubnetID string, agentSubnetID string, isVM
 	}
 
 	if config.EnableKMSEncryption && config.ClientObjectID != "" {
-		if prop.OrchestratorProfile.KubernetesConfig == nil {
-			prop.OrchestratorProfile.KubernetesConfig = &vlabs.KubernetesConfig{}
+		if cs.ContainerService.Properties.OrchestratorProfile.KubernetesConfig == nil {
+			cs.ContainerService.Properties.OrchestratorProfile.KubernetesConfig = &vlabs.KubernetesConfig{}
 		}
 		cs.ContainerService.Properties.OrchestratorProfile.KubernetesConfig.EnableEncryptionWithExternalKms = &config.EnableKMSEncryption
 		cs.ContainerService.Properties.ServicePrincipalProfile.ObjectID = config.ClientObjectID

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -139,10 +139,15 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			}
 		})
 
-		It("should have have the appropriate node count", func() {
-			nodeList, err := node.Get()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(nodeList.Nodes)).To(Equal(eng.NodeCount()))
+		It("should report all nodes in a Ready state", func() {
+			ready := node.WaitOnReady(eng.NodeCount(), 10*time.Second, cfg.Timeout)
+			cmd := exec.Command("kubectl", "get", "nodes", "-o", "wide")
+			out, _ := cmd.CombinedOutput()
+			log.Printf("%s\n", out)
+			if !ready {
+				log.Printf("Error: Not all nodes in a healthy state\n")
+			}
+			Expect(ready).To(Equal(true))
 		})
 
 		It("should have DNS pod running", func() {

--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -71,14 +71,22 @@ type List struct {
 // AreAllReady returns a bool depending on cluster state
 func AreAllReady(nodeCount int) bool {
 	list, _ := Get()
+	var ready int
 	if list != nil && len(list.Nodes) == nodeCount {
 		for _, node := range list.Nodes {
+			nodeReady := false
 			for _, condition := range node.Status.Conditions {
-				if condition.Type == "KubeletReady" && condition.Status == "false" {
-					return false
+				if condition.Type == "Ready" && condition.Status == "True" {
+					ready++
+					nodeReady = true
 				}
 			}
+			if !nodeReady {
+				return false
+			}
 		}
+	}
+	if ready == nodeCount {
 		return true
 	}
 	return false

--- a/test/e2e/runner/cli_provisioner.go
+++ b/test/e2e/runner/cli_provisioner.go
@@ -255,6 +255,9 @@ func (cli *CLIProvisioner) waitForNodes() error {
 		if !cli.IsPrivate() {
 			log.Println("Waiting on nodes to go into ready state...")
 			ready := node.WaitOnReady(cli.Engine.NodeCount(), 10*time.Second, cli.Config.Timeout)
+			cmd := exec.Command("kubectl", "get", "nodes", "-o", "wide")
+			out, _ := cmd.CombinedOutput()
+			log.Printf("%s\n", out)
 			if !ready {
 				return errors.New("Error: Not all nodes in a healthy state")
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: An active "intermittent zero byte `/etc/kubernetes/azure.json` on master nodes issue" reveals that we aren't properly (1) testing for the integrity of this cloudprovider file, and (2) our E2E tests are implemented in a way that masks this.

This PR re-arranges node readiness checks so that they more clearly communicate the state of nodes before testing, and during the E2E run.

We haven't root caused the azure.json issue, but we have repro'd it in isolation w/ KMS encryption enabled, so we're disabling that feature on standard cluster definitions.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Testing**:
- [x] disabled rescheduler addon
- [x] disabled flexvol addons
- [ ] disabled KMS <-- this is the one :)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
E2E: rationalize node check + kube-system check, no kms
```
