### PR TITLE
Update pause container to pipe ping result to nul

### DIFF
--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -155,7 +155,7 @@ New-InfraContainer
     }
 
     "FROM $($windowsBase)" | Out-File -encoding ascii -FilePath Dockerfile
-    "CMD cmd /c ping -t localhost" | Out-File -encoding ascii -FilePath Dockerfile -Append
+    "CMD cmd /c ping -t localhost > nul" | Out-File -encoding ascii -FilePath Dockerfile -Append
     docker build -t kubletwin/pause .
 }
 


### PR DESCRIPTION
As per https://github.com/Azure/acs-engine/issues/4277 pinging creates a few necessary issues down the line. This change is in line with how other pause containers run
