### PR TITLE
feat(perf): Invoke-WebRequest much slower then browser download

### DIFF
--- a/extensions/windows-patches/v1/installPatches.ps1
+++ b/extensions/windows-patches/v1/installPatches.ps1
@@ -13,6 +13,7 @@ function DownloadFile([string] $URI, [string] $fullName)
 {
     try {
         Write-Host "Downloading $URI"
+        $ProgressPreference = 'SilentlyContinue'
         Invoke-WebRequest -UseBasicParsing $URI -OutFile $fullName
     } catch {
         Write-Error $_


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Invoke-WebRequest much slower than a browser download when the progress bar is shown by an order of magnitude. Saw this when trying out the windows patches extension and a rather larger MSU.

http://download.windowsupdate.com/c/msdownload/update/software/updt/2018/08/windows10.0-kb4346783-x64_145555faf4e3e494c20f22508f9c28fe12af387a.msu

Before Patch: About an hour
After Patch: Less then a minute

> Note: The msu file was placed in a storage account using the premium service.

https://stackoverflow.com/questions/28682642/powershell-why-is-using-invoke-webrequest-much-slower-than-a-browser-download

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: I am not sure if this applies when is running as part of the CustomScriptExtension but did for me when running manually. Feel free to close if is the case :)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Invoke-WebRequest much slower than a browser download 
```
