### PR TITLE
Support Windows Server 2019 and make it default

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -624,8 +624,10 @@ $ az vm image list --publisher MicrosoftWindowsServer --all -o table
 Offer                    Publisher                      Sku                                             Urn                                                                                                            Version
 -----------------------  -----------------------------  ----------------------------------------------  -------------------------------------------------------------------------------------------------------------  -----------------
 ...
-WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1709-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1709-with-Containers-smalldisk:1709.0.20180412  1709.0.20180412
-WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1803-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1803-with-Containers-smalldisk:1803.0.20180504  1803.0.20180504
+WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1709-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1709-with-Containers-smalldisk:1709.0.20181017  1709.0.20181017
+WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1803-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1803-with-Containers-smalldisk:1803.0.20181017  1803.0.20181017
+WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1809-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1809-with-Containers-smalldisk:1809.0.20181107  1809.0.20181107
+WindowsServer            MicrosoftWindowsServer         2019-Datacenter-Core-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core-with-Containers-smalldisk:2019.0.20181107            2019.0.20181107
 ```
 
 If you wanted to use the last one in the list above, then set:
@@ -635,9 +637,9 @@ If you wanted to use the last one in the list above, then set:
             "adminUsername": "...",
             "adminPassword": "...",
             "windowsPublisher": "MicrosoftWindowsServer",
-            "windowsOffer": "WindowsServerSemiAnnual",
-            "windowsSku": "Datacenter-Core-1803-with-Containers-smalldisk",
-            "imageVersion": "1803.0.20180504"
+            "windowsOffer": "WindowsServer",
+            "windowsSku": "2019-Datacenter-Core-with-Containers-smalldisk",
+            "imageVersion": "2019.0.20181107"
      },
 ```
 

--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -607,7 +607,7 @@ https://{keyvaultname}.vault.azure.net:443/secrets/{secretName}/{version}
 | adminPassword                    | yes      | Password for the Windows adminstrator account created on each Windows node |
 | windowsPublisher                 | no       | Publisher used to find Windows VM to deploy from marketplace. Default: `MicrosoftWindowsServer` |
 | windowsOffer                     | no       | Offer used to find Windows VM to deploy from marketplace. Default: `WindowsServerSemiAnnual` |
-| windowsSku                       | no       | SKU usedto find Windows VM to deploy from marketplace. Default: `Datacenter-Core-1803-with-Containers-smalldisk` |
+| windowsSku                       | no       | SKU usedto find Windows VM to deploy from marketplace. Default: `Datacenter-Core-1809-with-Containers-smalldisk` |
 | imageVersion                     | no       | Specific image version to deploy from marketplace.  Default: `latest` |
 | windowsImageSourceURL            | no       | Path to an existing Azure storage blob with a sysprepped VHD. This is used to test pre-release or customized VHD files that you have uploaded to Azure. If provided, the above 4 parameters are ignored. |
 

--- a/docs/kubernetes/windows-details.md
+++ b/docs/kubernetes/windows-details.md
@@ -38,7 +38,7 @@ WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1809-wit
 WindowsServer            MicrosoftWindowsServer         2019-Datacenter-Core-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core-with-Containers-smalldisk:2019.0.20181107            2019.0.20181107
 ```
 
-You can use the Offer, Publisher and Sku to pick a specific version by adding `windowsOffer`, `windowsPublisher`, `windowsSku` and (optionally) `imageVersion` to the `windowsProfile` section. In this example, the latest Windows Server version 1803 image would be deployed.
+You can use the Offer, Publisher and Sku to pick a specific version by adding `windowsOffer`, `windowsPublisher`, `windowsSku` and (optionally) `imageVersion` to the `windowsProfile` section. In this example, the latest Windows Server version 1809 image would be deployed.
 
 ```json
 "windowsProfile": {
@@ -46,7 +46,7 @@ You can use the Offer, Publisher and Sku to pick a specific version by adding `w
             "adminPassword": "...",
             "windowsPublisher": "MicrosoftWindowsServer",
             "windowsOffer": "WindowsServerSemiAnnual",
-            "windowsSku": "Datacenter-Core-1803-with-Containers-smalldisk"
+            "windowsSku": "Datacenter-Core-1809-with-Containers-smalldisk"
      },
 ```
 

--- a/docs/kubernetes/windows-details.md
+++ b/docs/kubernetes/windows-details.md
@@ -32,8 +32,10 @@ $ az vm image list --publisher MicrosoftWindowsServer --all -o table
 Offer                    Publisher                      Sku                                             Urn                                                                                                            Version
 -----------------------  -----------------------------  ----------------------------------------------  -------------------------------------------------------------------------------------------------------------  -----------------
 ...
-WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1709-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1709-with-Containers-smalldisk:1709.0.20180412  1709.0.20180412
-WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1803-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1803-with-Containers-smalldisk:1803.0.20180504  1803.0.20180504
+WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1709-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1709-with-Containers-smalldisk:1709.0.20181017  1709.0.20181017
+WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1803-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1803-with-Containers-smalldisk:1803.0.20181017  1803.0.20181017
+WindowsServerSemiAnnual  MicrosoftWindowsServer         Datacenter-Core-1809-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServerSemiAnnual:Datacenter-Core-1809-with-Containers-smalldisk:1809.0.20181107  1809.0.20181107
+WindowsServer            MicrosoftWindowsServer         2019-Datacenter-Core-with-Containers-smalldisk  MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core-with-Containers-smalldisk:2019.0.20181107            2019.0.20181107
 ```
 
 You can use the Offer, Publisher and Sku to pick a specific version by adding `windowsOffer`, `windowsPublisher`, `windowsSku` and (optionally) `imageVersion` to the `windowsProfile` section. In this example, the latest Windows Server version 1803 image would be deployed.

--- a/examples/windows/kubernetes-windows-version.json
+++ b/examples/windows/kubernetes-windows-version.json
@@ -21,7 +21,10 @@
     "windowsProfile": {
       "adminUsername": "azureuser",
       "adminPassword": "replacepassword1234$",
-      "imageVersion": "2016.127.20170510"
+      "windowsPublisher": "MicrosoftWindowsServer",
+      "windowsOffer": "WindowsServerSemiAnnual",
+      "windowsSku": "Datacenter-Core-1803-with-Containers-smalldisk",
+      "imageVersion": "1803.0.20181017"
     },
     "linuxProfile": {
       "adminUsername": "azureuser",

--- a/parts/k8s/windowskubeletfunc.ps1
+++ b/parts/k8s/windowskubeletfunc.ps1
@@ -148,8 +148,7 @@ New-InfraContainer
     } elseif ($computerInfo.WindowsVersion -eq "1803") {
         "microsoft/nanoserver:1803"
     } elseif ($computerInfo.WindowsVersion -eq "1809") {
-        # TODO: unsure if 2019 will report 1809 or not
-        "microsoft/nanoserver:1809"
+        "mcr.microsoft.com/windows/nanoserver:1809"
     } else {
         "mcr.microsoft.com/nanoserver-insider"
     }

--- a/parts/windowsparams.t
+++ b/parts/windowsparams.t
@@ -71,7 +71,7 @@
       "type": "string"
     },
     "agentWindowsSku": {
-      "defaultValue": "Datacenter-Core-1803-with-Containers-smalldisk",
+      "defaultValue": "Datacenter-Core-1809-with-Containers-smalldisk",
       "metadata": {
         "description": "The SKU of windows image for the agent virtual machines."
       },

--- a/pkg/acsengine/params.go
+++ b/pkg/acsengine/params.go
@@ -223,10 +223,8 @@ func getParameters(cs *api.ContainerService, generatorCode string, acsengineVers
 		if properties.WindowsProfile.WindowsOffer != "" {
 			addValue(parametersMap, "agentWindowsOffer", properties.WindowsProfile.WindowsOffer)
 		}
-		if properties.WindowsProfile.WindowsSku != "" {
-			addValue(parametersMap, "agentWindowsSku", properties.WindowsProfile.WindowsSku)
-		}
 
+		addValue(parametersMap, "agentWindowsSku", properties.WindowsProfile.GetWindowsSku())
 		addValue(parametersMap, "windowsDockerVersion", properties.WindowsProfile.GetWindowsDockerVersion())
 
 		for i, s := range properties.WindowsProfile.Secrets {

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -45,6 +45,8 @@ const (
 	DockerCEDockerComposeVersion = "1.14.0"
 	// KubernetesWindowsDockerVersion is the default version for docker on Windows nodes in kubernetes
 	KubernetesWindowsDockerVersion = "18.09.0"
+	// KubernetesDefaultWindowsSku is the default SKU for Windows VMs in kubernetes
+	KubernetesDefaultWindowsSku = "Datacenter-Core-1809-with-Containers-smalldisk"
 )
 
 // validation values

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1126,6 +1126,14 @@ func (w *WindowsProfile) GetWindowsDockerVersion() string {
 	return KubernetesWindowsDockerVersion
 }
 
+// GetWindowsSku gets the marketplace sku specified (such as Datacenter-Core-1809-with-Containers-smalldisk) or returns default value
+func (w *WindowsProfile) GetWindowsSku() string {
+	if w.WindowsSku != "" {
+		return w.WindowsSku
+	}
+	return KubernetesDefaultWindowsSku
+}
+
 // HasSecrets returns true if the customer specified secrets to install
 func (l *LinuxProfile) HasSecrets() bool {
 	return len(l.Secrets) > 0

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -826,7 +826,7 @@ func TestWindowsProfile(t *testing.T) {
 
 	w = WindowsProfile{
 		WindowsDockerVersion: "18.03.1-ee-3",
-		WindowsSku: "Datacenter-Core-1809-with-Containers-smalldisk"
+		WindowsSku:           "Datacenter-Core-1809-with-Containers-smalldisk",
 	}
 
 	dv = w.GetWindowsDockerVersion()

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -834,9 +834,9 @@ func TestWindowsProfile(t *testing.T) {
 		t.Fatalf("Expected GetWindowsDockerVersion() to equal 18.03.1-ee-3, got %s", dv)
 	}
 
-	windowsVersion = w.GetWindowsSku()
-	if windowsVersion != "Datacenter-Core-1809-with-Containers-smalldisk" {
-		t.Fatalf("Expected GetWindowsSku() to equal Datacenter-Core-1809-with-Containers-smalldisk, got %s", windowsVersion)
+	windowsSku = w.GetWindowsSku()
+	if windowsSku != "Datacenter-Core-1809-with-Containers-smalldisk" {
+		t.Fatalf("Expected GetWindowsSku() to equal Datacenter-Core-1809-with-Containers-smalldisk, got %s", windowsSku)
 	}
 }
 

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -800,6 +800,11 @@ func TestWindowsProfile(t *testing.T) {
 		t.Fatalf("Expected GetWindowsDockerVersion() to equal default KubernetesWindowsDockerVersion, got %s", dv)
 	}
 
+	windowsSku := w.GetWindowsSku()
+	if windowsSku != KubernetesDefaultWindowsSku {
+		t.Fatalf("Expected GetWindowsSku() to equal default KubernetesDefaultWindowsSku, got %s", windowsSku)
+	}
+
 	w = WindowsProfile{
 		Secrets: []KeyVaultSecrets{
 			{
@@ -821,11 +826,17 @@ func TestWindowsProfile(t *testing.T) {
 
 	w = WindowsProfile{
 		WindowsDockerVersion: "18.03.1-ee-3",
+		WindowsSku: "Datacenter-Core-1809-with-Containers-smalldisk"
 	}
 
 	dv = w.GetWindowsDockerVersion()
 	if dv != "18.03.1-ee-3" {
 		t.Fatalf("Expected GetWindowsDockerVersion() to equal 18.03.1-ee-3, got %s", dv)
+	}
+
+	windowsVersion = w.GetWindowsSku()
+	if windowsVersion != "Datacenter-Core-1809-with-Containers-smalldisk" {
+		t.Fatalf("Expected GetWindowsSku() to equal Datacenter-Core-1809-with-Containers-smalldisk, got %s", windowsVersion)
 	}
 }
 

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -201,9 +201,7 @@ func (e *Engine) GetWindowsTestImages() (WindowsTestImages, error) {
 		return nil, errors.New("Can't guess a Windows version without Windows nodes in the cluster")
 	}
 
-	if (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("1809") || 
-	   (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("2019")
-	{
+	if (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("1809") || (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("2019")	{
 		return WindowsTestImages { IIS = "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019", 
 		                           ServerCore = "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019"}, nil
 	} else if (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("1803") {

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -190,12 +190,14 @@ func (e *Engine) HasWindowsAgents() bool {
 }
 
 // GetWindowsImageIIS will return the right IIS image for the Windows version used
-func (e *Engine) GetWindowsImageIIS() string, error {
+func (e *Engine) GetWindowsImageIIS() (string, error) {
+	// TODO finish this
 	return "microsoft/iis:windowsservercore-1803", nil
 }
 
 // GetWindowsImageServerCore will return the right Server Core image for the Windows version used
-func (e *Engine) GetWindowsImageServerCore() string, error {
+func (e *Engine) GetWindowsImageServerCore() (string, error) {
+	// TODO finish this
 	return "microsoft/windowsservercore:1803", nil
 }
 

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -201,17 +201,17 @@ func (e *Engine) GetWindowsTestImages() (*WindowsTestImages, error) {
 		return nil, errors.New("Can't guess a Windows version without Windows nodes in the cluster")
 	}
 
-	if strings.Contains(e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku, "1809") || strings.Contains(e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku, "2019") {
+	if strings.Contains(e.ExpandedDefinition.Properties.WindowsProfile.GetWindowsSku(), "1809") || strings.Contains(e.ExpandedDefinition.Properties.WindowsProfile.GetWindowsSku(), "2019") {
 		return &WindowsTestImages{IIS: "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019",
 			ServerCore: "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019"}, nil
-	} else if strings.Contains(e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku, "1803") {
+	} else if strings.Contains(e.ExpandedDefinition.Properties.WindowsProfile.GetWindowsSku(), "1803") {
 		return &WindowsTestImages{IIS: "microsoft/iis:windowsservercore-1803",
 			ServerCore: "microsoft/iis:windowsservercore-1803"}, nil
-	} else if strings.Contains(e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku, "1709") {
+	} else if strings.Contains(e.ExpandedDefinition.Properties.WindowsProfile.GetWindowsSku(), "1709") {
 		return nil, errors.New("Windows Server version 1709 hasn't been tested in a long time and is deprecated")
 	}
 
-	return nil, errors.New("Unknown Windows version. WindowsSku = " + e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku)
+	return nil, errors.New("Unknown Windows version. GetWindowsSku() = " + e.ExpandedDefinition.Properties.WindowsProfile.GetWindowsSku())
 }
 
 // HasAddon will return true if an addon is enabled

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -197,7 +197,7 @@ type WindowsTestImages struct {
 
 // GetWindowsTestImages will return the right list of container images for the Windows version used
 func (e *Engine) GetWindowsTestImages() (*WindowsTestImages, error) {
-	if e.HasWindowsAgents() == false {
+	if !e.HasWindowsAgents() {
 		return nil, errors.New("Can't guess a Windows version without Windows nodes in the cluster")
 	}
 

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -211,7 +211,7 @@ func (e *Engine) GetWindowsTestImages() (*WindowsTestImages, error) {
 		return nil, errors.New("Windows Server version 1709 hasn't been tested in a long time and is deprecated")
 	}
 
-	return nil, errors.New("Unknown Windows version")
+	return nil, errors.New("Unknown Windows version. WindowsSku = " + e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku)
 }
 
 // HasAddon will return true if an addon is enabled

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -189,24 +189,25 @@ func (e *Engine) HasWindowsAgents() bool {
 	return false
 }
 
+// WindowsTestImages holds the Windows container image names used in this test pass
 type WindowsTestImages struct {
 	IIS        string
 	ServerCore string
 }
 
 // GetWindowsTestImages will return the right list of container images for the Windows version used
-func (e *Engine) GetWindowsTestImages() (WindowsTestImages, error) {
-	if e.HasWindowsAgents == false {
+func (e *Engine) GetWindowsTestImages() (*WindowsTestImages, error) {
+	if e.HasWindowsAgents() == false {
 		return nil, errors.New("Can't guess a Windows version without Windows nodes in the cluster")
 	}
 
-	if (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("1809") || (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("2019") {
-		return WindowsTestImages{IIS: "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019",
+	if strings.Contains(e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku, "1809") || strings.Contains(e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku, "2019") {
+		return &WindowsTestImages{IIS: "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019",
 			ServerCore: "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019"}, nil
-	} else if (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("1803") {
-		return WindowsTestImages{IIS: "microsoft/iis:windowsservercore-1803",
+	} else if strings.Contains(e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku, "1803") {
+		return &WindowsTestImages{IIS: "microsoft/iis:windowsservercore-1803",
 			ServerCore: "microsoft/iis:windowsservercore-1803"}, nil
-	} else if (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("1709") {
+	} else if strings.Contains(e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku, "1709") {
 		return nil, errors.New("Windows Server version 1709 hasn't been tested in a long time and is deprecated")
 	}
 

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -189,10 +189,9 @@ func (e *Engine) HasWindowsAgents() bool {
 	return false
 }
 
-
 type WindowsTestImages struct {
-	IIS string
-	ServerCore string 
+	IIS        string
+	ServerCore string
 }
 
 // GetWindowsTestImages will return the right list of container images for the Windows version used
@@ -201,16 +200,16 @@ func (e *Engine) GetWindowsTestImages() (WindowsTestImages, error) {
 		return nil, errors.New("Can't guess a Windows version without Windows nodes in the cluster")
 	}
 
-	if (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("1809") || (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("2019")	{
-		return WindowsTestImages { IIS = "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019", 
-		                           ServerCore = "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019"}, nil
+	if (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("1809") || (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("2019") {
+		return WindowsTestImages{IIS: "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019",
+			ServerCore: "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019"}, nil
 	} else if (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("1803") {
-		return WindowsTestImages { IIS = "microsoft/iis:windowsservercore-1803", 
-		                           ServerCore = "microsoft/iis:windowsservercore-1803"}, nil
+		return WindowsTestImages{IIS: "microsoft/iis:windowsservercore-1803",
+			ServerCore: "microsoft/iis:windowsservercore-1803"}, nil
 	} else if (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("1709") {
 		return nil, errors.New("Windows Server version 1709 hasn't been tested in a long time and is deprecated")
 	}
-	
+
 	return nil, errors.New("Unknown Windows version")
 }
 

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -189,6 +189,16 @@ func (e *Engine) HasWindowsAgents() bool {
 	return false
 }
 
+// GetWindowsImageIIS will return the right IIS image for the Windows version used
+func (e *Engine) GetWindowsImageIIS() string, error {
+	return "microsoft/iis:windowsservercore-1803", nil
+}
+
+// GetWindowsImageServerCore will return the right Server Core image for the Windows version used
+func (e *Engine) GetWindowsImageServerCore() string, error {
+	return "microsoft/windowsservercore:1803", nil
+}
+
 // HasAddon will return true if an addon is enabled
 func (e *Engine) HasAddon(name string) (bool, api.KubernetesAddon) {
 	for _, addon := range e.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.Addons {

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -189,16 +189,31 @@ func (e *Engine) HasWindowsAgents() bool {
 	return false
 }
 
-// GetWindowsImageIIS will return the right IIS image for the Windows version used
-func (e *Engine) GetWindowsImageIIS() (string, error) {
-	// TODO finish this
-	return "microsoft/iis:windowsservercore-1803", nil
+
+type WindowsTestImages struct {
+	IIS string
+	ServerCore string 
 }
 
-// GetWindowsImageServerCore will return the right Server Core image for the Windows version used
-func (e *Engine) GetWindowsImageServerCore() (string, error) {
-	// TODO finish this
-	return "microsoft/windowsservercore:1803", nil
+// GetWindowsTestImages will return the right list of container images for the Windows version used
+func (e *Engine) GetWindowsTestImages() (WindowsTestImages, error) {
+	if e.HasWindowsAgents == false {
+		return nil, errors.New("Can't guess a Windows version without Windows nodes in the cluster")
+	}
+
+	if (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("1809") || 
+	   (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("2019")
+	{
+		return WindowsTestImages { IIS = "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019", 
+		                           ServerCore = "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019"}, nil
+	} else if (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("1803") {
+		return WindowsTestImages { IIS = "microsoft/iis:windowsservercore-1803", 
+		                           ServerCore = "microsoft/iis:windowsservercore-1803"}, nil
+	} else if (e.ExpandedDefinition.Properties.WindowsProfile.WindowsSku).Contains("1709") {
+		return nil, errors.New("Windows Server version 1709 hasn't been tested in a long time and is deprecated")
+	}
+	
+	return nil, errors.New("Unknown Windows version")
 }
 
 // HasAddon will return true if an addon is enabled

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -973,12 +973,13 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 	Describe("with a windows agent pool", func() {
 		It("should be able to deploy an iis webserver", func() {
 			if eng.HasWindowsAgents() {
-				iisImage := "microsoft/iis:windowsservercore-1803" // BUG: This should be set based on the host OS version
+				windowsImages, err := eng.GetWindowsTestImages()
+				Expect(err).NotTo(HaveOccurred())
 
 				By("Creating a deployment with 1 pod running IIS")
 				r := rand.New(rand.NewSource(time.Now().UnixNano()))
 				deploymentName := fmt.Sprintf("iis-%s-%v", cfg.Name, r.Intn(99999))
-				iisDeploy, err := deployment.CreateWindowsDeploy(iisImage, deploymentName, "default", 80, -1)
+				iisDeploy, err := deployment.CreateWindowsDeploy(windowsImages.IIS, deploymentName, "default", 80, -1)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Waiting on pod to be Ready")
@@ -1016,15 +1017,119 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			}
 		})
 
+		It("should be able to scale an iis webserver", func() {
+			if eng.HasWindowsAgents() {
+				windowsImages, err := eng.GetWindowsTestImages()
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Creating a deployment with 1 pod running IIS")
+				r := rand.New(rand.NewSource(time.Now().UnixNano()))
+				deploymentName := fmt.Sprintf("iis-%s-%v", cfg.Name, r.Intn(99999))
+				iisDeploy, err := deployment.CreateWindowsDeploy(windowsImages.IIS, deploymentName, "default", 80, -1)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Waiting on pod to be Ready")
+				running, err := pod.WaitOnReady(deploymentName, "default", 3, 30*time.Second, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(running).To(Equal(true))
+
+				By("Exposing a LoadBalancer for the pod")
+				err = iisDeploy.Expose("LoadBalancer", 80, 80)
+				Expect(err).NotTo(HaveOccurred())
+				iisService, err := service.Get(deploymentName, "default")
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying that the service is reachable and returns the default IIS start page")
+				valid := iisService.Validate("(IIS Windows Server)", 10, 10*time.Second, cfg.Timeout)
+				Expect(valid).To(BeTrue())
+
+				By("Checking that each pod can reach http://www.bing.com")
+				iisPods, err := iisDeploy.Pods()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(iisPods)).ToNot(BeZero())
+				for _, iisPod := range iisPods {
+					pass, err := iisPod.CheckWindowsOutboundConnection("www.bing.com", 10*time.Second, cfg.Timeout)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(pass).To(BeTrue())
+				}
+
+				By("Scaling deployment to 5 pods")
+				err = iisDeploy.ScaleDeployment(5)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = iisDeploy.WaitForReplicas(5, 5, 2*time.Second, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Waiting on 5 pods to be Ready")
+				running, err = pod.WaitOnReady(deploymentName, "default", 3, 30*time.Second, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(running).To(Equal(true))
+				iisPods, err = iisDeploy.Pods()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(iisPods)).To(Equal(5))
+
+				By("Verifying that the service is reachable and returns the default IIS start page")
+				valid = iisService.Validate("(IIS Windows Server)", 10, 10*time.Second, cfg.Timeout)
+				Expect(valid).To(BeTrue())
+
+				By("Checking that each pod can reach http://www.bing.com")
+				iisPods, err = iisDeploy.Pods()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(iisPods)).ToNot(BeZero())
+				for _, iisPod := range iisPods {
+					pass, err := iisPod.CheckWindowsOutboundConnection("www.bing.com", 10*time.Second, cfg.Timeout)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(pass).To(BeTrue())
+				}
+
+				By("Checking that no pods restart")
+				for _, iisPod := range iisPods {
+					log.Printf("Checking %s", iisPod.Metadata.Name)
+					Expect(iisPod.Status.ContainerStatuses[0].Ready).To(BeTrue())
+					Expect(iisPod.Status.ContainerStatuses[0].RestartCount).To(Equal(0))
+				}
+
+				By("Scaling deployment to 2 pods")
+				err = iisDeploy.ScaleDeployment(2)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = iisDeploy.WaitForReplicas(2, 2, 2*time.Second, cfg.Timeout)
+				Expect(err).NotTo(HaveOccurred())
+				iisPods, err = iisDeploy.Pods()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(iisPods)).To(Equal(2))
+
+				By("Verifying that the service is reachable and returns the default IIS start page")
+				valid = iisService.Validate("(IIS Windows Server)", 10, 10*time.Second, cfg.Timeout)
+				Expect(valid).To(BeTrue())
+
+				By("Checking that each pod can reach http://www.bing.com")
+				iisPods, err = iisDeploy.Pods()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(iisPods)).ToNot(BeZero())
+				for _, iisPod := range iisPods {
+					pass, err := iisPod.CheckWindowsOutboundConnection("www.bing.com", 10*time.Second, cfg.Timeout)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(pass).To(BeTrue())
+				}
+
+				By("Verifying pods & services can be deleted")
+				err = iisDeploy.Delete(deleteResourceRetries)
+				Expect(err).NotTo(HaveOccurred())
+				err = iisService.Delete(deleteResourceRetries)
+				Expect(err).NotTo(HaveOccurred())
+			} else {
+				Skip("No windows agent was provisioned for this Cluster Definition")
+			}
+		})
+
 		It("should be able to resolve DNS across windows and linux deployments", func() {
 			if eng.HasWindowsAgents() {
-				iisImage := "microsoft/iis:windowsservercore-1803" // BUG: This should be set based on the host OS version
-				windowsServerImage := "microsoft/windowsservercore:1803"
+				windowsImages, err := eng.GetWindowsTestImages()
+				Expect(err).NotTo(HaveOccurred())
 
 				By("Creating a deployment running IIS")
 				r := rand.New(rand.NewSource(time.Now().UnixNano()))
 				windowsDeploymentName := fmt.Sprintf("iis-dns-%s-%v", cfg.Name, r.Intn(99999))
-				windowsIISDeployment, err := deployment.CreateWindowsDeploy(iisImage, windowsDeploymentName, "default", 80, -1)
+				windowsIISDeployment, err := deployment.CreateWindowsDeploy(windowsImages.IIS, windowsDeploymentName, "default", 80, -1)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Creating a nginx deployment")
@@ -1057,14 +1162,14 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				By("Connecting to Windows from another Windows deployment")
 				name := fmt.Sprintf("windows-2-windows-%s", cfg.Name)
 				command := fmt.Sprintf("iwr -UseBasicParsing -TimeoutSec 60 %s", windowsService.Metadata.Name)
-				successes, err := pod.RunCommandMultipleTimes(pod.RunWindowsPod, windowsServerImage, name, command, cfg.StabilityIterations, 1*time.Second, retryCommandsTimeout)
+				successes, err := pod.RunCommandMultipleTimes(pod.RunWindowsPod, windowsImages.ServerCore, name, command, cfg.StabilityIterations, 1*time.Second, retryCommandsTimeout)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(successes).To(Equal(cfg.StabilityIterations))
 
 				By("Connecting to Linux from Windows deployment")
 				name = fmt.Sprintf("windows-2-linux-%s", cfg.Name)
 				command = fmt.Sprintf("iwr -UseBasicParsing -TimeoutSec 60 %s", linuxService.Metadata.Name)
-				successes, err = pod.RunCommandMultipleTimes(pod.RunWindowsPod, windowsServerImage, name, command, cfg.StabilityIterations, 1*time.Second, retryCommandsTimeout)
+				successes, err = pod.RunCommandMultipleTimes(pod.RunWindowsPod, windowsImages.ServerCore, name, command, cfg.StabilityIterations, 1*time.Second, retryCommandsTimeout)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(successes).To(Equal(cfg.StabilityIterations))
 
@@ -1114,24 +1219,19 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					deploymentName := fmt.Sprintf("iis-%s-%v", cfg.Name, r.Intn(99999))
 					iisDeploy, err := deployment.CreateWindowsDeploy(iisImage, deploymentName, "default", 80, hostport)
 					Expect(err).NotTo(HaveOccurred())
-
 					running, err := pod.WaitOnReady(deploymentName, "default", 3, 30*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(running).To(Equal(true))
-
 					iisPods, err := iisDeploy.Pods()
 					Expect(err).NotTo(HaveOccurred())
 					Expect(len(iisPods)).ToNot(BeZero())
-
 					kubeConfig, err := GetConfig()
 					Expect(err).NotTo(HaveOccurred())
 					master := fmt.Sprintf("azureuser@%s", kubeConfig.GetServerName())
-
 					for _, iisPod := range iisPods {
 						valid := iisPod.ValidateHostPort("(IIS Windows Server)", 10, 10*time.Second, master, masterSSHPrivateKeyFilepath)
 						Expect(valid).To(BeTrue())
 					}
-
 					err = iisDeploy.Delete(kubectlOutput)
 					Expect(err).NotTo(HaveOccurred())
 				} else {
@@ -1145,6 +1245,13 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					// Failure in 1.11.0 - https://github.com/kubernetes/kubernetes/issues/65845, fixed in 1.11.1
 					Skip("Kubernetes 1.11.0 has a known issue creating Azure PersistentVolumeClaims")
 				} else if common.IsKubernetesVersionGe(eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.8.0") {
+					windowsImages, err := eng.GetWindowsTestImages()
+					Expect(err).NotTo(HaveOccurred())
+
+					iisAzurefileYaml, err := pod.ReplaceContainerImageFromFile(filepath.Join(WorkloadDir, "iis-azurefile.yaml"), windowsImages.IIS)
+					Expect(err).NotTo(HaveOccurred())
+					defer os.Remove(iisAzurefileYaml)
+
 					By("Creating an AzureFile storage class")
 					storageclassName := "azurefile" // should be the same as in storageclass-azurefile.yaml
 					sc, err := storageclass.CreateStorageClassFromFile(filepath.Join(WorkloadDir, "storageclass-azurefile.yaml"), storageclassName)
@@ -1162,8 +1269,8 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					Expect(ready).To(Equal(true))
 
 					By("Launching an IIS pod using the volume claim")
-					podName := "iis-azurefile"                                                                                                             // should be the same as in iis-azurefile.yaml
-					iisPod, err := pod.CreatePodFromFile(filepath.Join(WorkloadDir, "iis-azurefile.yaml"), podName, "default", 1*time.Second, cfg.Timeout) // BUG: this should support OS versioning
+					podName := "iis-azurefile" // should be the same as in iis-azurefile.yaml
+					iisPod, err := pod.CreatePodFromFile(iisAzurefileYaml, podName, "default", 1*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					ready, err = iisPod.WaitOnReady(5*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"log"
 	"math/rand"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -122,12 +123,12 @@ type Status struct {
 }
 
 // ReplaceContainerImageFromFile loads in a YAML, finds the image: line, and replaces it with the value of containerImage
-func ReplaceContainerImageFromFile(filename, containerImage) (string, error) {
-	outString string
-	file, err := os.OpenFile(filename, O_RDONLY)
+func ReplaceContainerImageFromFile(filename, containerImage string) (string, error) {
+	var outString string
+	file, err := os.Open(filename)
 	if err != nil {
 		log.Printf("Error opening source YAML file %s\n", filename)
-		return nil, err
+		return "", err
 	}
 	defer file.Close()
 	re := regexp.MustCompile("(image:) .*$")
@@ -135,7 +136,7 @@ func ReplaceContainerImageFromFile(filename, containerImage) (string, error) {
 	reader := bufio.NewReader(file)
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
-		outString += re.Replace(scanner.Text(), replacementString) + "\n"
+		outString += re.ReplaceAllString(scanner.Text(), replacementString) + "\n"
 	}
 	err = scanner.Err()
 	if err != nil {
@@ -145,7 +146,7 @@ func ReplaceContainerImageFromFile(filename, containerImage) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	_, err = tmpFile.Write(outString)
+	_, err = tmpFile.Write([]byte(outString))
 	return tmpFile.Name(), err
 }
 

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -10,6 +10,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -142,7 +143,8 @@ func ReplaceContainerImageFromFile(filename, containerImage string) (string, err
 	if err != nil {
 		return "", err
 	}
-	tmpFile, err := ioutil.TempFile(os.TempDir(), filename)
+	_, filenameOnly := path.Split(filename)
+	tmpFile, err := ioutil.TempFile(os.TempDir(), filenameOnly)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Windows Server 2019 was released on Azure a few weeks ago. This PR adds support for 2019 and makes it the default

This also updates the tests to work on 1803 and 1809/2019.

**If applicable**:
- [x] documentation
- [x] e2e tests
