### PR TITLE
ensure --read-only-port=10255

### DIFF
--- a/docs/clusterdefinition.md
+++ b/docs/clusterdefinition.md
@@ -265,7 +265,10 @@ Below is a list of kubelet options that acs-engine will configure by default:
 | "--non-masquerade-cidr"             | "10.0.0.0/8"                                                                                                                                                  |
 | "--azure-container-registry-config" | "/etc/kubernetes/azure.json"                                                                                                                                  |
 | "--pod-max-pids"                    | "100" (need to activate the feature in --feature-gates=SupportPodPidsLimit=true)                                                                              |
-| "--image-pull-progress-deadline"    | "30m"                                                                                                                                                         |
+| "--image-pull-progress-deadline"    | "30m"
+        |
+| "--read-only-port"    | "10255"
+        |                                                                                                                                                 |
 | "--feature-gates"                   | No default (can be a comma-separated list). On agent nodes `Accelerators=true` will be applied in the `--feature-gates` option for k8s versions before 1.11.0 |
 
 Below is a list of kubelet options that are _not_ currently user-configurable, either because a higher order configuration vector is available that enforces kubelet configuration, or because a static configuration is required to build a functional cluster:

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -61,6 +61,7 @@ func (cs *ContainerService) setKubeletConfig() {
 		"--cadvisor-port":                   DefaultKubeletCadvisorPort,
 		"--pod-max-pids":                    strconv.Itoa(DefaultKubeletPodMaxPIDs),
 		"--image-pull-progress-deadline":    "30m",
+		"--read-only-port":                  "10255",
 	}
 
 	// AKS overrides

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -15,6 +15,7 @@ func TestKubeletConfigDefaults(t *testing.T) {
 	for key, val := range map[string]string{
 		"--azure-container-registry-config": "/etc/kubernetes/azure.json",
 		"--image-pull-progress-deadline":    "30m",
+		"--read-only-port":                  "10255",
 	} {
 		if k[key] != val {
 			t.Fatalf("got unexpected kubelet config value for %s: %s, expected %s",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: Recently k8s upstream disabled this by default, though much of our default componentry assumes it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
ensure --read-only-port=10255
```
