### PR TITLE
Add support for Kubernetes 1.12.3

### DIFF
--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -91,7 +91,7 @@ for TILLER_VERSION in ${TILLER_VERSIONS}; do
     pullContainerImage "docker" "gcr.io/kubernetes-helm/tiller:v${TILLER_VERSION}"
 done
 
-CLUSTER_AUTOSCALER_VERSIONS="1.3.4 1.3.3 1.3.1 1.3.0 1.2.2 1.1.2"
+CLUSTER_AUTOSCALER_VERSIONS="1.12.1 1.3.4 1.3.3 1.3.1 1.3.0 1.2.2 1.1.2"
 for CLUSTER_AUTOSCALER_VERSION in ${CLUSTER_AUTOSCALER_VERSIONS}; do
     pullContainerImage "docker" "k8s.gcr.io/cluster-autoscaler:v${CLUSTER_AUTOSCALER_VERSION}"
 done
@@ -154,11 +154,7 @@ done
 pullContainerImage "docker" "busybox"
 
 # TODO: fetch supported k8s versions from an acs-engine command instead of hardcoding them here
-<<<<<<< HEAD
-K8S_VERSIONS="1.7.15 1.7.16 1.8.14 1.8.15 1.9.10 1.9.11 1.10.8 1.10.9 1.11.4 1.11.5 1.12.1 1.12.2"
-=======
-K8S_VERSIONS="1.7.15 1.7.16 1.8.14 1.8.15 1.9.10 1.9.11 1.10.8 1.10.9 1.11.3 1.11.4 1.12.2 1.12.3"
->>>>>>> Add support for Kubernetes 1.12.3
+K8S_VERSIONS="1.7.15 1.7.16 1.8.14 1.8.15 1.9.10 1.9.11 1.10.8 1.10.9 1.11.4 1.11.5 1.12.2 1.12.3"
 
 for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
     HYPERKUBE_URL="k8s.gcr.io/hyperkube-amd64:v${KUBERNETES_VERSION}"

--- a/packer/install-dependencies.sh
+++ b/packer/install-dependencies.sh
@@ -154,7 +154,11 @@ done
 pullContainerImage "docker" "busybox"
 
 # TODO: fetch supported k8s versions from an acs-engine command instead of hardcoding them here
+<<<<<<< HEAD
 K8S_VERSIONS="1.7.15 1.7.16 1.8.14 1.8.15 1.9.10 1.9.11 1.10.8 1.10.9 1.11.4 1.11.5 1.12.1 1.12.2"
+=======
+K8S_VERSIONS="1.7.15 1.7.16 1.8.14 1.8.15 1.9.10 1.9.11 1.10.8 1.10.9 1.11.3 1.11.4 1.12.2 1.12.3"
+>>>>>>> Add support for Kubernetes 1.12.3
 
 for KUBERNETES_VERSION in ${K8S_VERSIONS}; do
     HYPERKUBE_URL="k8s.gcr.io/hyperkube-amd64:v${KUBERNETES_VERSION}"

--- a/pkg/api/common/versions.go
+++ b/pkg/api/common/versions.go
@@ -87,8 +87,9 @@ var AllKubernetesSupportedVersions = map[string]bool{
 	"1.12.0-rc.1":    false,
 	"1.12.0-rc.2":    false,
 	"1.12.0":         false,
-	"1.12.1":         true,
+	"1.12.1":         false,
 	"1.12.2":         true,
+	"1.12.3":         true,
 	"1.13.0-alpha.1": true,
 	"1.13.0-alpha.2": true,
 }

--- a/pkg/api/k8s_versions.go
+++ b/pkg/api/k8s_versions.go
@@ -60,7 +60,7 @@ var k8sComponentVersions = map[string]map[string]string{
 		"aci-connector":                    "virtual-kubelet:latest",
 		ContainerMonitoringAddonName:       "oms:ciprod10162018-2",
 		AzureCNINetworkMonitoringAddonName: "networkmonitor:v0.0.4",
-		"cluster-autoscaler":               "cluster-autoscaler:v1.3.3",
+		"cluster-autoscaler":               "cluster-autoscaler:v1.12.1",
 		NVIDIADevicePluginAddonName:        "k8s-device-plugin:1.11",
 		"k8s-dns-sidecar":                  "k8s-dns-sidecar-amd64:1.14.10",
 		"nodestatusfreq":                   DefaultKubernetesNodeStatusUpdateFrequency,


### PR DESCRIPTION
**What this PR does / why we need it**:

See https://github.com/kubernetes/kubernetes/releases/tag/v1.12.3

TODO:

- [x] upload Windows binary

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
```release-note
Add support for Kubernetes 1.12.3
```
