### PR TITLE
update kubernetes api to 1.12.3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -611,8 +611,8 @@
     "storage/v1beta1",
   ]
   pruneopts = "UT"
-  revision = "d1dc89ebaebe945edbeff52a79f50c791a59ff87"
-  version = "kubernetes-1.12.2"
+  revision = "b503174bad5991eb66f18247f52e41c3258f6348"
+  version = "kubernetes-1.12.3"
 
 [[projects]]
   digest = "1:7ed53199d71d41f8b978c1a01cf91a149d4f3fc6a9d68c57065df2e1ec3fe89a"
@@ -657,8 +657,8 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
-  revision = "f71dbbc36e126f5a371b85f6cca96bc8c57db2b6"
-  version = "kubernetes-1.12.2"
+  revision = "eddba98df674a16931d2d4ba75edc3a389bf633a"
+  version = "kubernetes-1.12.3"
 
 [[projects]]
   digest = "1:51fd9ac9f2be10d79f5af101a7a1d758ef283fdb028a0d11198754bd3d4a6020"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -100,11 +100,11 @@ required = [
 
 [[constraint]]
   name = "k8s.io/api"
-  version = "kubernetes-1.12.2"
+  version = "kubernetes-1.12.3"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  version = "kubernetes-1.12.2"
+  version = "kubernetes-1.12.3"
 
 [[constraint]]
   name = "k8s.io/client-go"


### PR DESCRIPTION
Kubernetes api/apimachinery deps need the same cadence as that of updating kubernetes versions supported by acs-engine