### PR TITLE
update Calico network policy examples docs

### DIFF
--- a/examples/networkpolicy/README.md
+++ b/examples/networkpolicy/README.md
@@ -7,6 +7,10 @@ There are 2 different Network Policy options :
 
 ## Calico
 
+Before enabling Calico policy for the ACS-engine cluster, you must first decide which network plugin to use for the cluster: Azure or Kubenet. 
+The difference between Azure and Kubenet lies in the way IP addresses get allocated; Azure uses Azure-native IPs while Kubenet does static IP assignment based on the node's pod CIDR.
+If you're not sure which one to go with, we recommend going with Azure.
+
 The kubernetes-calico deployment template enables Calico networking and policies for the ACS-engine cluster via `"networkPolicy": "calico"` being present inside the `kubernetesConfig`.
 
 ```json
@@ -14,17 +18,16 @@ The kubernetes-calico deployment template enables Calico networking and policies
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
-        "networkPolicy": "calico"
+        "networkPolicy": "calico",
+        "networkPlugin": "azure|kubenet"
       }
 ```
 
-This template will deploy the [v3.1 release](https://docs.projectcalico.org/v3.1/releases/) of [Kubernetes Datastore Install](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/other) version of calico with the "Calico for policy" with user-supplied networking which supports kubernetes ingress policies.
-
-> Note: The Typha service and deployment is installed on the cluster, but effectively disabled using the default settings of deployment replicas set to 0 and Typha service name not configured.  Typha is recommended to be enabled when scaling to 50+ nodes on the cluster to reduce the load on the Kubernetes API server.  If this functionality is desired to be configurable via the API model, please file an issue on Github requesting this feature be added.  Otherwise, this can be manually changed via modifying and applying changes with the `/etc/kubernetes/addons/calico-daemonset.yaml` file on every master node in the cluster.
+This template will deploy the [Kubernetes Datastore backed version of Calico](https://docs.projectcalico.org/v3.3/getting-started/kubernetes/installation/other) with user-supplied networking which supports kubernetes ingress policies.
 
 If deploying on a K8s 1.8 or later cluster, then egress policies are also supported!
 
-To understand how to deploy this template, please read the baseline [Kubernetes](../../docs/kubernetes.md) document, and use the example **kubernetes-calico.json** file in this folder as an api model reference.
+To understand how to deploy this template, please read the baseline [Kubernetes](../../docs/kubernetes.md) document, and use the appropriate **kubernetes-calico-[azure|kubenet].json** example file in this folder as an api model reference.
 
 ### Post installation
 

--- a/examples/networkpolicy/kubernetes-calico-azure.json
+++ b/examples/networkpolicy/kubernetes-calico-azure.json
@@ -4,7 +4,8 @@
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
       "kubernetesConfig": {
-        "networkPolicy": "calico"
+        "networkPolicy": "calico",
+        "networkPlugin": "azure"
       }
     },
     "masterProfile": {

--- a/examples/networkpolicy/kubernetes-calico-kubenet.json
+++ b/examples/networkpolicy/kubernetes-calico-kubenet.json
@@ -1,0 +1,39 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "kubernetesConfig": {
+        "networkPolicy": "calico",
+        "networkPlugin": "kubenet"
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "",
+      "vmSize": "Standard_DS2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 3,
+        "vmSize": "Standard_DS2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- updates documentation around how to configure Calico policy on the acs-engine deploy
