### PR TITLE
[BUG] orchestratorVersion should not get changed for ACS scale apiVersion 2017-07-01

### DIFF
--- a/pkg/api/apiloader.go
+++ b/pkg/api/apiloader.go
@@ -178,9 +178,7 @@ func (a *Apiloader) LoadContainerService(
 			return nil, e
 		}
 		unversioned := ConvertV20170701ContainerService(containerService)
-		if curOrchVersion != "" &&
-			(containerService.Properties.OrchestratorProfile == nil ||
-				containerService.Properties.OrchestratorProfile.OrchestratorVersion == "") {
+		if curOrchVersion != "" {
 			unversioned.Properties.OrchestratorProfile.OrchestratorVersion = curOrchVersion
 		}
 		return unversioned, nil

--- a/pkg/api/apiloader.go
+++ b/pkg/api/apiloader.go
@@ -177,8 +177,10 @@ func (a *Apiloader) LoadContainerService(
 		if e := containerService.Properties.Validate(isUpdate); validate && e != nil {
 			return nil, e
 		}
-		unversioned := ConvertV20170701ContainerService(containerService)
-		if curOrchVersion != "" {
+		unversioned := ConvertV20170701ContainerService(containerService, isUpdate)
+		if curOrchVersion != "" &&
+			(containerService.Properties.OrchestratorProfile == nil ||
+				containerService.Properties.OrchestratorProfile.OrchestratorVersion == "") {
 			unversioned.Properties.OrchestratorProfile.OrchestratorVersion = curOrchVersion
 		}
 		return unversioned, nil

--- a/pkg/api/apiloader_test.go
+++ b/pkg/api/apiloader_test.go
@@ -93,6 +93,15 @@ func TestLoadContainerServiceFromFile(t *testing.T) {
 		t.Errorf("Failed to set orcherstator version to windows default when it is not set in the json API v20170131, got %s but expected %s", containerService.Properties.OrchestratorProfile.OrchestratorVersion, common.GetDefaultKubernetesVersion(true))
 	}
 
+	// Test ACS scale scenario
+	existingContainerService.Properties.OrchestratorProfile.OrchestratorVersion = "1.8.12"
+	containerService, _, err = apiloader.LoadContainerServiceFromFile("../acsengine/testdata/v20170701/kubernetes.json", true, true, existingContainerService)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if containerService.Properties.OrchestratorProfile.OrchestratorVersion != "1.8.12" {
+		t.Errorf("Failed to set orcherstator version when it is set in the json, expected 1.8.12 but got %s", containerService.Properties.OrchestratorProfile.OrchestratorVersion)
+	}
 }
 
 func TestLoadContainerServiceForAgentPoolOnlyCluster(t *testing.T) {

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -79,7 +79,7 @@ func ConvertV20170131ContainerService(v20170131 *v20170131.ContainerService) *Co
 }
 
 // ConvertV20170701ContainerService converts a v20170701 ContainerService to an unversioned ContainerService
-func ConvertV20170701ContainerService(v20170701 *v20170701.ContainerService) *ContainerService {
+func ConvertV20170701ContainerService(v20170701 *v20170701.ContainerService, isUpdate bool) *ContainerService {
 	c := &ContainerService{}
 	c.ID = v20170701.ID
 	c.Location = helpers.NormalizeAzureRegion(v20170701.Location)
@@ -94,7 +94,7 @@ func ConvertV20170701ContainerService(v20170701 *v20170701.ContainerService) *Co
 	}
 	c.Type = v20170701.Type
 	c.Properties = &Properties{}
-	convertV20170701Properties(v20170701.Properties, c.Properties)
+	convertV20170701Properties(v20170701.Properties, c.Properties, isUpdate)
 	return c
 }
 
@@ -300,12 +300,12 @@ func convertV20170131Properties(v20170131 *v20170131.Properties, api *Properties
 	}
 }
 
-func convertV20170701Properties(v20170701 *v20170701.Properties, api *Properties) {
+func convertV20170701Properties(v20170701 *v20170701.Properties, api *Properties, isUpdate bool) {
 	api.ProvisioningState = ProvisioningState(v20170701.ProvisioningState)
 
 	if v20170701.OrchestratorProfile != nil {
 		api.OrchestratorProfile = &OrchestratorProfile{}
-		convertV20170701OrchestratorProfile(v20170701.OrchestratorProfile, api.OrchestratorProfile, v20170701.HasWindows())
+		convertV20170701OrchestratorProfile(v20170701.OrchestratorProfile, api.OrchestratorProfile, isUpdate, v20170701.HasWindows())
 	}
 	if v20170701.MasterProfile != nil {
 		api.MasterProfile = &MasterProfile{}
@@ -564,7 +564,7 @@ func convertV20170131OrchestratorProfile(v20170131 *v20170131.OrchestratorProfil
 	}
 }
 
-func convertV20170701OrchestratorProfile(v20170701cs *v20170701.OrchestratorProfile, api *OrchestratorProfile, hasWindows bool) {
+func convertV20170701OrchestratorProfile(v20170701cs *v20170701.OrchestratorProfile, api *OrchestratorProfile, isUpdate, hasWindows bool) {
 	if v20170701cs.OrchestratorType == v20170701.DockerCE {
 		api.OrchestratorType = SwarmMode
 	} else {
@@ -573,7 +573,7 @@ func convertV20170701OrchestratorProfile(v20170701cs *v20170701.OrchestratorProf
 
 	switch api.OrchestratorType {
 	case Kubernetes:
-		api.OrchestratorVersion = common.GetSupportedKubernetesVersion(v20170701cs.OrchestratorVersion, hasWindows)
+		api.OrchestratorVersion = common.RationalizeReleaseAndVersion(Kubernetes, "", v20170701cs.OrchestratorVersion, isUpdate, hasWindows)
 	case DCOS:
 		switch v20170701cs.OrchestratorVersion {
 		case common.DCOSVersion1Dot10Dot0, common.DCOSVersion1Dot9Dot0, common.DCOSVersion1Dot8Dot8:

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -574,6 +574,9 @@ func convertV20170701OrchestratorProfile(v20170701cs *v20170701.OrchestratorProf
 	switch api.OrchestratorType {
 	case Kubernetes:
 		api.OrchestratorVersion = common.RationalizeReleaseAndVersion(Kubernetes, "", v20170701cs.OrchestratorVersion, isUpdate, hasWindows)
+		if api.OrchestratorVersion == "" {
+			api.OrchestratorVersion = common.GetDefaultKubernetesVersion(hasWindows)
+		}
 	case DCOS:
 		switch v20170701cs.OrchestratorVersion {
 		case common.DCOSVersion1Dot10Dot0, common.DCOSVersion1Dot9Dot0, common.DCOSVersion1Dot8Dot8:

--- a/pkg/api/convertertoapi_test.go
+++ b/pkg/api/convertertoapi_test.go
@@ -88,7 +88,7 @@ func TestOrchestratorVersion(t *testing.T) {
 			},
 		},
 	}
-	cs := ConvertV20170701ContainerService(v20170701cs)
+	cs := ConvertV20170701ContainerService(v20170701cs, false)
 	if cs.Properties.OrchestratorProfile.OrchestratorVersion != common.GetDefaultKubernetesVersion(false) {
 		t.Fatalf("incorrect OrchestratorVersion '%s'", cs.Properties.OrchestratorProfile.OrchestratorVersion)
 	}
@@ -97,12 +97,12 @@ func TestOrchestratorVersion(t *testing.T) {
 		Properties: &v20170701.Properties{
 			OrchestratorProfile: &v20170701.OrchestratorProfile{
 				OrchestratorType:    v20170701.Kubernetes,
-				OrchestratorVersion: "1.7.15",
+				OrchestratorVersion: "1.7.14",
 			},
 		},
 	}
-	cs = ConvertV20170701ContainerService(v20170701cs)
-	if cs.Properties.OrchestratorProfile.OrchestratorVersion != "1.7.15" {
+	cs = ConvertV20170701ContainerService(v20170701cs, true)
+	if cs.Properties.OrchestratorProfile.OrchestratorVersion != "1.7.14" {
 		t.Fatalf("incorrect OrchestratorVersion '%s'", cs.Properties.OrchestratorProfile.OrchestratorVersion)
 	}
 	// test vlabs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This is a regression since we started retiring k8s version. ACS needs to keep the previous version for update (upgrade is not supported for that apiversion).


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**If applicable**:
- [ ] documentation
- [ ] unit tests
- [ ] tested backward compatibility (ie. deploy with previous version, upgrade with this branch)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
